### PR TITLE
Preserve exit code for "esy <cmd>" and similar invocations

### DIFF
--- a/__tests__/common/anycmd-test.sh
+++ b/__tests__/common/anycmd-test.sh
@@ -6,9 +6,23 @@ doTest() {
   run esy build
 
   expectStdout "dep" esy dep
-  expectStdout "dev-dep" esy x dev-dep
+  expectStdout "dev-dep" esy dev-dep
 
   # Make sure we can pass environment from the outside dynamically.
-  X=1 expectStdout "1" esy x bash -c 'echo $X'
-  X=2 expectStdout "2" esy x bash -c 'echo $X'
+  X=1 expectStdout "1" esy bash -c 'echo $X'
+  X=2 expectStdout "2" esy bash -c 'echo $X'
+
+  checkExitCode () {
+    set +e
+    "$@"
+    local ret="$?"
+    set -e
+    echo "$ret"
+  }
+  export -f checkExitCode
+
+  # Make sure exit code is preserved
+  expectStdout "1" checkExitCode esy bash -c 'exit 1'
+  expectStdout "7" checkExitCode esy bash -c 'exit 7'
+
 }

--- a/__tests__/common/build-anycmd-test.sh
+++ b/__tests__/common/build-anycmd-test.sh
@@ -6,4 +6,18 @@ doTest() {
   run esy build
   expectStdout "dep" esy build dep
   expectStdout "dep" esy b dep
+
+  checkExitCode () {
+    set +e
+    "$@"
+    local ret="$?"
+    set -e
+    echo "$ret"
+  }
+  export -f checkExitCode
+
+  # Make sure exit code is preserved
+  expectStdout "1" checkExitCode esy b bash -c 'exit 1'
+  expectStdout "7" checkExitCode esy b bash -c 'exit 7'
+
 }

--- a/__tests__/common/x-anycmd-test.sh
+++ b/__tests__/common/x-anycmd-test.sh
@@ -10,5 +10,18 @@ doTest() {
   # Make sure we can pass environment from the outside dynamically.
   X=1 expectStdout "1" esy x bash -c 'echo $X'
   X=2 expectStdout "2" esy x bash -c 'echo $X'
+
+  checkExitCode () {
+    set +e
+    "$@"
+    local ret="$?"
+    set -e
+    echo "$ret"
+  }
+  export -f checkExitCode
+
+  # Make sure exit code is preserved
+  expectStdout "1" checkExitCode esy x bash -c 'exit 1'
+  expectStdout "7" checkExitCode esy x bash -c 'exit 7'
 }
 

