### PR TITLE
Generate `command-exec` utility.

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,6 +525,9 @@ of source destination `$cur__target_dir`.
 Cached environment computations (for commands such as `esy cmd`) are stored in
 `./node_modules/.cache/_esy/bin/command-env`
 
+A convenience executable that runs arbitrary commands within the `command-env`
+is stored at `./node_modules/.cache/_esy/bin/command-exec`.
+
 Support for "ejecting" a build is computed and stored in
 `./node_modules/.cache/_esy/build-eject`.
 

--- a/__tests__/build/__snapshots__/build-no-deps-test.js.snap
+++ b/__tests__/build/__snapshots__/build-no-deps-test.js.snap
@@ -14,6 +14,7 @@ exports[`esy local prefix dir 1`] = `
 | | | build-env
 | | | build-exec
 | | | command-env
+| | | command-exec
 | | | fastreplacestring.cpp
 | | | fastreplacestring.exe
 | | | install

--- a/__tests__/build/__snapshots__/build-with-dep-test.js.snap
+++ b/__tests__/build/__snapshots__/build-with-dep-test.js.snap
@@ -16,6 +16,7 @@ exports[`esy local prefix dir 1`] = `
 | | | build-env
 | | | build-exec
 | | | command-env
+| | | command-exec
 | | | fastreplacestring.cpp
 | | | fastreplacestring.exe
 | | | install

--- a/__tests__/build/__snapshots__/build-with-dev-dep-test.js.snap
+++ b/__tests__/build/__snapshots__/build-with-dev-dep-test.js.snap
@@ -18,6 +18,7 @@ exports[`esy local prefix dir 1`] = `
 | | | build-env
 | | | build-exec
 | | | command-env
+| | | command-exec
 | | | fastreplacestring.cpp
 | | | fastreplacestring.exe
 | | | install

--- a/__tests__/build/__snapshots__/build-with-linked-dep-test.js.snap
+++ b/__tests__/build/__snapshots__/build-with-linked-dep-test.js.snap
@@ -16,6 +16,7 @@ exports[`esy local prefix dir 1`] = `
 | | | build-env
 | | | build-exec
 | | | command-env
+| | | command-exec
 | | | fastreplacestring.cpp
 | | | fastreplacestring.exe
 | | | install

--- a/scripts/babel-plugin-transform-fs-read-file-sync.js
+++ b/scripts/babel-plugin-transform-fs-read-file-sync.js
@@ -20,7 +20,7 @@ module.exports = function(babel) {
             path.replaceWith(
               t.callExpression(t.identifier('require'), [
                 t.stringLiteral(`raw-loader!${moduleNode.value}`),
-              ]),
+              ])
             );
           }
         }

--- a/scripts/build-webpack.js
+++ b/scripts/build-webpack.js
@@ -10,7 +10,7 @@ const version = require('../package.json').version;
 const basedir = path.join(__dirname, '../');
 const babelRc = JSON.parse(fs.readFileSync(path.join(basedir, '.babelrc'), 'utf8'));
 const babelPluginTrasnformFsReadFileSync = require.resolve(
-  './babel-plugin-transform-fs-read-file-sync.js',
+  './babel-plugin-transform-fs-read-file-sync.js'
 );
 
 babelRc.plugins.unshift(babelPluginTrasnformFsReadFileSync);

--- a/src/builders/shell-builder.js
+++ b/src/builders/shell-builder.js
@@ -84,6 +84,15 @@ export const eject = async (
   });
 
   await emitFile({
+    filename: ['bin/command-exec'],
+    executable: true,
+    contents: outdent`
+      ${environment.printEnvironment(S.getCommandEnv(sandbox, config))}
+      exec "$@"
+    `
+  });
+
+  await emitFile({
     filename: ['bin/sandbox-env'],
     contents: environment.printEnvironment(S.getSandboxEnv(sandbox, config)),
   });


### PR DESCRIPTION
Summary: This is a wrapper script that helps with IDE integration.

Test Plan: Ran the tests. Some unit tests fail - but they were failing
before.

I tested this with [my `ocaml-language-server` pull request](https://github.com/freebroccolo/ocaml-language-server/pull/65) and it works wonderfully. Just open any project built with `esy` and all the IDE features just work. Open another project with a totally different set of dependencies and that works too!

Reviewers:

CC: