### PR TITLE
Allow writing package.opam at the root.

### DIFF
--- a/src/builders/util.js
+++ b/src/builders/util.js
@@ -59,6 +59,12 @@ export function renderSandboxSbConfig(
          (regex "^${config.getRootPath(spec, '.*', '[^/]*\\.install')}$")
         ; $cur__root/NAME.install
          (regex "^${config.getRootPath(spec, '[^/]*\\.install')}$")
+
+        ; $cur__root/NAME.opam
+         (regex "^${config.getRootPath(spec, '[^/]*\\.opam')}$")
+
+        ; $cur__root/jbuild-ignore
+         (regex "^${config.getRootPath(spec, 'jbuild-ignore')}$")
         `
         : ''};
 

--- a/src/builders/util.js
+++ b/src/builders/util.js
@@ -66,7 +66,16 @@ export function renderSandboxSbConfig(
         ; $cur__root/jbuild-ignore
          (regex "^${config.getRootPath(spec, 'jbuild-ignore')}$")
         `
-        : ''};
+        :
+        // cur__original_root is where the original source files lived,
+        // and cur__root is where they might have been copied to.
+        `
+        ; $cur__original_root/*/.merlin
+         (regex "^${config.getRootPath(spec, '.*', '\\.merlin')}$")
+        ; $cur__original_root/.merlin
+         (regex "^${config.getRootPath(spec, '\\.merlin')}$")
+        `
+      };
 
       ; $cur__target_dir
       (subpath "${config.getBuildPath(spec)}")


### PR DESCRIPTION
Summary:For some automated workflows that remove boilerplate, this would
help.

Test Plan:Tested locally, `buildsInSource:"_build"`

Reviewers:

CC: