### PR TITLE
esy create command

### DIFF
--- a/bin/esy
+++ b/bin/esy
@@ -318,6 +318,10 @@ elif [ $# -eq 1 ]; then
       ensureSandbox
       callBuiltInCommandWithLock release
       ;;
+    init)
+      shift
+      callBuiltInCommand create
+      ;;
     build|b)
       shift
       ensureSandbox
@@ -456,6 +460,10 @@ else
       shift
       ensureSandbox
       callBuiltInCommandWithLock build-shell "$@"
+      ;;
+    init|create)
+      shift
+      callBuiltInCommand create "$@"
       ;;
     install|i)
       shift

--- a/src/bin/esy.js
+++ b/src/bin/esy.js
@@ -160,6 +160,7 @@ type Command = {
 };
 
 const commandsByName: {[name: string]: () => Command} = {
+  create: () => require('./esyCreate'),
   build: () => require('./esyBuild'),
   release: () => require('./esyRelease'),
   config: () => require('./esyConfig'),

--- a/src/bin/esyCreate.js
+++ b/src/bin/esyCreate.js
@@ -24,7 +24,7 @@ export default async function esyCreate(
     [builderName, ...builderArgs] = invocation.args;
   } else {
     builderName = 'esy-project';
-    builderArgs = invocation.args;
+    builderArgs = ['my-esy-project', ...invocation.args];
   }
 
   const packageName = builderName.replace(/^(@[^\/]+\/)?/, '$1create-');

--- a/src/bin/esyCreate.js
+++ b/src/bin/esyCreate.js
@@ -2,17 +2,30 @@
  * @flow
  */
 
+import type {CommandContext, CommandInvocation} from './esy';
+
+import chalk from 'chalk';
+import * as child from '@esy-ocaml/esy-install/src/util/child';
 import * as path from 'path';
 import * as fs from 'fs';
-import type {CommandContext, CommandInvocation} from './esy';
+import commander from 'commander';
+import parse from 'cli-argparse';
 import runYarnCommand from './runYarnCommand';
-import * as child from '@esy-ocaml/esy-install/src/util/child';
 
 export default async function esyCreate(
   ctx: CommandContext,
   invocation: CommandInvocation,
 ) {
-  const [builderName = 'esy-project', ...rest] = invocation.args;
+  const {unparsed} = parse(invocation.args);
+  let builderName;
+  let builderArgs;
+
+  if (unparsed.length) {
+    [builderName, ...builderArgs] = invocation.args;
+  } else {
+    builderName = 'esy-project';
+    builderArgs = invocation.args;
+  }
 
   const packageName = builderName.replace(/^(@[^\/]+\/)?/, '$1create-');
   const commandName = packageName.replace(/^@[^\/]+\//, '');
@@ -30,7 +43,7 @@ export default async function esyCreate(
   const binFolder = path.resolve(globalFolder, 'node_modules', '.bin');
   const command = path.resolve(binFolder, path.basename(commandName));
 
-  await child.spawn(command, [...rest], {stdio: `inherit`, shell: true});
+  await child.spawn(command, [...builderArgs], {stdio: `inherit`, shell: true});
 }
 
 export const noParse = true;

--- a/src/bin/esyCreate.js
+++ b/src/bin/esyCreate.js
@@ -1,0 +1,36 @@
+/**
+ * @flow
+ */
+
+import * as path from 'path';
+import * as fs from 'fs';
+import type {CommandContext, CommandInvocation} from './esy';
+import runYarnCommand from './runYarnCommand';
+import * as child from '@esy-ocaml/esy-install/src/util/child';
+
+export default async function esyCreate(
+  ctx: CommandContext,
+  invocation: CommandInvocation,
+) {
+  const [builderName = 'esy-project', ...rest] = invocation.args;
+
+  const packageName = builderName.replace(/^(@[^\/]+\/)?/, '$1create-');
+  const commandName = packageName.replace(/^@[^\/]+\//, '');
+
+  const globalFolder = path.join(ctx.prefixPath, 'install');
+
+  const addInvocation = {
+    commandName: 'global',
+    args: ['add', packageName, '--global-folder', globalFolder],
+    options: {options: {}, flags: {}},
+  };
+
+  await runYarnCommand(ctx, addInvocation, 'global');
+
+  const binFolder = path.resolve(globalFolder, 'node_modules', '.bin');
+  const command = path.resolve(binFolder, path.basename(commandName));
+
+  await child.spawn(command, [...rest], {stdio: `inherit`, shell: true});
+}
+
+export const noParse = true;


### PR DESCRIPTION
This is a WIP `esy create` command for #87.

In its current state, it can pull existing yarn starter packages and create projects. It duplicates yarn behaviour with one exception - we don't add starter packages to our global folder (instead, we use a custom global folder).

Running `esy init` will call `esy create esy-project` (and currently, fail at that), but for any other templates `init` and `create` can be used interchangeably. I.e `esy init react-app myreactapp` will work fine.

Next step is a working `create-esy-project` template for ocaml/reason projects.

CC: @jordwalke @andreypopp 