### PR TITLE
Rewrite symlinks when doing relocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,11 @@ test-e2e:
 	(cd __tests__ && bash symlink-workflow-test.sh)
 
 test:
-	@$(BIN)/jest ./src/__tests__ ./__tests__/build/*-test.js ./__tests__/release/*-test.js
+	@$(BIN)/jest \
+		./src/__tests__ \
+		./__tests__/build/*-test.js \
+		./__tests__/release/*-test.js \
+		./__tests__/export-import-build/*-test.js
 	$(MAKE) test-e2e
 
 ci:

--- a/__tests__/build/__snapshots__/build-creates-symlinks-test.js.snap
+++ b/__tests__/build/__snapshots__/build-creates-symlinks-test.js.snap
@@ -1,0 +1,60 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`build creates-symlinks 1`] = `
+"RUNNING: esy config ls
+esy:bin no .esyrc found
+esy:bin prefix: <testRoot>/esy
+RUNNING: esy build
+esy:bin no .esyrc found
+esy:bin prefix: <testRoot>/esy
+esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
+esy:bin trying to acquire lock
+esy:bin:esyBuild execute
+esy:simple-builder:dep build: { buildType: 'out-of-source', sourceType: 'immutable' }
+esy:simple-builder:dep executing: echo \\"#!/bin/bash
+esy:simple-builder:dep executing: chmod +x $cur__target_dir/$cur__name
+esy:simple-builder:dep executing: cp $cur__target_dir/$cur__name $cur__lib/$cur__name
+esy:simple-builder:dep executing: ln -s $cur__lib/$cur__name $cur__bin/$cur__name
+esy:simple-builder:dep rewritePaths
+esy:bin trying to acquire lock
+esy:bin no .esyrc found
+esy:bin prefix: <testRoot>/esy
+esy:build-dependencies checking if dependencies are built
+esy:shell-builder esyPrepare
+esy:shell-builder esyRunBuildCommands
+esy:shell-builder esyComplete
+RUNNING: esy dep
+esy:bin no .esyrc found
+esy:bin prefix: <testRoot>/esy
+esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
+RUNNING: esy b dep
+esy:bin no .esyrc found
+esy:bin prefix: <testRoot>/esy
+esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
+esy:bin trying to acquire lock
+esy:bin no .esyrc found
+esy:bin prefix: <testRoot>/esy
+esy:build-dependencies checking if dependencies are built
+esy:shell-builder esyPrepare
+esy:shell-builder esyComplete
+RUNNING: esy x dep
+esy:bin no .esyrc found
+esy:bin prefix: <testRoot>/esy
+esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
+esy:bin trying to acquire lock
+esy:bin no .esyrc found
+esy:bin prefix: <testRoot>/esy
+esy:build-dependencies checking if dependencies are built
+esy:shell-builder esyPrepare
+esy:shell-builder esyRunBuildCommands
+esy:shell-builder esyRunInstallCommands
+esy:shell-builder esyComplete
+RUNNING: esy x creates-symlinks
+esy:bin no .esyrc found
+esy:bin prefix: <testRoot>/esy
+esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
+esy:bin trying to acquire lock
+esy:bin no .esyrc found
+esy:bin prefix: <testRoot>/esy
+esy:build-dependencies checking if dependencies are built"
+`;

--- a/__tests__/build/__snapshots__/build-custom-prefix-test.js.snap
+++ b/__tests__/build/__snapshots__/build-custom-prefix-test.js.snap
@@ -4,7 +4,6 @@ exports[`build custom-prefix 1`] = `
 "RUNNING: esy config ls
 esy:bin using <sandbox>/.esyrc
 esy:bin prefix: <testRoot>/esy
-esy:bin trying to acquire lock
 RUNNING: esy build
 esy:bin using <sandbox>/.esyrc
 esy:bin prefix: <testRoot>/project/store

--- a/__tests__/build/__snapshots__/build-errorneous-build-test.js.snap
+++ b/__tests__/build/__snapshots__/build-errorneous-build-test.js.snap
@@ -4,7 +4,6 @@ exports[`build errorneous-build 1`] = `
 "RUNNING: esy config ls
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
-esy:bin trying to acquire lock
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build

--- a/__tests__/build/__snapshots__/build-import-archive-test.js.snap
+++ b/__tests__/build/__snapshots__/build-import-archive-test.js.snap
@@ -4,7 +4,6 @@ exports[`build import-archive 1`] = `
 "RUNNING: esy config ls
 esy:bin using <sandbox>/.esyrc
 esy:bin prefix: <testRoot>/esy
-esy:bin trying to acquire lock
 RUNNING: esy build
 esy:bin using <sandbox>/.esyrc
 esy:bin prefix: <testRoot>/esy
@@ -28,7 +27,6 @@ esy:shell-builder esyComplete
 RUNNING: esy export-dependencies
 esy:bin using <sandbox>/.esyrc
 esy:bin prefix: <testRoot>/esy
-esy:bin trying to acquire lock
 esy:bin using <sandbox>/.esyrc
 esy:bin prefix: <testRoot>/esy
 esy:bin using <sandbox>/.esyrc

--- a/__tests__/build/__snapshots__/build-import-dir-test.js.snap
+++ b/__tests__/build/__snapshots__/build-import-dir-test.js.snap
@@ -4,7 +4,6 @@ exports[`build import-archive 1`] = `
 "RUNNING: esy config ls
 esy:bin using <sandbox>/.esyrc
 esy:bin prefix: <testRoot>/esy
-esy:bin trying to acquire lock
 RUNNING: esy build
 esy:bin using <sandbox>/.esyrc
 esy:bin prefix: <testRoot>/esy
@@ -28,7 +27,6 @@ esy:shell-builder esyComplete
 RUNNING: esy export-dependencies
 esy:bin using <sandbox>/.esyrc
 esy:bin prefix: <testRoot>/esy
-esy:bin trying to acquire lock
 esy:bin using <sandbox>/.esyrc
 esy:bin prefix: <testRoot>/esy
 esy:bin using <sandbox>/.esyrc

--- a/__tests__/build/__snapshots__/build-no-deps-_build-test.js.snap
+++ b/__tests__/build/__snapshots__/build-no-deps-_build-test.js.snap
@@ -4,7 +4,6 @@ exports[`build no-deps-_build 1`] = `
 "RUNNING: esy config ls
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
-esy:bin trying to acquire lock
 RUNNING: esy build
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy

--- a/__tests__/build/__snapshots__/build-no-deps-in-source-test.js.snap
+++ b/__tests__/build/__snapshots__/build-no-deps-in-source-test.js.snap
@@ -4,7 +4,6 @@ exports[`build no-deps-in-source 1`] = `
 "RUNNING: esy config ls
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
-esy:bin trying to acquire lock
 RUNNING: esy build
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy

--- a/__tests__/build/__snapshots__/build-no-deps-test.js.snap
+++ b/__tests__/build/__snapshots__/build-no-deps-test.js.snap
@@ -4,7 +4,6 @@ exports[`build no-deps 1`] = `
 "RUNNING: esy config ls
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
-esy:bin trying to acquire lock
 RUNNING: esy build
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy

--- a/__tests__/build/__snapshots__/build-with-dep-_build-test.js.snap
+++ b/__tests__/build/__snapshots__/build-with-dep-_build-test.js.snap
@@ -4,7 +4,6 @@ exports[`build with-dep-_build 1`] = `
 "RUNNING: esy config ls
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
-esy:bin trying to acquire lock
 RUNNING: esy build
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy

--- a/__tests__/build/__snapshots__/build-with-dep-in-source-test.js.snap
+++ b/__tests__/build/__snapshots__/build-with-dep-in-source-test.js.snap
@@ -4,7 +4,6 @@ exports[`build with-dep-in-source 1`] = `
 "RUNNING: esy config ls
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
-esy:bin trying to acquire lock
 RUNNING: esy build
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy

--- a/__tests__/build/__snapshots__/build-with-dep-test.js.snap
+++ b/__tests__/build/__snapshots__/build-with-dep-test.js.snap
@@ -4,7 +4,6 @@ exports[`build with-dep 1`] = `
 "RUNNING: esy config ls
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
-esy:bin trying to acquire lock
 RUNNING: esy build
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy

--- a/__tests__/build/__snapshots__/build-with-dev-dep-test.js.snap
+++ b/__tests__/build/__snapshots__/build-with-dev-dep-test.js.snap
@@ -4,7 +4,6 @@ exports[`build with-dev-dep 1`] = `
 "RUNNING: esy config ls
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
-esy:bin trying to acquire lock
 RUNNING: esy build
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy

--- a/__tests__/build/__snapshots__/build-with-linked-dep-_build-test.js.snap
+++ b/__tests__/build/__snapshots__/build-with-linked-dep-_build-test.js.snap
@@ -4,7 +4,6 @@ exports[`build with-linked-dep-_build 1`] = `
 "RUNNING: esy config ls
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
-esy:bin trying to acquire lock
 RUNNING: esy build
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy

--- a/__tests__/build/__snapshots__/build-with-linked-dep-in-source-test.js.snap
+++ b/__tests__/build/__snapshots__/build-with-linked-dep-in-source-test.js.snap
@@ -4,7 +4,6 @@ exports[`build with-linked-dep-in-source 1`] = `
 "RUNNING: esy config ls
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
-esy:bin trying to acquire lock
 RUNNING: esy build
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy

--- a/__tests__/build/__snapshots__/build-with-linked-dep-test.js.snap
+++ b/__tests__/build/__snapshots__/build-with-linked-dep-test.js.snap
@@ -4,7 +4,6 @@ exports[`build with-linked-dep 1`] = `
 "RUNNING: esy config ls
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
-esy:bin trying to acquire lock
 RUNNING: esy build
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy

--- a/__tests__/build/build-creates-symlinks-test.js
+++ b/__tests__/build/build-creates-symlinks-test.js
@@ -1,0 +1,21 @@
+/**
+ * @flow
+ */
+
+import * as path from 'path';
+import {defineTestCaseWithShell} from '../utils';
+
+defineTestCaseWithShell(
+  path.join(__dirname, 'fixtures', 'creates-symlinks'),
+  `
+    run esy build
+
+    # package "dep" should be visible in all envs
+    assertStdout "esy dep" "dep"
+    assertStdout "esy b dep" "dep"
+    assertStdout "esy x dep" "dep"
+
+    assertStdout "esy x creates-symlinks" "creates-symlinks"
+  `,
+  {snapshotExecutionTrace: true},
+);

