### PR TITLE
Refactor build locking

### DIFF
--- a/__tests__/build/__snapshots__/build-creates-symlinks-test.js.snap
+++ b/__tests__/build/__snapshots__/build-creates-symlinks-test.js.snap
@@ -8,11 +8,9 @@ RUNNING: esy build
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
-esy:bin trying to acquire lock
 esy:bin:esyBuild execute
 esy:build:dep@1.0.0 start building
 esy:build:dep@1.0.0 build success
-esy:bin trying to acquire lock
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:build-dependencies checking if dependencies are built
@@ -24,7 +22,6 @@ RUNNING: esy b dep
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
-esy:bin trying to acquire lock
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:build-dependencies checking if dependencies are built
@@ -32,7 +29,6 @@ RUNNING: esy x dep
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
-esy:bin trying to acquire lock
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:build-dependencies checking if dependencies are built
@@ -40,7 +36,6 @@ RUNNING: esy x creates-symlinks
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
-esy:bin trying to acquire lock
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:build-dependencies checking if dependencies are built"

--- a/__tests__/build/__snapshots__/build-custom-prefix-test.js.snap
+++ b/__tests__/build/__snapshots__/build-custom-prefix-test.js.snap
@@ -8,9 +8,7 @@ RUNNING: esy build
 esy:bin using <sandbox>/.esyrc
 esy:bin prefix: <testRoot>/project/store
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
-esy:bin trying to acquire lock
 esy:bin:esyBuild execute
-esy:bin trying to acquire lock
 esy:bin using <sandbox>/.esyrc
 esy:bin prefix: <testRoot>/project/store
 esy:build-dependencies checking if dependencies are built
@@ -18,7 +16,6 @@ RUNNING: esy x custom-prefix
 esy:bin using <sandbox>/.esyrc
 esy:bin prefix: <testRoot>/project/store
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
-esy:bin trying to acquire lock
 esy:bin using <sandbox>/.esyrc
 esy:bin prefix: <testRoot>/project/store
 esy:build-dependencies checking if dependencies are built"

--- a/__tests__/build/__snapshots__/build-errorneous-build-test.js.snap
+++ b/__tests__/build/__snapshots__/build-errorneous-build-test.js.snap
@@ -7,9 +7,7 @@ esy:bin prefix: <testRoot>/esy
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
-esy:bin trying to acquire lock
 esy:bin:esyBuild execute
-esy:bin trying to acquire lock
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:build-dependencies checking if dependencies are built"

--- a/__tests__/build/__snapshots__/build-import-archive-test.js.snap
+++ b/__tests__/build/__snapshots__/build-import-archive-test.js.snap
@@ -8,13 +8,11 @@ RUNNING: esy build
 esy:bin using <sandbox>/.esyrc
 esy:bin prefix: <testRoot>/esy
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
-esy:bin trying to acquire lock
 esy:bin:esyBuild execute
 esy:build:dep@1.0.0 start building
 esy:build:dep@1.0.0 testing for import: _export/dep-1.0.0
 esy:build:dep@1.0.0 testing for import: _export/dep-1.0.0.tar.gz
 esy:build:dep@1.0.0 build success
-esy:bin trying to acquire lock
 esy:bin using <sandbox>/.esyrc
 esy:bin prefix: <testRoot>/esy
 esy:build-dependencies checking if dependencies are built
@@ -31,7 +29,6 @@ RUNNING: esy build
 esy:bin using <sandbox>/.esyrc
 esy:bin prefix: <testRoot>/esy
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
-esy:bin trying to acquire lock
 esy:bin using <sandbox>/.esyrc
 esy:bin prefix: <testRoot>/esy
 esy:build-dependencies checking if dependencies are built

--- a/__tests__/build/__snapshots__/build-import-dir-test.js.snap
+++ b/__tests__/build/__snapshots__/build-import-dir-test.js.snap
@@ -8,13 +8,11 @@ RUNNING: esy build
 esy:bin using <sandbox>/.esyrc
 esy:bin prefix: <testRoot>/esy
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
-esy:bin trying to acquire lock
 esy:bin:esyBuild execute
 esy:build:dep@1.0.0 start building
 esy:build:dep@1.0.0 testing for import: _export/dep-1.0.0
 esy:build:dep@1.0.0 testing for import: _export/dep-1.0.0.tar.gz
 esy:build:dep@1.0.0 build success