--- a/esy-core/esy-build-package/BuildTask.re
+++ b/esy-core/esy-build-package/BuildTask.re
@@ -125,7 +125,9 @@ module ConfigFile = {
     let render = s => PathSyntax.render(lookupVar, s);
     let renderPath = s => {
       let%bind s = PathSyntax.render(lookupVar, s);
-      Path.of_string(s);
+      (
+        Path.of_string(s): result(Path.t, [ | `Msg(string)]) :> Run.t(Path.t, _)
+      );
     };
     let renderEnv = env => {
       let f = (k, v) =>
@@ -173,7 +175,7 @@ module ConfigFile = {
   };
 };
 
-let ofFile = (config: Config.t, path: Path.t) =>
+let ofFile = (config: Config.t, path: Path.t) : Run.t(t, _) =>
   Run.(
     {
       let%bind data = Bos.OS.File.read(path);

--- a/esy-core/esy-build-package/Builder.re
+++ b/esy-core/esy-build-package/Builder.re
@@ -246,15 +246,25 @@ let withBuildEnvUnlocked =
     };
   let run = cmd => {
     let%bind cmd = Cmd.resolveInvocation(path, cmd);
-    Bos.OS.Cmd.(
-      in_null |> exec(~err=Bos.OS.Cmd.err_run_out, ~env, cmd) |> to_stdout
-    );
+    let%bind ((), (_runInfo, runStatus)) =
+      Bos.OS.Cmd.(
+        in_null |> exec(~err=Bos.OS.Cmd.err_run_out, ~env, cmd) |> out_stdout
+      );
+    switch runStatus {
+    | `Exited(0) => Ok()
+    | status => Error(`CommandError((cmd, status)))
+    };
   };
   let runInteractive = cmd => {
     let%bind cmd = Cmd.resolveInvocation(path, cmd);
-    Bos.OS.Cmd.(
-      in_stdin |> exec(~err=Bos.OS.Cmd.err_stderr, ~env, cmd) |> to_stdout
-    );
+    let%bind ((), (_runInfo, runStatus)) =
+      Bos.OS.Cmd.(
+        in_stdin |> exec(~err=Bos.OS.Cmd.err_stderr, ~env, cmd) |> out_stdout
+      );
+    switch runStatus {
+    | `Exited(0) => Ok()
+    | status => Error(`CommandError((cmd, status)))
+    };
   };
   /*
    * Prepare build/install.

--- a/esy-core/esy-build-package/Run.re
+++ b/esy-core/esy-build-package/Run.re
@@ -3,7 +3,13 @@ open Std;
 /**
  * This module implements utilities which are used to "script" build processes.
  */
-type t('a, 'b) = result('a, [> Rresult.R.msg] as 'b);
+type t('a, 'b) =
+  result(
+    'a,
+    [> | `Msg(string) | `CommandError(Bos.Cmd.t, Bos.OS.Cmd.status)] as 'b
+  );
+
+let coerceFrmMsgOnly = x => (x: result(_, [ | `Msg(string)]) :> t(_, _));
 
 let ok = Result.ok;
 

--- a/esy-core/esy/ChildProcess.ml
+++ b/esy-core/esy/ChildProcess.ml
@@ -62,6 +62,14 @@ let run ?env ?resolveProgramInEnv ?stdin ?stdout ?stderr cmd =
   in
   withProcess ?env ?resolveProgramInEnv ?stdin ?stdout ?stderr cmd f
 
+let runToStatus ?env ?resolveProgramInEnv ?stdin ?stdout ?stderr cmd =
+  let open RunAsync.Syntax in
+  let f process =
+    let%lwt status = process#status in
+    return status
+  in
+  withProcess ?env ?resolveProgramInEnv ?stdin ?stdout ?stderr cmd f
+
 let runOut ?(env=`CurrentEnv) ?(resolveProgramInEnv=false) ?stdin ?stderr cmd =
   let open RunAsync.Syntax in
 

--- a/esy-core/esy/ChildProcess.mli
+++ b/esy-core/esy/ChildProcess.mli
@@ -25,6 +25,15 @@ val runOut :
   -> Cmd.t
   -> string RunAsync.t
 
+val runToStatus :
+  ?env:env
+  -> ?resolveProgramInEnv:bool
+  -> ?stdin:Lwt_process.redirection
+  -> ?stdout:Lwt_process.redirection
+  -> ?stderr:Lwt_process.redirection
+  -> Cmd.t
+  -> Unix.process_status RunAsync.t
+
 val withProcess :
   ?env:env
   -> ?resolveProgramInEnv:bool

--- a/esy-core/esy/PackageBuilder.mli
+++ b/esy-core/esy/PackageBuilder.mli
@@ -1,6 +1,5 @@
 (**
- * This module describes methods which are performed on build tasks through
- * "esy-build-package" package builder executable.
+ * This module describes methods which are performed on build tasks through * "esy-build-package" package builder executable.
  *)
 
 (**
@@ -21,7 +20,7 @@ val build :
 val buildShell :
   Config.t
   -> BuildTask.t
-  -> unit RunAsync.t
+  -> Unix.process_status RunAsync.t
 
 (*
  * Execute a command inside build environment of the task.
@@ -30,4 +29,4 @@ val buildExec :
   Config.t
   -> BuildTask.t
   -> string list
-  -> unit RunAsync.t
+  -> Unix.process_status RunAsync.t

--- a/esy-core/esy/bin/esyCommand.ml
+++ b/esy-core/esy/bin/esyCommand.ml
@@ -431,13 +431,17 @@ let makeExecCommand
       Ok (`CustomEnv env)
     ) in
 
-  ChildProcess.run
+  let%bind status = ChildProcess.runToStatus
     ~env
     ~resolveProgramInEnv:true
     ~stderr:(`FD_copy Unix.stderr)
     ~stdout:(`FD_copy Unix.stdout)
     ~stdin:(`FD_copy Unix.stdin)
     (Cmd.ofList command)
+  in match status with
+  | Unix.WEXITED n
+  | Unix.WSTOPPED n
+  | Unix.WSIGNALED n -> exit n
 
 let exec cfgRes =
   let open RunAsync.Syntax in

--- a/esy-core/esy/bin/esyCommand.ml
+++ b/esy-core/esy/bin/esyCommand.ml
@@ -309,7 +309,11 @@ let buildShell cfg packagePath =
 
   let f task =
     let%bind () = Build.buildDependencies ~concurrency cfg task in
-    PackageBuilder.buildShell cfg task
+    match%bind PackageBuilder.buildShell cfg task with
+    | Unix.WEXITED 0 -> return ()
+    | Unix.WEXITED n
+    | Unix.WSTOPPED n
+    | Unix.WSIGNALED n -> exit n
   in withBuildTaskByPath ~cfg ~info packagePath f
 
 let buildPackage cfg packagePath =
@@ -340,7 +344,11 @@ let build ?(buildOnly=true) cfg command =
 
   | command ->
     let%bind () = Build.buildDependencies ~concurrency cfg task in
-    PackageBuilder.buildExec cfg task command
+    match%bind PackageBuilder.buildExec cfg task command with
+    | Unix.WEXITED 0 -> return ()
+    | Unix.WEXITED n
+    | Unix.WSTOPPED n
+    | Unix.WSIGNALED n -> exit n
 
 let makeEnvCommand ~computeEnv ~header cfg asJson packagePath =
   let open RunAsync.Syntax in


### PR DESCRIPTION
- [x] `esy <cmd>`
- [x] `esy x <cmd>`
- [x] `esy b <cmd>`