--- a/__tests__/build/fixtures/creates-symlinks/node_modules/dep/package.json
+++ b/__tests__/build/fixtures/creates-symlinks/node_modules/dep/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "dep",
+  "version": "1.0.0",
+  "license": "MIT",
+  "esy": {
+    "build": [
+      "echo \"#!/bin/bash\necho $cur__name\" > $cur__target_dir/$cur__name",
+      "chmod +x $cur__target_dir/$cur__name"
+    ],
+    "install": [
+      "cp $cur__target_dir/$cur__name $cur__lib/$cur__name",
+      "ln -s $cur__lib/$cur__name $cur__bin/$cur__name"
+    ]
+  },
+  "_resolved": "http://sometarball.gz"
+}

--- a/__tests__/build/fixtures/creates-symlinks/package.json
+++ b/__tests__/build/fixtures/creates-symlinks/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "creates-symlinks",
+  "version": "1.0.0",
+  "license": "MIT",
+  "esy": {
+    "build": [
+      "echo \"#!/bin/bash\necho $cur__name\" > $cur__target_dir/$cur__name",
+      "chmod +x $cur__target_dir/$cur__name"
+    ],
+    "install": [
+      "cp $cur__target_dir/$cur__name $cur__lib/$cur__name",
+      "ln -s $cur__lib/$cur__name $cur__bin/$cur__name"
+    ]
+  },
+  "dependencies": {
+    "dep": "*"
+  }
+}