-esy:bin trying to acquire lock
 esy:bin using <sandbox>/.esyrc
 esy:bin prefix: <testRoot>/esy
 esy:build-dependencies checking if dependencies are built
@@ -31,7 +29,6 @@ RUNNING: esy build
 esy:bin using <sandbox>/.esyrc
 esy:bin prefix: <testRoot>/esy
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
-esy:bin trying to acquire lock
 esy:bin using <sandbox>/.esyrc
 esy:bin prefix: <testRoot>/esy
 esy:build-dependencies checking if dependencies are built

--- a/__tests__/build/__snapshots__/build-no-deps-_build-test.js.snap
+++ b/__tests__/build/__snapshots__/build-no-deps-_build-test.js.snap
@@ -8,9 +8,7 @@ RUNNING: esy build
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
-esy:bin trying to acquire lock
 esy:bin:esyBuild execute
-esy:bin trying to acquire lock
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:build-dependencies checking if dependencies are built
@@ -20,7 +18,6 @@ RUNNING: esy x no-deps-_build
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
-esy:bin trying to acquire lock
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:build-dependencies checking if dependencies are built
@@ -28,7 +25,6 @@ RUNNING: esy x no-deps-_build
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
-esy:bin trying to acquire lock
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:build-dependencies checking if dependencies are built"

--- a/__tests__/build/__snapshots__/build-no-deps-in-source-test.js.snap
+++ b/__tests__/build/__snapshots__/build-no-deps-in-source-test.js.snap
@@ -8,9 +8,7 @@ RUNNING: esy build
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
-esy:bin trying to acquire lock
 esy:bin:esyBuild execute
-esy:bin trying to acquire lock
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:build-dependencies checking if dependencies are built
@@ -18,7 +16,6 @@ RUNNING: esy x no-deps-in-source
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
-esy:bin trying to acquire lock
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:build-dependencies checking if dependencies are built"

--- a/__tests__/build/__snapshots__/build-no-deps-test.js.snap
+++ b/__tests__/build/__snapshots__/build-no-deps-test.js.snap
@@ -8,9 +8,7 @@ RUNNING: esy build
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
-esy:bin trying to acquire lock
 esy:bin:esyBuild execute
-esy:bin trying to acquire lock
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:build-dependencies checking if dependencies are built
@@ -18,7 +16,6 @@ RUNNING: esy x no-deps
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
-esy:bin trying to acquire lock
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:build-dependencies checking if dependencies are built"

--- a/__tests__/build/__snapshots__/build-sandbox-stress-_build-test.js.snap
+++ b/__tests__/build/__snapshots__/build-sandbox-stress-_build-test.js.snap
@@ -8,9 +8,7 @@ RUNNING: esy build
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
-esy:bin trying to acquire lock
 esy:bin:esyBuild execute
-esy:bin trying to acquire lock
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:build-dependencies checking if dependencies are built
@@ -18,7 +16,6 @@ RUNNING: esy x echo ok
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
-esy:bin trying to acquire lock
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:build-dependencies checking if dependencies are built"

--- a/__tests__/build/__snapshots__/build-sandbox-stress-in-source-test.js.snap
+++ b/__tests__/build/__snapshots__/build-sandbox-stress-in-source-test.js.snap
@@ -8,9 +8,7 @@ RUNNING: esy build
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
-esy:bin trying to acquire lock
 esy:bin:esyBuild execute
-esy:bin trying to acquire lock
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:build-dependencies checking if dependencies are built
@@ -18,7 +16,6 @@ RUNNING: esy x echo ok
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
-esy:bin trying to acquire lock
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:build-dependencies checking if dependencies are built"

--- a/__tests__/build/__snapshots__/build-sandbox-stress-test.js.snap
+++ b/__tests__/build/__snapshots__/build-sandbox-stress-test.js.snap
@@ -8,9 +8,7 @@ RUNNING: esy build
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
-esy:bin trying to acquire lock
 esy:bin:esyBuild execute
-esy:bin trying to acquire lock
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:build-dependencies checking if dependencies are built
@@ -18,7 +16,6 @@ RUNNING: esy x echo ok
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
-esy:bin trying to acquire lock
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:build-dependencies checking if dependencies are built"

--- a/__tests__/build/__snapshots__/build-with-dep-_build-test.js.snap
+++ b/__tests__/build/__snapshots__/build-with-dep-_build-test.js.snap
@@ -8,11 +8,9 @@ RUNNING: esy build
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
-esy:bin trying to acquire lock
 esy:bin:esyBuild execute
 esy:build:dep@1.0.0 start building
 esy:build:dep@1.0.0 build success
-esy:bin trying to acquire lock
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:build-dependencies checking if dependencies are built
@@ -24,7 +22,6 @@ RUNNING: esy b dep
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
-esy:bin trying to acquire lock
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:build-dependencies checking if dependencies are built
@@ -32,7 +29,6 @@ RUNNING: esy x dep
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
-esy:bin trying to acquire lock
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:build-dependencies checking if dependencies are built
@@ -40,7 +36,6 @@ RUNNING: esy x with-dep-_build
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
-esy:bin trying to acquire lock
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:build-dependencies checking if dependencies are built"

--- a/__tests__/build/__snapshots__/build-with-dep-in-source-test.js.snap
+++ b/__tests__/build/__snapshots__/build-with-dep-in-source-test.js.snap
@@ -8,11 +8,9 @@ RUNNING: esy build
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
-esy:bin trying to acquire lock
 esy:bin:esyBuild execute
 esy:build:dep@1.0.0 start building
 esy:build:dep@1.0.0 build success
-esy:bin trying to acquire lock
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:build-dependencies checking if dependencies are built
@@ -24,7 +22,6 @@ RUNNING: esy b dep
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
-esy:bin trying to acquire lock
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:build-dependencies checking if dependencies are built
@@ -32,7 +29,6 @@ RUNNING: esy x dep
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
-esy:bin trying to acquire lock
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:build-dependencies checking if dependencies are built
@@ -40,7 +36,6 @@ RUNNING: esy x with-dep-in-source
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
-esy:bin trying to acquire lock
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:build-dependencies checking if dependencies are built"

--- a/__tests__/build/__snapshots__/build-with-dep-test.js.snap
+++ b/__tests__/build/__snapshots__/build-with-dep-test.js.snap
@@ -8,11 +8,9 @@ RUNNING: esy build
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
-esy:bin trying to acquire lock
 esy:bin:esyBuild execute
 esy:build:dep@1.0.0 start building
 esy:build:dep@1.0.0 build success
-esy:bin trying to acquire lock
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:build-dependencies checking if dependencies are built
@@ -24,7 +22,6 @@ RUNNING: esy b dep
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
-esy:bin trying to acquire lock
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:build-dependencies checking if dependencies are built
@@ -32,7 +29,6 @@ RUNNING: esy x dep
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
-esy:bin trying to acquire lock
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:build-dependencies checking if dependencies are built
@@ -40,7 +36,6 @@ RUNNING: esy x with-dep
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
-esy:bin trying to acquire lock
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:build-dependencies checking if dependencies are built"

--- a/__tests__/build/__snapshots__/build-with-dev-dep-test.js.snap
+++ b/__tests__/build/__snapshots__/build-with-dev-dep-test.js.snap
@@ -8,13 +8,11 @@ RUNNING: esy build
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
-esy:bin trying to acquire lock
 esy:bin:esyBuild execute
 esy:build:dep@1.0.0 start building
 esy:build:dev-dep@1.0.0 start building
-esy:build:dep@1.0.0 build success
 esy:build:dev-dep@1.0.0 build success
-esy:bin trying to acquire lock
+esy:build:dep@1.0.0 build success
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:build-dependencies checking if dependencies are built
@@ -26,7 +24,6 @@ RUNNING: esy b dep
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
-esy:bin trying to acquire lock
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:build-dependencies checking if dependencies are built
@@ -34,7 +31,6 @@ RUNNING: esy x dep
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
-esy:bin trying to acquire lock
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:build-dependencies checking if dependencies are built
@@ -45,14 +41,12 @@ esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
-esy:bin trying to acquire lock
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:build-dependencies checking if dependencies are built
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
-esy:bin trying to acquire lock
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:build-dependencies checking if dependencies are built
@@ -60,7 +54,6 @@ RUNNING: esy x with-dev-dep
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
-esy:bin trying to acquire lock
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:build-dependencies checking if dependencies are built"

--- a/__tests__/build/__snapshots__/build-with-linked-dep-_build-test.js.snap
+++ b/__tests__/build/__snapshots__/build-with-linked-dep-_build-test.js.snap
@@ -8,11 +8,9 @@ RUNNING: esy build
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
-esy:bin trying to acquire lock
 esy:bin:esyBuild execute
 esy:build:dep@1.0.0 start building
 esy:build:dep@1.0.0 build success
-esy:bin trying to acquire lock
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:build-dependencies checking if dependencies are built
@@ -24,7 +22,6 @@ RUNNING: esy b dep
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
-esy:bin trying to acquire lock
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:build-dependencies checking if dependencies are built
@@ -32,7 +29,6 @@ RUNNING: esy x dep
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
-esy:bin trying to acquire lock
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:build-dependencies checking if dependencies are built
@@ -40,7 +36,6 @@ RUNNING: esy x with-linked-dep-_build
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
-esy:bin trying to acquire lock
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:build-dependencies checking if dependencies are built"

--- a/__tests__/build/__snapshots__/build-with-linked-dep-in-source-test.js.snap
+++ b/__tests__/build/__snapshots__/build-with-linked-dep-in-source-test.js.snap
@@ -8,11 +8,9 @@ RUNNING: esy build
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
-esy:bin trying to acquire lock
 esy:bin:esyBuild execute
 esy:build:dep@1.0.0 start building
 esy:build:dep@1.0.0 build success
-esy:bin trying to acquire lock
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:build-dependencies checking if dependencies are built
@@ -24,7 +22,6 @@ RUNNING: esy b dep
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
-esy:bin trying to acquire lock
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:build-dependencies checking if dependencies are built
@@ -32,7 +29,6 @@ RUNNING: esy x dep
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
-esy:bin trying to acquire lock
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:build-dependencies checking if dependencies are built
@@ -40,7 +36,6 @@ RUNNING: esy x with-linked-dep-in-source
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
-esy:bin trying to acquire lock
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:build-dependencies checking if dependencies are built"

--- a/__tests__/build/__snapshots__/build-with-linked-dep-test.js.snap
+++ b/__tests__/build/__snapshots__/build-with-linked-dep-test.js.snap
@@ -8,11 +8,9 @@ RUNNING: esy build
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
-esy:bin trying to acquire lock
 esy:bin:esyBuild execute
 esy:build:dep@1.0.0 start building
 esy:build:dep@1.0.0 build success
-esy:bin trying to acquire lock
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:build-dependencies checking if dependencies are built
@@ -24,7 +22,6 @@ RUNNING: esy b dep
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
-esy:bin trying to acquire lock
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:build-dependencies checking if dependencies are built
@@ -32,7 +29,6 @@ RUNNING: esy x dep
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
-esy:bin trying to acquire lock
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:build-dependencies checking if dependencies are built
@@ -40,7 +36,6 @@ RUNNING: esy x with-linked-dep
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
-esy:bin trying to acquire lock
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:build-dependencies checking if dependencies are built
@@ -49,7 +44,6 @@ RUNNING: esy build
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
-esy:bin trying to acquire lock
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:build-dependencies checking if dependencies are built
@@ -58,7 +52,6 @@ RUNNING: esy build
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
-esy:bin trying to acquire lock
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:build-dependencies checking if dependencies are built"

--- a/__tests__/export-import-build/__snapshots__/export-import-from-list-test.js.snap
+++ b/__tests__/export-import-build/__snapshots__/export-import-from-list-test.js.snap
@@ -8,13 +8,11 @@ RUNNING: esy build
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
-esy:bin trying to acquire lock
 esy:bin:esyBuild execute
 esy:build:subdep@1.0.0 start building
 esy:build:subdep@1.0.0 build success
 esy:build:dep@1.0.0 start building
 esy:build:dep@1.0.0 build success
-esy:bin trying to acquire lock
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:build-dependencies checking if dependencies are built

--- a/__tests__/export-import-build/__snapshots__/export-import-symlinks-into-dep-test.js.snap
+++ b/__tests__/export-import-build/__snapshots__/export-import-symlinks-into-dep-test.js.snap
@@ -8,13 +8,11 @@ RUNNING: esy build
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
-esy:bin trying to acquire lock
 esy:bin:esyBuild execute
 esy:build:subdep@1.0.0 start building
 esy:build:subdep@1.0.0 build success
 esy:build:dep@1.0.0 start building
 esy:build:dep@1.0.0 build success
