### PR TITLE
Fixed `build-plan` and `build-shell` commands for linked packages

### DIFF
--- a/esy-core/esy/Sandbox.re
+++ b/esy-core/esy/Sandbox.re
@@ -168,7 +168,7 @@ let ofDir = (cfg: Config.t) => {
         let esy =
           Std.Option.orDefault(Package.EsyManifest.empty, manifest.esy);
         Package.{
-          id: Path.to_string(sourcePath),
+          id: Path.to_string(path),
           name: manifest.name,
           version: manifest.version,
           dependencies,


### PR DESCRIPTION
This PR fixes commands like `esy build-plan <path>` and `esy build-shell <path>` when the path is a linked package.

Esy used to fail because it compared `%project/node_modules/package_name` path  with actual `/linked/package_name/source/path`, now it compares the path to package id - which should be the same. I had to fix `Sandbox` as well, it used to set id to the actual source path.