--- a/__tests__/export-import-build/__snapshots__/export-import-symlinks-into-dep-test.js.snap
+++ b/__tests__/export-import-build/__snapshots__/export-import-symlinks-into-dep-test.js.snap
@@ -1,0 +1,100 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`build symlinks-into-dep 1`] = `
+"RUNNING: esy config ls
+esy:bin no .esyrc found
+esy:bin prefix: <testRoot>/esy
+RUNNING: esy build
+esy:bin no .esyrc found
+esy:bin prefix: <testRoot>/esy
+esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
+esy:bin trying to acquire lock
+esy:bin:esyBuild execute
+esy:simple-builder:subdep build: { buildType: 'out-of-source', sourceType: 'immutable' }
+esy:simple-builder:subdep executing: echo \\"#!/bin/bash
+esy:simple-builder:subdep executing: chmod +x $cur__target_dir/$cur__name
+esy:simple-builder:subdep executing: cp $cur__target_dir/$cur__name $cur__bin/$cur__name
+esy:simple-builder:subdep rewritePaths
+esy:simple-builder:dep build: { buildType: 'out-of-source', sourceType: 'immutable' }
+esy:simple-builder:dep executing: ln -s #{subdep.bin / subdep.name} #{self.bin / self.name}
+esy:simple-builder:dep rewritePaths
+esy:bin trying to acquire lock
+esy:bin no .esyrc found
+esy:bin prefix: <testRoot>/esy
+esy:build-dependencies checking if dependencies are built
+esy:shell-builder esyPrepare
+esy:shell-builder esyRunBuildCommands
+esy:shell-builder esyComplete
+RUNNING: esy subdep
+esy:bin no .esyrc found
+esy:bin prefix: <testRoot>/esy
+esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
+RUNNING: esy b subdep
+esy:bin no .esyrc found
+esy:bin prefix: <testRoot>/esy
+esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
+esy:bin trying to acquire lock
+esy:bin no .esyrc found
+esy:bin prefix: <testRoot>/esy
+esy:build-dependencies checking if dependencies are built
+esy:shell-builder esyPrepare
+esy:shell-builder esyComplete
+RUNNING: esy x subdep
+esy:bin no .esyrc found
+esy:bin prefix: <testRoot>/esy
+esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
+esy:bin trying to acquire lock
+esy:bin no .esyrc found
+esy:bin prefix: <testRoot>/esy
+esy:build-dependencies checking if dependencies are built
+esy:shell-builder esyPrepare
+esy:shell-builder esyRunBuildCommands
+esy:shell-builder esyRunInstallCommands
+esy:shell-builder esyComplete
+RUNNING: esy dep
+esy:bin no .esyrc found
+esy:bin prefix: <testRoot>/esy
+esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
+RUNNING: esy b dep
+esy:bin no .esyrc found
+esy:bin prefix: <testRoot>/esy
+esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
+esy:bin trying to acquire lock
+esy:bin no .esyrc found
+esy:bin prefix: <testRoot>/esy
+esy:build-dependencies checking if dependencies are built
+esy:shell-builder esyPrepare
+esy:shell-builder esyComplete
+RUNNING: esy x dep
+esy:bin no .esyrc found
+esy:bin prefix: <testRoot>/esy
+esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
+esy:bin trying to acquire lock
+esy:bin no .esyrc found
+esy:bin prefix: <testRoot>/esy
+esy:build-dependencies checking if dependencies are built
+esy:shell-builder esyPrepare
+esy:shell-builder esyRunBuildCommands
+esy:shell-builder esyRunInstallCommands
+esy:shell-builder esyComplete
+RUNNING: esy x symlinks-into-dep
+esy:bin no .esyrc found
+esy:bin prefix: <testRoot>/esy
+esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
+esy:bin trying to acquire lock
+esy:bin no .esyrc found
+esy:bin prefix: <testRoot>/esy
+esy:build-dependencies checking if dependencies are built
+RUNNING: esy export-build ../esy/3/i/dep-1.0.0
+esy:bin no .esyrc found
+esy:bin prefix: <testRoot>/esy
+esy:bin no .esyrc found
+esy:bin prefix: <testRoot>/esy
+RUNNING: tar xzf dep-1.0.0.tar.gz
+RUNNING: rm -rf ../esy/3/i/dep-1.0.0
+RUNNING: esy import-build ./_export/dep-1.0.0.tar.gz
+esy:bin no .esyrc found
+esy:bin prefix: <testRoot>/esy
+esy:bin no .esyrc found
+esy:bin prefix: <testRoot>/esy"
+`;