-esy:bin trying to acquire lock
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:build-dependencies checking if dependencies are built
@@ -26,7 +24,6 @@ RUNNING: esy b subdep
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
-esy:bin trying to acquire lock
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:build-dependencies checking if dependencies are built
@@ -34,7 +31,6 @@ RUNNING: esy x subdep
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
-esy:bin trying to acquire lock
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:build-dependencies checking if dependencies are built
@@ -46,7 +42,6 @@ RUNNING: esy b dep
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
-esy:bin trying to acquire lock
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:build-dependencies checking if dependencies are built
@@ -54,7 +49,6 @@ RUNNING: esy x dep
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
-esy:bin trying to acquire lock
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:build-dependencies checking if dependencies are built
@@ -62,7 +56,6 @@ RUNNING: esy x symlinks-into-dep
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:bin needRebuildTarget <sandbox>/node_modules/.cache/_esy/build/bin/build
-esy:bin trying to acquire lock
 esy:bin no .esyrc found
 esy:bin prefix: <testRoot>/esy
 esy:build-dependencies checking if dependencies are built

--- a/bin/esy
+++ b/bin/esy
@@ -19,7 +19,6 @@ source "$SCRIPTDIR/esyConfig.sh"
 source "$SCRIPTDIR/esyRuntime.sh"
 
 mkdir -p "$ESY__PREFIX"
-ESY__LOCK="$ESY__PREFIX/lock"
 
 BUILD_EJECT_PATH="$ESY__SANDBOX/node_modules/.cache/_esy/build"
 
@@ -96,31 +95,12 @@ run () {
   fi
 }
 