--- a/__tests__/export-import-build/export-import-symlinks-into-dep-test.js
+++ b/__tests__/export-import-build/export-import-symlinks-into-dep-test.js
@@ -1,0 +1,56 @@
+/**
+ * @flow
+ */
+
+import * as path from 'path';
+import {defineTestCaseWithShell} from '../utils';
+
+defineTestCaseWithShell(
+  path.join(__dirname, 'fixtures', 'symlinks-into-dep'),
+  `
+    run esy build
+
+    # package "subdep" should be visible in all envs
+    assertStdout "esy subdep" "subdep"
+    assertStdout "esy b subdep" "subdep"
+    assertStdout "esy x subdep" "subdep"
+
+    # same for package "dep" but it should reuse the impl of "subdep"
+    assertStdout "esy dep" "subdep"
+    assertStdout "esy b dep" "subdep"
+    assertStdout "esy x dep" "subdep"
+
+    # and root package links into "dep" which links into "subdep"
+    assertStdout "esy x symlinks-into-dep" "subdep"
+
+    # check that link is here
+    storeTarget=$(readlink ../esy/3/i/dep-1.0.0/bin/dep)
+    if [[ "$storeTarget" != $ESY_TEST__PREFIX* ]]; then
+      failwith "invalid symlink target: $storeTarget"
+    fi
+
+    # export build from store
+    run esy export-build ../esy/3/i/dep-1.0.0
+    cd _export
+    run tar xzf dep-1.0.0.tar.gz
+    cd ../
+
+    # check symlink target for exported build
+    exportedTarget=$(readlink _export/dep-1.0.0/bin/dep)
+    if [[ "$exportedTarget" != ________* ]]; then
+      failwith "invalid symlink target: $exportedTarget"
+    fi
+
+    # drop & import
+    run rm -rf ../esy/3/i/dep-1.0.0
+    run esy import-build ./_export/dep-1.0.0.tar.gz
+
+    # check symlink target for imported build
+    importedTarget=$(readlink ../esy/3/i/dep-1.0.0/bin/dep)
+    if [[ "$importedTarget" != $ESY_TEST__PREFIX* ]]; then
+      failwith "invalid symlink target: $exportedTarget"
+    fi
+
+  `,
+  {snapshotExecutionTrace: true},
+);

--- a/__tests__/export-import-build/fixtures/symlinks-into-dep/node_modules/dep/node_modules/subdep/package.json
+++ b/__tests__/export-import-build/fixtures/symlinks-into-dep/node_modules/dep/node_modules/subdep/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "subdep",
+  "version": "1.0.0",
+  "license": "MIT",
+  "esy": {
+    "build": [
+      "echo \"#!/bin/bash\necho $cur__name\" > $cur__target_dir/$cur__name",
+      "chmod +x $cur__target_dir/$cur__name"
+    ],
+    "install": [
+      "cp $cur__target_dir/$cur__name $cur__bin/$cur__name"
+    ]
+  },
+  "_resolved": "http://subdep-sometarball.gz"
+}

--- a/__tests__/export-import-build/fixtures/symlinks-into-dep/node_modules/dep/package.json
+++ b/__tests__/export-import-build/fixtures/symlinks-into-dep/node_modules/dep/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "dep",
+  "version": "1.0.0",
+  "license": "MIT",
+  "esy": {
+    "build": [
+      "ln -s #{subdep.bin / subdep.name} #{self.bin / self.name}"
+    ]
+  },
+  "dependencies": {
+    "subdep": "*"
+  },
+  "_resolved": "http://sometarball.gz"
+}

--- a/__tests__/export-import-build/fixtures/symlinks-into-dep/package.json
+++ b/__tests__/export-import-build/fixtures/symlinks-into-dep/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "symlinks-into-dep",
+  "version": "1.0.0",
+  "license": "MIT",
+  "esy": {
+    "build": [
+      "ln -s #{dep.bin / dep.name} #{self.bin / self.name}"
+    ]
+  },
+  "dependencies": {
+    "dep": "*"
+  }
+}

--- a/__tests__/utils.js
+++ b/__tests__/utils.js
@@ -126,6 +126,7 @@ export function initFixtureSync(fixturePath: string) {
 
       export ESY__COMMAND="${require.resolve('../bin/esy')}"
       export ESY_TEST__ROOT="${root}"
+      export ESY_TEST__PREFIX="${esyPrefix}"
       export ESY_TEST__PROJECT="${project}"
       export PATH="${npmPrefix}/bin:$PATH"
 

--- a/__tests__/utils.js
+++ b/__tests__/utils.js
@@ -125,6 +125,8 @@ export function initFixtureSync(fixturePath: string) {
       export DEBUG_HIDE_DATE="yes"
 
       export ESY__COMMAND="${require.resolve('../bin/esy')}"
+      export ESY_TEST__ROOT="${root}"
+      export ESY_TEST__PROJECT="${project}"
       export PATH="${npmPrefix}/bin:$PATH"
 
       set -u

--- a/bin/esy
+++ b/bin/esy
@@ -162,6 +162,10 @@ callBuiltInCommand__buildEject () {
 }
 
 callBuiltInCommand() {
+	node "$SCRIPTDIR/esy.js" "$@"
+}
+
+callBuiltInCommandWithLock() {
 	withLock node "$SCRIPTDIR/esy.js" "$@"
 }
 
@@ -301,7 +305,7 @@ elif [ $# -eq 1 ]; then
       ;;
     release)
       shift
-      callBuiltInCommand release
+      callBuiltInCommandWithLock release
       ;;
     build|b)
       shift
@@ -309,11 +313,11 @@ elif [ $# -eq 1 ]; then
       ;;
     _build)
       shift
-      callBuiltInCommand build
+      callBuiltInCommandWithLock build
       ;;
     build-shell)
       shift
-      callBuiltInCommand build-shell
+      callBuiltInCommandWithLock build-shell
       ;;
     ls-builds)
       shift
@@ -413,7 +417,7 @@ else
       ;;
     build-shell)
       shift
-      callBuiltInCommand build-shell "$@"
+      callBuiltInCommandWithLock build-shell "$@"
       ;;
     install|i)
       shift
@@ -423,7 +427,7 @@ else
       shift
       case "$1" in
         -*)
-          callBuiltInCommand build "$@"
+          callBuiltInCommandWithLock build "$@"
           ;;
         *)
           callBuiltInCommand__build "$@"
@@ -432,7 +436,7 @@ else
       ;;
     _build)
       shift
-      callBuiltInCommand build "$@"
+      callBuiltInCommandWithLock build "$@"
       ;;
     install-cache)
       shift
@@ -440,7 +444,7 @@ else
       ;;
     release)
       shift
-      callBuiltInCommand release "$@"
+      callBuiltInCommandWithLock release "$@"
       ;;
     ls-builds)
       shift