-withLock () {
-  if [ -z "${ESY__LOCKED+x}" ]; then
-    esyLog "esy:bin" "trying to acquire lock"
-    local command="$@"
-    set +e
-    # we do || exit 2 to distinguish between $command failure and flock failure
-    ESY__LOCKED="$ESY__LOCK" "$FLOCK_COMMAND" -n "$ESY__LOCK" bash -c "$command || exit 2"
-    retCode="$?"
-    set -e
-    if [ $retCode -eq 1 ]; then
-      esyError "another esy process is running ($ESY__LOCK exists), exiting..."
-    elif [ $retCode -ne 0 ]; then
-      exit 1
-    fi
-  else
-    "$@"
-  fi
-}
-
 callBuiltInCommand__build () {
   ensureBuildEjected
   if [ $# -eq 0 ]; then
-    withLock "$BUILD_EJECT_PATH/bin/build"
+    "$BUILD_EJECT_PATH/bin/build"
   else
-    withLock "$BUILD_EJECT_PATH/bin/build-exec" "$@"
+    "$BUILD_EJECT_PATH/bin/build-exec" "$@"
   fi
 }
 
@@ -128,12 +108,12 @@ callBuiltInCommand__buildShell () {
   local buildJson
   buildJson=$(mktemp)
   node "$SCRIPTDIR/esy.js" build-plan "$@" > "$buildJson"
-  run withLock "$OCAMLRUN_COMMAND" "$ESY_BUILD_PACKAGE_COMMAND" shell -B "$buildJson"
+  run "$OCAMLRUN_COMMAND" "$ESY_BUILD_PACKAGE_COMMAND" shell -B "$buildJson"
 }
 
 callBuiltInCommand__x () {
   ensureBuildEjected --silent
-  run --suppressOutput withLock "$BUILD_EJECT_PATH/bin/install"
+  run --suppressOutput "$BUILD_EJECT_PATH/bin/install"
   source "$BUILD_EJECT_PATH/bin/sandbox-env"
   shift
   # Checks if command ($1) is present available
@@ -154,7 +134,7 @@ ensureBuildEjected () {
       esyArgs="$esyArgs --silent"
       shift
     fi
-    run withLock node "$SCRIPTDIR/esy.js" "$esyArgs" build \
+    run node "$SCRIPTDIR/esy.js" "$esyArgs" build \
       --dependencies-only \
       --eject "$BUILD_EJECT_PATH" "$@"
   fi
@@ -165,7 +145,7 @@ callBuiltInCommand() {
 }
 
 callBuiltInCommandWithLock() {
-	withLock node "$SCRIPTDIR/esy.js" "$@"
+	node "$SCRIPTDIR/esy.js" "$@"
 }
 
 printHelp() {

--- a/esy-build-package/lib/BuildSpec.re
+++ b/esy-build-package/lib/BuildSpec.re
@@ -73,6 +73,7 @@ type t = {
   installPath: Path.t,
   buildPath: Path.t,
   infoPath: Path.t,
+  lockPath: Path.t,
   env: Env.t
 };
 
@@ -142,6 +143,8 @@ module ConfigFile = {
       buildPath: Path.(storePath / Config.storeBuildTree / specConfig.id),
       infoPath:
         Path.(storePath / Config.storeBuildTree / (specConfig.id ++ ".info")),
+      lockPath:
+        Path.(storePath / Config.storeBuildTree / (specConfig.id ++ ".lock")),
       sourcePath,
       env,
       install,

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
   "dependencies": {
     "@esy-ocaml/esy-install": "link:./esy-install",
     "@esy-ocaml/esy-opam": "0.0.12",
-    "@esy-ocaml/flock": "0.2.3001",
     "@esy-ocaml/ocamlrun": "^4.6.2",
     "babel-polyfill": "^6.23.0",
     "cli-argparse": "^1.1.2",

--- a/scripts/generate-esy-install-package-json.js
+++ b/scripts/generate-esy-install-package-json.js
@@ -13,7 +13,6 @@ const releasePackageJson = {
   description: packageJson.description,
   dependencies: {
     '@esy-ocaml/esy-opam': packageJson.dependencies['@esy-ocaml/esy-opam'],
-    '@esy-ocaml/flock': packageJson.dependencies['@esy-ocaml/flock'],
     '@esy-ocaml/ocamlrun': packageJson.dependencies['@esy-ocaml/ocamlrun'],
     fastreplacestring: packageJson.dependencies['fastreplacestring'],
   },

--- a/src/bin/esyAutoconf.js
+++ b/src/bin/esyAutoconf.js
@@ -23,7 +23,6 @@ export default async function esyAutoconf(ctx: CommandContext) {
     export OCAMLRUN_COMMAND="${config.OCAMLRUN_COMMAND}"
     export ESY_BUILD_PACKAGE_COMMAND="${config.ESY_BUILD_PACKAGE_COMMAND}"
     export FASTREPLACESTRING_COMMAND="${config.FASTREPLACESTRING_COMMAND}"
-    export FLOCK_COMMAND="${config.FLOCK_COMMAND}"
   `);
 }
 

--- a/src/config.js
+++ b/src/config.js
@@ -19,7 +19,6 @@ export const OCAMLRUN_COMMAND = resolve('@esy-ocaml/ocamlrun/install/bin/ocamlru
 export const ESY_BUILD_PACKAGE_COMMAND = resolve('../bin/esyBuildPackage', {
   basedir: __dirname,
 });
-export const FLOCK_COMMAND = resolve('@esy-ocaml/flock/flock', {basedir: __dirname});
 export const FASTREPLACESTRING_COMMAND = resolve(
   'fastreplacestring/.bin/fastreplacestring.exe',
   {basedir: __dirname},

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,10 +10,6 @@
   version "0.0.12"
   resolved "https://registry.yarnpkg.com/@esy-ocaml/esy-opam/-/esy-opam-0.0.12.tgz#7eab51e8c9f1cbfec748935e3c178a83c31450cc"
 
-"@esy-ocaml/flock@0.2.3001":
-  version "0.2.3001"
-  resolved "https://registry.yarnpkg.com/@esy-ocaml/flock/-/flock-0.2.3001.tgz#94b796a8a51c06ef0ebb0a12ff0096f35de6d29c"
-
 "@esy-ocaml/ocamlrun@^4.6.2":
   version "4.6.3"
   resolved "https://registry.yarnpkg.com/@esy-ocaml/ocamlrun/-/ocamlrun-4.6.3.tgz#36caccd8f312f607a7f411bc2c7d76de52c40e58"


### PR DESCRIPTION
* More granular locking per transient/root build and not on entire sandbox as before
* Lock in `esy-build-package` command in OCaml code so we don't require `@esy-ocaml/flock` C package which we used before.
* Lock using `lockf`