--- a/bin/esyExportBuild
+++ b/bin/esyExportBuild
@@ -42,7 +42,8 @@ function _do () {
   local origStorePath
   local destStorePath
 
-  cp -r "$buildPath" "$stageBuildPath"
+  # copy into stage recursively (-R) and do not follow symlinks (-P)
+  cp -RP "$buildPath" "$stageBuildPath"
 
   origStorePath=$(cat "$stageBuildPath/_esy/storePrefix")
   destStorePath=${origStorePath//?/_}

--- a/bin/esyImportBuild
+++ b/bin/esyImportBuild
@@ -57,7 +57,8 @@ function esyImportBuild () {
     cp "$buildPath" "$stageBuildPath.tar.gz"
     (cd "$stageDir" && tar xzf "$stageBuildPath.tar.gz")
   else
-    cp -rf "$buildPath" "$stageBuildPath"
+    # copy into stage recursively (-R) and do not follow symlinks (-P)
+    cp -RP "$buildPath" "$stageBuildPath"
   fi
 
   origStorePath=$(cat "$stageBuildPath/_esy/storePrefix")

--- a/bin/esyImportBuild
+++ b/bin/esyImportBuild
@@ -31,7 +31,7 @@ stageDir=$(mktemp -d)
 destStorePath=$(esyGetStorePathFromPrefix "$ESY__PREFIX")
 destStorePathLen=$(esyStrLen "$destStorePath")
 
-function esyimportBuild () {
+function esyImportBuild () {
   set -e
   set -u
   set -o pipefail
@@ -90,16 +90,16 @@ if [ "$1" == "--from" ] || [ "$1" == "-f" ]; then
   export stageDir
   export destStorePath
   export destStorePathLen
-  export -f esyimportBuild
+  export -f esyImportBuild
 
   set +e
-  cat "$buildPathList" | xargs -n1 -P12 -I {} bash -c 'esyimportBuild "{}"'
+  cat "$buildPathList" | xargs -n1 -P12 -I {} bash -c 'esyImportBuild "{}"'
   ret="$?"
   set -e
 else
   buildPath="$1"
   set +e
-  (esyimportBuild "$buildPath")
+  (esyImportBuild "$buildPath")
   ret="$?"
   set -e
 fi

--- a/bin/esyRuntime.sh
+++ b/bin/esyRuntime.sh
@@ -131,7 +131,7 @@ esyRewriteSymlink () {
 
   symlinkTarget=$(readlink "$path")
   if [[ "$symlinkTarget" == $origPrefix* ]]; then
-    symlinkTarget="$destPrefix/${symlinkTarget#$origPrefix}"
+    symlinkTarget="$destPrefix${symlinkTarget#$origPrefix}"
     rm "$path"
     ln -s "$symlinkTarget" "$path"
   fi

--- a/bin/esyRuntime.sh
+++ b/bin/esyRuntime.sh
@@ -121,7 +121,7 @@ esyRewriteStorePrefix () {
     | xargs -0 -I {} -P 30 "$BINDIR/fastreplacestring.exe" "{}" "$origPrefix" "$destPrefix"
   # rewrite paths in symlinks
   find "$path" -type l -print0 \
-    | xargs -0 -I {} -P 30 "$BINDIR/fastreplacestring.exe" "{}" "$origPrefix" "$destPrefix"
+    | xargs -0 -I {} -P 30 bash -c "esyRewriteSymlinks '{}' '$origPrefix' '$destPrefix'"
 }
 
 esyRewriteSymlinks () {
@@ -130,12 +130,13 @@ esyRewriteSymlinks () {
   local destPrefix="$3"
 
   symlinkTarget=$(readlink "$path")
-  if [[ "$symlinkTarget" == $cur__install* ]]; then
-    symlinkTarget="$esy_build__install_root/${symlinkTarget#$cur__install}"
-    rm "$filename"
-    ln -s "$symlinkTarget" "$filename"
+  if [[ "$symlinkTarget" == $origPrefix* ]]; then
+    symlinkTarget="$destPrefix/${symlinkTarget#$origPrefix}"
+    rm "$path"
+    ln -s "$symlinkTarget" "$path"
   fi
 }
+export -f esyRewriteSymlinks
 
 #
 # Find source modification time

--- a/bin/esyRuntime.sh
+++ b/bin/esyRuntime.sh
@@ -119,12 +119,12 @@ esyRewriteStorePrefix () {
   # rewrite paths in files
   find "$path" -type f -print0 \
     | xargs -0 -I {} -P 30 "$BINDIR/fastreplacestring.exe" "{}" "$origPrefix" "$destPrefix"
-  # rewrite paths in symlinks
+  # rewrite paths symlinks point to
   find "$path" -type l -print0 \
-    | xargs -0 -I {} -P 30 bash -c "esyRewriteSymlinks '{}' '$origPrefix' '$destPrefix'"
+    | xargs -0 -I {} -P 30 bash -c "esyRewriteSymlink '{}' '$origPrefix' '$destPrefix'"
 }
 
-esyRewriteSymlinks () {
+esyRewriteSymlink () {
   local path="$1"
   local origPrefix="$2"
   local destPrefix="$3"
@@ -136,7 +136,7 @@ esyRewriteSymlinks () {
     ln -s "$symlinkTarget" "$path"
   fi
 }
-export -f esyRewriteSymlinks
+export -f esyRewriteSymlink
 
 #
 # Find source modification time

--- a/bin/esyRuntime.sh
+++ b/bin/esyRuntime.sh
@@ -120,8 +120,9 @@ esyRewriteStorePrefix () {
   find "$path" -type f -print0 \
     | xargs -0 -I {} -P 30 "$BINDIR/fastreplacestring.exe" "{}" "$origPrefix" "$destPrefix"
   # rewrite paths symlinks point to
-  find "$path" -type l -print0 \
-    | xargs -0 -I {} -P 30 bash -c "esyRewriteSymlink '{}' '$origPrefix' '$destPrefix'"
+  find "$path" -type l | while read -r name; do
+    esyRewriteSymlink "$name" "$origPrefix" "$destPrefix"
+  done
 }
 
 esyRewriteSymlink () {
@@ -136,7 +137,6 @@ esyRewriteSymlink () {
     ln -s "$symlinkTarget" "$path"
   fi
 }
-export -f esyRewriteSymlink
 
 #
 # Find source modification time

--- a/bin/esyRuntime.sh
+++ b/bin/esyRuntime.sh
@@ -116,8 +116,25 @@ esyRewriteStorePrefix () {
   local path="$1"
   local origPrefix="$2"
   local destPrefix="$3"
+  # rewrite paths in files
   find "$path" -type f -print0 \
     | xargs -0 -I {} -P 30 "$BINDIR/fastreplacestring.exe" "{}" "$origPrefix" "$destPrefix"
+  # rewrite paths in symlinks
+  find "$path" -type l -print0 \
+    | xargs -0 -I {} -P 30 "$BINDIR/fastreplacestring.exe" "{}" "$origPrefix" "$destPrefix"
+}
+
+esyRewriteSymlinks () {
+  local path="$1"
+  local origPrefix="$2"
+  local destPrefix="$3"
+
+  symlinkTarget=$(readlink "$path")
+  if [[ "$symlinkTarget" == $cur__install* ]]; then
+    symlinkTarget="$esy_build__install_root/${symlinkTarget#$cur__install}"
+    rm "$filename"
+    ln -s "$symlinkTarget" "$filename"
+  fi
 }
 
 #

--- a/bin/realpath.sh
+++ b/bin/realpath.sh
@@ -24,10 +24,12 @@
 realpath() {
     canonicalize_path "$(resolve_symlinks "$1")"
 }
+export -f realpath
 
 resolve_symlinks() {
     _resolve_symlinks "$1"
 }
+export -f resolve_symlinks
 
 _resolve_symlinks() {
     _assert_no_path_cycles "$@" || return
@@ -41,6 +43,7 @@ _resolve_symlinks() {
         printf '%s\n' "$1"
     fi
 }
+export -f _resolve_symlinks
 
 _prepend_dir_context_if_necessary() {
     if [ "$1" = . ]; then
@@ -49,6 +52,7 @@ _prepend_dir_context_if_necessary() {
         _prepend_path_if_relative "$1" "$2"
     fi
 }
+export -f _prepend_dir_context_if_necessary
 
 _prepend_path_if_relative() {
     case "$2" in
@@ -56,6 +60,7 @@ _prepend_path_if_relative() {
          * ) printf '%s\n' "$1/$2" ;;
     esac
 }
+export -f _prepend_path_if_relative
 
 _assert_no_path_cycles() {
     local target path
@@ -69,6 +74,7 @@ _assert_no_path_cycles() {
         fi
     done
 }
+export -f _assert_no_path_cycles
 
 canonicalize_path() {
     if [ -d "$1" ]; then
@@ -77,10 +83,12 @@ canonicalize_path() {
         _canonicalize_file_path "$1"
     fi
 }
+export -f canonicalize_path
 
 _canonicalize_dir_path() {
     (cd "$1" 2>/dev/null && pwd -P)
 }
+export -f _canonicalize_dir_path
 
 _canonicalize_file_path() {
     local dir file
@@ -88,6 +96,7 @@ _canonicalize_file_path() {
     file=$(basename -- "$1")
     (cd "$dir" 2>/dev/null && printf '%s/%s\n' "$(pwd -P)" "$file")
 }
+export -f _canonicalize_file_path
 
 # Optionally, you may also want to include:
 
@@ -100,14 +109,17 @@ readlink() {
         _emulated_readlink "$@"
     fi
 }
+export -f readlink
 
 _has_command() {
     hash -- "$1" 2>/dev/null
 }
+export -f _has_command
 
 _system_readlink() {
     command readlink "$@"
 }
+export -f _system_readlink
 
 _emulated_readlink() {
     if [ "$1" = -- ]; then
@@ -116,6 +128,7 @@ _emulated_readlink() {
 
     _gnu_stat_readlink "$@" || _bsd_stat_readlink "$@"
 }
+export -f _emulated_readlink
 
 _gnu_stat_readlink() {
     local output
@@ -126,7 +139,9 @@ _gnu_stat_readlink() {
              s/^'[^']*' -> '\(.*\)'/\1/"
     # FIXME: handle newlines
 }
+export -f _gnu_stat_readlink
 
 _bsd_stat_readlink() {
     stat -f %Y -- "$1" 2>/dev/null
 }
+export -f _bsd_stat_readlink

--- a/bin/realpath.sh
+++ b/bin/realpath.sh
@@ -24,12 +24,10 @@
 realpath() {
     canonicalize_path "$(resolve_symlinks "$1")"
 }
-export -f realpath
 
 resolve_symlinks() {
     _resolve_symlinks "$1"
 }
-export -f resolve_symlinks
 
 _resolve_symlinks() {
     _assert_no_path_cycles "$@" || return
@@ -43,7 +41,6 @@ _resolve_symlinks() {
         printf '%s\n' "$1"
     fi
 }
-export -f _resolve_symlinks
 
 _prepend_dir_context_if_necessary() {
     if [ "$1" = . ]; then
@@ -52,7 +49,6 @@ _prepend_dir_context_if_necessary() {
         _prepend_path_if_relative "$1" "$2"
     fi
 }
-export -f _prepend_dir_context_if_necessary
 
 _prepend_path_if_relative() {
     case "$2" in
@@ -60,7 +56,6 @@ _prepend_path_if_relative() {
          * ) printf '%s\n' "$1/$2" ;;
     esac
 }
-export -f _prepend_path_if_relative
 
 _assert_no_path_cycles() {
     local target path
@@ -74,7 +69,6 @@ _assert_no_path_cycles() {
         fi
     done
 }
-export -f _assert_no_path_cycles
 
 canonicalize_path() {
     if [ -d "$1" ]; then
@@ -83,12 +77,10 @@ canonicalize_path() {
         _canonicalize_file_path "$1"
     fi
 }
-export -f canonicalize_path
 
 _canonicalize_dir_path() {
     (cd "$1" 2>/dev/null && pwd -P)
 }
-export -f _canonicalize_dir_path
 
 _canonicalize_file_path() {
     local dir file
@@ -96,7 +88,6 @@ _canonicalize_file_path() {
     file=$(basename -- "$1")
     (cd "$dir" 2>/dev/null && printf '%s/%s\n' "$(pwd -P)" "$file")
 }
-export -f _canonicalize_file_path
 
 # Optionally, you may also want to include:
 
@@ -109,17 +100,14 @@ readlink() {
         _emulated_readlink "$@"
     fi
 }
-export -f readlink
 
 _has_command() {
     hash -- "$1" 2>/dev/null
 }
-export -f _has_command
 
 _system_readlink() {
     command readlink "$@"
 }
-export -f _system_readlink
 
 _emulated_readlink() {
     if [ "$1" = -- ]; then
@@ -128,7 +116,6 @@ _emulated_readlink() {
 
     _gnu_stat_readlink "$@" || _bsd_stat_readlink "$@"
 }
-export -f _emulated_readlink
 
 _gnu_stat_readlink() {
     local output
@@ -139,9 +126,7 @@ _gnu_stat_readlink() {
              s/^'[^']*' -> '\(.*\)'/\1/"
     # FIXME: handle newlines
 }
-export -f _gnu_stat_readlink
 
 _bsd_stat_readlink() {
     stat -f %Y -- "$1" 2>/dev/null
 }
-export -f _bsd_stat_readlink

--- a/src/builders/shell-builder.sh
+++ b/src/builders/shell-builder.sh
@@ -233,8 +233,27 @@ esyRunInstallCommands () {
   done
 
   # Relocate installation
-  for filename in $(find $cur__install -type f); do
+
+  local files
+
+  files=$(find "$cur__install" -type f)
+
+  for filename in $files; do
     "$ESY_EJECT__ROOT/bin/fastreplacestring.exe" "$filename" "$cur__install" "$esy_build__install_root"
+  done
+
+  local symlinks
+  local symlinkTarget
+
+  symlinks=$(find "$cur__install" -type l)
+
+  for filename in $symlinks; do
+    symlinkTarget=$(readlink "$filename")
+    if [[ "$symlinkTarget" == $cur__install* ]]; then
+      symlinkTarget="$esy_build__install_root/${symlinkTarget#$cur__install}"
+      rm "$filename"
+      ln -s "$symlinkTarget" "$filename"
+    fi
   done
 
   mkdir -p "$cur__install/_esy"

--- a/src/builders/shell-builder.sh
+++ b/src/builders/shell-builder.sh
@@ -250,7 +250,7 @@ esyRunInstallCommands () {
   for filename in $symlinks; do
     symlinkTarget=$(readlink "$filename")
     if [[ "$symlinkTarget" == $cur__install* ]]; then
-      symlinkTarget="$esy_build__install_root/${symlinkTarget#$cur__install}"
+      symlinkTarget="$esy_build__install_root${symlinkTarget#$cur__install}"
       rm "$filename"
       ln -s "$symlinkTarget" "$filename"
     fi

--- a/src/builders/util.js
+++ b/src/builders/util.js
@@ -96,6 +96,24 @@ export async function rewritePathInFile(
   }
 }
 
+export async function rewritePathInSymlink(
+  filename: string,
+  origPath: string,
+  destPath: string,
+) {
+  const stat = await fs.lstat(filename);
+  if (!stat.isSymbolicLink()) {
+    return;
+  }
+  const linkPath = path.resolve(path.dirname(filename), await fs.readlink(filename));
+  if (linkPath.indexOf(origPath) !== 0) {
+    return;
+  }
+  const nextTargetPath = path.join(destPath, path.relative(origPath, linkPath));
+  await fs.unlink(filename);
+  await fs.fsSymlink(nextTargetPath, filename);
+}
+
 export function exec(
   ...args: *
 ): {process: child.ChildProcess, exit: Promise<{code: number, signal: string}>} {

--- a/src/lib/path.js
+++ b/src/lib/path.js
@@ -41,6 +41,10 @@ export function join<B: Path | string>(base: B, ...p: string[]): B {
   return (path.join(base, ...p): any);
 }
 
+export function resolve<B: Path | string>(...p: B[]): B {
+  return (path.resolve(...p): any);
+}
+
 export function basename<P: Path | string>(p: P): string {
   return path.basename(p);
 }


### PR DESCRIPTION
This fixes #93 

* `shell-builder.sh` is modified to fix symlinks (`esy build` and `esy build-eject` affected)
* `esy export-build` and `esy import-build` are modified to rewrite symlinks
* `simple-builder.js` is modified to rewrite symlinks
* use `cp -RP` to copy symlinks as-is when doing import/export (this makes symlinks handling consistent between macOS and Linux)
* tests for build and import/export workflows
