### PR TITLE
Skip non-esy packages when crawling sandbox

### DIFF
--- a/esy-build-package.install
+++ b/esy-build-package.install
@@ -1,52 +1,53 @@
 lib: [
   "_build/install/default/lib/esy-build-package/META" {"META"}
   "_build/install/default/lib/esy-build-package/opam" {"opam"}
-  "_build/install/default/lib/esy-build-package/EsyBuildPackage__BuildInfo.cmi"
-  "_build/install/default/lib/esy-build-package/EsyBuildPackage__BuildInfo.cmt"
-  "_build/install/default/lib/esy-build-package/BuildInfo.re"
-  "_build/install/default/lib/esy-build-package/EsyBuildPackage__BuildTask.cmi"
-  "_build/install/default/lib/esy-build-package/EsyBuildPackage__BuildTask.cmt"
-  "_build/install/default/lib/esy-build-package/BuildTask.re"
-  "_build/install/default/lib/esy-build-package/EsyBuildPackage__Builder.cmi"
-  "_build/install/default/lib/esy-build-package/EsyBuildPackage__Builder.cmt"
-  "_build/install/default/lib/esy-build-package/Builder.re"
-  "_build/install/default/lib/esy-build-package/EsyBuildPackage__Cmd.cmi"
-  "_build/install/default/lib/esy-build-package/EsyBuildPackage__Cmd.cmt"
-  "_build/install/default/lib/esy-build-package/Cmd.re"
-  "_build/install/default/lib/esy-build-package/EsyBuildPackage__Config.cmi"
-  "_build/install/default/lib/esy-build-package/EsyBuildPackage__Config.cmt"
-  "_build/install/default/lib/esy-build-package/Config.re"
-  "_build/install/default/lib/esy-build-package/EsyBuildPackage.cmi"
-  "_build/install/default/lib/esy-build-package/EsyBuildPackage.cmt"
-  "_build/install/default/lib/esy-build-package/EsyBuildPackage.ml-gen"
-  "_build/install/default/lib/esy-build-package/EsyBuildPackage__Json.cmi"
-  "_build/install/default/lib/esy-build-package/EsyBuildPackage__Json.cmt"
-  "_build/install/default/lib/esy-build-package/Json.re"
-  "_build/install/default/lib/esy-build-package/EsyBuildPackage__NodeResolution.cmi"
-  "_build/install/default/lib/esy-build-package/EsyBuildPackage__NodeResolution.cmt"
-  "_build/install/default/lib/esy-build-package/NodeResolution.re"
-  "_build/install/default/lib/esy-build-package/EsyBuildPackage__Path.cmi"
-  "_build/install/default/lib/esy-build-package/EsyBuildPackage__Path.cmt"
-  "_build/install/default/lib/esy-build-package/Path.re"
-  "_build/install/default/lib/esy-build-package/EsyBuildPackage__PathSyntax.cmi"
-  "_build/install/default/lib/esy-build-package/EsyBuildPackage__PathSyntax.cmt"
-  "_build/install/default/lib/esy-build-package/PathSyntax.re"
-  "_build/install/default/lib/esy-build-package/EsyBuildPackage__Run.cmi"
-  "_build/install/default/lib/esy-build-package/EsyBuildPackage__Run.cmt"
-  "_build/install/default/lib/esy-build-package/Run.re"
-  "_build/install/default/lib/esy-build-package/EsyBuildPackage__Sandbox.cmi"
-  "_build/install/default/lib/esy-build-package/EsyBuildPackage__Sandbox.cmt"
-  "_build/install/default/lib/esy-build-package/Sandbox.re"
-  "_build/install/default/lib/esy-build-package/EsyBuildPackage__Sexp.cmi"
-  "_build/install/default/lib/esy-build-package/EsyBuildPackage__Sexp.cmt"
-  "_build/install/default/lib/esy-build-package/Sexp.re"
-  "_build/install/default/lib/esy-build-package/EsyBuildPackage__Std.cmi"
-  "_build/install/default/lib/esy-build-package/EsyBuildPackage__Std.cmt"
-  "_build/install/default/lib/esy-build-package/Std.re"
-  "_build/install/default/lib/esy-build-package/EsyBuildPackage__Store.cmi"
-  "_build/install/default/lib/esy-build-package/EsyBuildPackage__Store.cmt"
-  "_build/install/default/lib/esy-build-package/Store.re"
-  "_build/install/default/lib/esy-build-package/EsyBuildPackage.cma"
+  "_build/install/default/lib/esy-build-package/EsyBuildPackage__BuildInfo.cmi" {"EsyBuildPackage__BuildInfo.cmi"}
+  "_build/install/default/lib/esy-build-package/EsyBuildPackage__BuildInfo.cmt" {"EsyBuildPackage__BuildInfo.cmt"}
+  "_build/install/default/lib/esy-build-package/BuildInfo.re" {"BuildInfo.re"}
+  "_build/install/default/lib/esy-build-package/EsyBuildPackage__BuildTask.cmi" {"EsyBuildPackage__BuildTask.cmi"}
+  "_build/install/default/lib/esy-build-package/EsyBuildPackage__BuildTask.cmt" {"EsyBuildPackage__BuildTask.cmt"}
+  "_build/install/default/lib/esy-build-package/BuildTask.re" {"BuildTask.re"}
+  "_build/install/default/lib/esy-build-package/EsyBuildPackage__Builder.cmi" {"EsyBuildPackage__Builder.cmi"}
+  "_build/install/default/lib/esy-build-package/EsyBuildPackage__Builder.cmt" {"EsyBuildPackage__Builder.cmt"}
+  "_build/install/default/lib/esy-build-package/Builder.re" {"Builder.re"}
+  "_build/install/default/lib/esy-build-package/EsyBuildPackage__Cmd.cmi" {"EsyBuildPackage__Cmd.cmi"}
+  "_build/install/default/lib/esy-build-package/EsyBuildPackage__Cmd.cmt" {"EsyBuildPackage__Cmd.cmt"}
+  "_build/install/default/lib/esy-build-package/Cmd.re" {"Cmd.re"}
+  "_build/install/default/lib/esy-build-package/EsyBuildPackage__Config.cmi" {"EsyBuildPackage__Config.cmi"}
+  "_build/install/default/lib/esy-build-package/EsyBuildPackage__Config.cmt" {"EsyBuildPackage__Config.cmt"}
+  "_build/install/default/lib/esy-build-package/Config.re" {"Config.re"}
+  "_build/install/default/lib/esy-build-package/EsyBuildPackage.cmi" {"EsyBuildPackage.cmi"}
+  "_build/install/default/lib/esy-build-package/EsyBuildPackage.cmt" {"EsyBuildPackage.cmt"}
+  "_build/install/default/lib/esy-build-package/EsyBuildPackage.ml-gen" {"EsyBuildPackage.ml-gen"}
+  "_build/install/default/lib/esy-build-package/EsyBuildPackage__Json.cmi" {"EsyBuildPackage__Json.cmi"}
+  "_build/install/default/lib/esy-build-package/EsyBuildPackage__Json.cmt" {"EsyBuildPackage__Json.cmt"}
+  "_build/install/default/lib/esy-build-package/Json.re" {"Json.re"}
+  "_build/install/default/lib/esy-build-package/EsyBuildPackage__NodeResolution.cmi" {"EsyBuildPackage__NodeResolution.cmi"}
+  "_build/install/default/lib/esy-build-package/EsyBuildPackage__NodeResolution.cmt" {"EsyBuildPackage__NodeResolution.cmt"}
+  "_build/install/default/lib/esy-build-package/NodeResolution.re" {"NodeResolution.re"}
+  "_build/install/default/lib/esy-build-package/EsyBuildPackage__Path.cmi" {"EsyBuildPackage__Path.cmi"}
+  "_build/install/default/lib/esy-build-package/EsyBuildPackage__Path.cmt" {"EsyBuildPackage__Path.cmt"}
+  "_build/install/default/lib/esy-build-package/Path.re" {"Path.re"}
+  "_build/install/default/lib/esy-build-package/EsyBuildPackage__PathSyntax.cmi" {"EsyBuildPackage__PathSyntax.cmi"}
+  "_build/install/default/lib/esy-build-package/EsyBuildPackage__PathSyntax.cmt" {"EsyBuildPackage__PathSyntax.cmt"}
+  "_build/install/default/lib/esy-build-package/PathSyntax.re" {"PathSyntax.re"}
+  "_build/install/default/lib/esy-build-package/EsyBuildPackage__Run.cmi" {"EsyBuildPackage__Run.cmi"}
+  "_build/install/default/lib/esy-build-package/EsyBuildPackage__Run.cmt" {"EsyBuildPackage__Run.cmt"}
+  "_build/install/default/lib/esy-build-package/Run.re" {"Run.re"}
+  "_build/install/default/lib/esy-build-package/EsyBuildPackage__Sandbox.cmi" {"EsyBuildPackage__Sandbox.cmi"}
+  "_build/install/default/lib/esy-build-package/EsyBuildPackage__Sandbox.cmt" {"EsyBuildPackage__Sandbox.cmt"}
+  "_build/install/default/lib/esy-build-package/Sandbox.re" {"Sandbox.re"}
+  "_build/install/default/lib/esy-build-package/EsyBuildPackage__Sexp.cmi" {"EsyBuildPackage__Sexp.cmi"}
+  "_build/install/default/lib/esy-build-package/EsyBuildPackage__Sexp.cmt" {"EsyBuildPackage__Sexp.cmt"}
+  "_build/install/default/lib/esy-build-package/Sexp.re" {"Sexp.re"}
+  "_build/install/default/lib/esy-build-package/EsyBuildPackage__Std.cmi" {"EsyBuildPackage__Std.cmi"}
+  "_build/install/default/lib/esy-build-package/EsyBuildPackage__Std.cmt" {"EsyBuildPackage__Std.cmt"}
+  "_build/install/default/lib/esy-build-package/Std.re" {"Std.re"}
+  "_build/install/default/lib/esy-build-package/EsyBuildPackage__Store.cmi" {"EsyBuildPackage__Store.cmi"}
+  "_build/install/default/lib/esy-build-package/EsyBuildPackage__Store.cmt" {"EsyBuildPackage__Store.cmt"}
+  "_build/install/default/lib/esy-build-package/Store.re" {"Store.re"}
+  "_build/install/default/lib/esy-build-package/EsyBuildPackage.cma" {"EsyBuildPackage.cma"}
+  "_build/install/default/lib/esy-build-package/esy-build-package.dune" {"esy-build-package.dune"}
 ]
 bin: [
   "_build/install/default/bin/esy-build-package" {"esy-build-package"}

--- a/esy.install
+++ b/esy.install
@@ -1,172 +1,173 @@
 lib: [
   "_build/install/default/lib/esy/META" {"META"}
   "_build/install/default/lib/esy/opam" {"opam"}
-  "_build/install/default/lib/esy/Esy__Build.cmi"
-  "_build/install/default/lib/esy/Esy__Build.cmx"
-  "_build/install/default/lib/esy/Esy__Build.cmt"
-  "_build/install/default/lib/esy/Build.ml"
-  "_build/install/default/lib/esy/Esy__Chalk.cmi"
-  "_build/install/default/lib/esy/Esy__Chalk.cmx"
-  "_build/install/default/lib/esy/Esy__Chalk.cmt"
-  "_build/install/default/lib/esy/Chalk.re"
-  "_build/install/default/lib/esy/Esy__ChildProcess.cmi"
-  "_build/install/default/lib/esy/Esy__ChildProcess.cmx"
-  "_build/install/default/lib/esy/Esy__ChildProcess.cmt"
-  "_build/install/default/lib/esy/Esy__ChildProcess.cmti"
-  "_build/install/default/lib/esy/ChildProcess.mli"
-  "_build/install/default/lib/esy/ChildProcess.ml"
-  "_build/install/default/lib/esy/Esy__Cmd.cmi"
-  "_build/install/default/lib/esy/Esy__Cmd.cmx"
-  "_build/install/default/lib/esy/Esy__Cmd.cmt"
-  "_build/install/default/lib/esy/Cmd.re"
-  "_build/install/default/lib/esy/Esy__CommandExpr.cmi"
-  "_build/install/default/lib/esy/Esy__CommandExpr.cmx"
-  "_build/install/default/lib/esy/Esy__CommandExpr.cmt"
-  "_build/install/default/lib/esy/CommandExpr.ml"
-  "_build/install/default/lib/esy/Esy__CommandExprParser.cmi"
-  "_build/install/default/lib/esy/Esy__CommandExprParser.cmx"
-  "_build/install/default/lib/esy/Esy__CommandExprParser.cmt"
-  "_build/install/default/lib/esy/CommandExprParser.ml"
-  "_build/install/default/lib/esy/Esy__CommandExprParserSupport.cmi"
-  "_build/install/default/lib/esy/Esy__CommandExprParserSupport.cmx"
-  "_build/install/default/lib/esy/Esy__CommandExprParserSupport.cmt"
-  "_build/install/default/lib/esy/CommandExprParserSupport.ml"
-  "_build/install/default/lib/esy/Esy__Config.cmi"
-  "_build/install/default/lib/esy/Esy__Config.cmx"
-  "_build/install/default/lib/esy/Esy__Config.cmt"
-  "_build/install/default/lib/esy/Config.ml"
-  "_build/install/default/lib/esy/Esy__DependencyGraph.cmi"
-  "_build/install/default/lib/esy/Esy__DependencyGraph.cmx"
-  "_build/install/default/lib/esy/Esy__DependencyGraph.cmt"
-  "_build/install/default/lib/esy/DependencyGraph.ml"
-  "_build/install/default/lib/esy/Esy__Environment.cmi"
-  "_build/install/default/lib/esy/Esy__Environment.cmx"
-  "_build/install/default/lib/esy/Esy__Environment.cmt"
-  "_build/install/default/lib/esy/Environment.ml"
-  "_build/install/default/lib/esy/Esy.cmi"
-  "_build/install/default/lib/esy/Esy.cmx"
-  "_build/install/default/lib/esy/Esy.cmt"
-  "_build/install/default/lib/esy/Esy.ml-gen"
-  "_build/install/default/lib/esy/Esy__EsyRc.cmi"
-  "_build/install/default/lib/esy/Esy__EsyRc.cmx"
-  "_build/install/default/lib/esy/Esy__EsyRc.cmt"
-  "_build/install/default/lib/esy/EsyRc.ml"
-  "_build/install/default/lib/esy/Esy__Fs.cmi"
-  "_build/install/default/lib/esy/Esy__Fs.cmx"
-  "_build/install/default/lib/esy/Esy__Fs.cmt"
-  "_build/install/default/lib/esy/Esy__Fs.cmti"
-  "_build/install/default/lib/esy/Fs.mli"
-  "_build/install/default/lib/esy/Fs.ml"
-  "_build/install/default/lib/esy/Esy__Json.cmi"
-  "_build/install/default/lib/esy/Esy__Json.cmx"
-  "_build/install/default/lib/esy/Esy__Json.cmt"
-  "_build/install/default/lib/esy/Json.ml"
-  "_build/install/default/lib/esy/Esy__LockfileLexer.cmi"
-  "_build/install/default/lib/esy/Esy__LockfileLexer.cmx"
-  "_build/install/default/lib/esy/Esy__LockfileLexer.cmt"
-  "_build/install/default/lib/esy/LockfileLexer.ml"
-  "_build/install/default/lib/esy/Esy__LockfileLexerSupport.cmi"
-  "_build/install/default/lib/esy/Esy__LockfileLexerSupport.cmx"
-  "_build/install/default/lib/esy/Esy__LockfileLexerSupport.cmt"
-  "_build/install/default/lib/esy/LockfileLexerSupport.ml"
-  "_build/install/default/lib/esy/Esy__LockfileParser.cmi"
-  "_build/install/default/lib/esy/Esy__LockfileParser.cmx"
-  "_build/install/default/lib/esy/Esy__LockfileParser.cmt"
-  "_build/install/default/lib/esy/LockfileParser.ml"
-  "_build/install/default/lib/esy/Esy__LwtTaskQueue.cmi"
-  "_build/install/default/lib/esy/Esy__LwtTaskQueue.cmx"
-  "_build/install/default/lib/esy/Esy__LwtTaskQueue.cmt"
-  "_build/install/default/lib/esy/Esy__LwtTaskQueue.cmti"
-  "_build/install/default/lib/esy/LwtTaskQueue.mli"
-  "_build/install/default/lib/esy/LwtTaskQueue.ml"
-  "_build/install/default/lib/esy/Esy__Memoize.cmi"
-  "_build/install/default/lib/esy/Esy__Memoize.cmx"
-  "_build/install/default/lib/esy/Esy__Memoize.cmt"
-  "_build/install/default/lib/esy/Memoize.re"
-  "_build/install/default/lib/esy/Esy__Package.cmi"
-  "_build/install/default/lib/esy/Esy__Package.cmx"
-  "_build/install/default/lib/esy/Esy__Package.cmt"
-  "_build/install/default/lib/esy/Package.ml"
-  "_build/install/default/lib/esy/Esy__PackageBuilder.cmi"
-  "_build/install/default/lib/esy/Esy__PackageBuilder.cmx"
-  "_build/install/default/lib/esy/Esy__PackageBuilder.cmt"
-  "_build/install/default/lib/esy/Esy__PackageBuilder.cmti"
-  "_build/install/default/lib/esy/PackageBuilder.mli"
-  "_build/install/default/lib/esy/PackageBuilder.ml"
-  "_build/install/default/lib/esy/Esy__ParseUtil.cmi"
-  "_build/install/default/lib/esy/Esy__ParseUtil.cmx"
-  "_build/install/default/lib/esy/Esy__ParseUtil.cmt"
-  "_build/install/default/lib/esy/ParseUtil.ml"
-  "_build/install/default/lib/esy/Esy__Path.cmi"
-  "_build/install/default/lib/esy/Esy__Path.cmx"
-  "_build/install/default/lib/esy/Esy__Path.cmt"
-  "_build/install/default/lib/esy/Path.re"
-  "_build/install/default/lib/esy/Esy__Perf.cmi"
-  "_build/install/default/lib/esy/Esy__Perf.cmx"
-  "_build/install/default/lib/esy/Esy__Perf.cmt"
-  "_build/install/default/lib/esy/Perf.ml"
-  "_build/install/default/lib/esy/Esy__Queue.cmi"
-  "_build/install/default/lib/esy/Esy__Queue.cmx"
-  "_build/install/default/lib/esy/Esy__Queue.cmt"
-  "_build/install/default/lib/esy/Esy__Queue.cmti"
-  "_build/install/default/lib/esy/Queue.mli"
-  "_build/install/default/lib/esy/Queue.ml"
-  "_build/install/default/lib/esy/Esy__Run.cmi"
-  "_build/install/default/lib/esy/Esy__Run.cmx"
-  "_build/install/default/lib/esy/Esy__Run.cmt"
-  "_build/install/default/lib/esy/Esy__Run.cmti"
-  "_build/install/default/lib/esy/Run.mli"
-  "_build/install/default/lib/esy/Run.ml"
-  "_build/install/default/lib/esy/Esy__RunAsync.cmi"
-  "_build/install/default/lib/esy/Esy__RunAsync.cmx"
-  "_build/install/default/lib/esy/Esy__RunAsync.cmt"
-  "_build/install/default/lib/esy/Esy__RunAsync.cmti"
-  "_build/install/default/lib/esy/RunAsync.mli"
-  "_build/install/default/lib/esy/RunAsync.ml"
-  "_build/install/default/lib/esy/Esy__Sandbox.cmi"
-  "_build/install/default/lib/esy/Esy__Sandbox.cmx"
-  "_build/install/default/lib/esy/Esy__Sandbox.cmt"
-  "_build/install/default/lib/esy/Sandbox.re"
-  "_build/install/default/lib/esy/Esy__SandboxTools.cmi"
-  "_build/install/default/lib/esy/Esy__SandboxTools.cmx"
-  "_build/install/default/lib/esy/Esy__SandboxTools.cmt"
-  "_build/install/default/lib/esy/SandboxTools.re"
-  "_build/install/default/lib/esy/Esy__ShellParamExpansion.cmi"
-  "_build/install/default/lib/esy/Esy__ShellParamExpansion.cmx"
-  "_build/install/default/lib/esy/Esy__ShellParamExpansion.cmt"
-  "_build/install/default/lib/esy/ShellParamExpansion.ml"
-  "_build/install/default/lib/esy/Esy__ShellParamExpansionParser.cmi"
-  "_build/install/default/lib/esy/Esy__ShellParamExpansionParser.cmx"
-  "_build/install/default/lib/esy/Esy__ShellParamExpansionParser.cmt"
-  "_build/install/default/lib/esy/ShellParamExpansionParser.ml"
-  "_build/install/default/lib/esy/Esy__ShellParamExpansionSupport.cmi"
-  "_build/install/default/lib/esy/Esy__ShellParamExpansionSupport.cmx"
-  "_build/install/default/lib/esy/Esy__ShellParamExpansionSupport.cmt"
-  "_build/install/default/lib/esy/ShellParamExpansionSupport.ml"
-  "_build/install/default/lib/esy/Esy__ShellSplit.cmi"
-  "_build/install/default/lib/esy/Esy__ShellSplit.cmx"
-  "_build/install/default/lib/esy/Esy__ShellSplit.cmt"
-  "_build/install/default/lib/esy/ShellSplit.ml"
-  "_build/install/default/lib/esy/Esy__Std.cmi"
-  "_build/install/default/lib/esy/Esy__Std.cmx"
-  "_build/install/default/lib/esy/Esy__Std.cmt"
-  "_build/install/default/lib/esy/Std.re"
-  "_build/install/default/lib/esy/Esy__System.cmi"
-  "_build/install/default/lib/esy/Esy__System.cmx"
-  "_build/install/default/lib/esy/Esy__System.cmt"
-  "_build/install/default/lib/esy/System.ml"
-  "_build/install/default/lib/esy/Esy__Task.cmi"
-  "_build/install/default/lib/esy/Esy__Task.cmx"
-  "_build/install/default/lib/esy/Esy__Task.cmt"
-  "_build/install/default/lib/esy/Task.ml"
-  "_build/install/default/lib/esy/Esy__TermTree.cmi"
-  "_build/install/default/lib/esy/Esy__TermTree.cmx"
-  "_build/install/default/lib/esy/Esy__TermTree.cmt"
-  "_build/install/default/lib/esy/TermTree.ml"
-  "_build/install/default/lib/esy/Esy.cma"
-  "_build/install/default/lib/esy/Esy.cmxa"
-  "_build/install/default/lib/esy/Esy.a"
-  "_build/install/default/lib/esy/Esy.cmxs"
+  "_build/install/default/lib/esy/Esy__Build.cmi" {"Esy__Build.cmi"}
+  "_build/install/default/lib/esy/Esy__Build.cmx" {"Esy__Build.cmx"}
+  "_build/install/default/lib/esy/Esy__Build.cmt" {"Esy__Build.cmt"}
+  "_build/install/default/lib/esy/Build.ml" {"Build.ml"}
+  "_build/install/default/lib/esy/Esy__Chalk.cmi" {"Esy__Chalk.cmi"}
+  "_build/install/default/lib/esy/Esy__Chalk.cmx" {"Esy__Chalk.cmx"}
+  "_build/install/default/lib/esy/Esy__Chalk.cmt" {"Esy__Chalk.cmt"}
+  "_build/install/default/lib/esy/Chalk.re" {"Chalk.re"}
+  "_build/install/default/lib/esy/Esy__ChildProcess.cmi" {"Esy__ChildProcess.cmi"}
+  "_build/install/default/lib/esy/Esy__ChildProcess.cmx" {"Esy__ChildProcess.cmx"}
+  "_build/install/default/lib/esy/Esy__ChildProcess.cmt" {"Esy__ChildProcess.cmt"}
+  "_build/install/default/lib/esy/Esy__ChildProcess.cmti" {"Esy__ChildProcess.cmti"}
+  "_build/install/default/lib/esy/ChildProcess.mli" {"ChildProcess.mli"}
+  "_build/install/default/lib/esy/ChildProcess.ml" {"ChildProcess.ml"}
+  "_build/install/default/lib/esy/Esy__Cmd.cmi" {"Esy__Cmd.cmi"}
+  "_build/install/default/lib/esy/Esy__Cmd.cmx" {"Esy__Cmd.cmx"}
+  "_build/install/default/lib/esy/Esy__Cmd.cmt" {"Esy__Cmd.cmt"}
+  "_build/install/default/lib/esy/Cmd.re" {"Cmd.re"}
+  "_build/install/default/lib/esy/Esy__CommandExpr.cmi" {"Esy__CommandExpr.cmi"}
+  "_build/install/default/lib/esy/Esy__CommandExpr.cmx" {"Esy__CommandExpr.cmx"}
+  "_build/install/default/lib/esy/Esy__CommandExpr.cmt" {"Esy__CommandExpr.cmt"}
+  "_build/install/default/lib/esy/CommandExpr.ml" {"CommandExpr.ml"}
+  "_build/install/default/lib/esy/Esy__CommandExprParser.cmi" {"Esy__CommandExprParser.cmi"}
+  "_build/install/default/lib/esy/Esy__CommandExprParser.cmx" {"Esy__CommandExprParser.cmx"}
+  "_build/install/default/lib/esy/Esy__CommandExprParser.cmt" {"Esy__CommandExprParser.cmt"}
+  "_build/install/default/lib/esy/CommandExprParser.ml" {"CommandExprParser.ml"}
+  "_build/install/default/lib/esy/Esy__CommandExprParserSupport.cmi" {"Esy__CommandExprParserSupport.cmi"}
+  "_build/install/default/lib/esy/Esy__CommandExprParserSupport.cmx" {"Esy__CommandExprParserSupport.cmx"}
+  "_build/install/default/lib/esy/Esy__CommandExprParserSupport.cmt" {"Esy__CommandExprParserSupport.cmt"}
+  "_build/install/default/lib/esy/CommandExprParserSupport.ml" {"CommandExprParserSupport.ml"}
+  "_build/install/default/lib/esy/Esy__Config.cmi" {"Esy__Config.cmi"}
+  "_build/install/default/lib/esy/Esy__Config.cmx" {"Esy__Config.cmx"}
+  "_build/install/default/lib/esy/Esy__Config.cmt" {"Esy__Config.cmt"}
+  "_build/install/default/lib/esy/Config.ml" {"Config.ml"}
+  "_build/install/default/lib/esy/Esy__DependencyGraph.cmi" {"Esy__DependencyGraph.cmi"}
+  "_build/install/default/lib/esy/Esy__DependencyGraph.cmx" {"Esy__DependencyGraph.cmx"}
+  "_build/install/default/lib/esy/Esy__DependencyGraph.cmt" {"Esy__DependencyGraph.cmt"}
+  "_build/install/default/lib/esy/DependencyGraph.ml" {"DependencyGraph.ml"}
+  "_build/install/default/lib/esy/Esy__Environment.cmi" {"Esy__Environment.cmi"}
+  "_build/install/default/lib/esy/Esy__Environment.cmx" {"Esy__Environment.cmx"}
+  "_build/install/default/lib/esy/Esy__Environment.cmt" {"Esy__Environment.cmt"}
+  "_build/install/default/lib/esy/Environment.ml" {"Environment.ml"}
+  "_build/install/default/lib/esy/Esy.cmi" {"Esy.cmi"}
+  "_build/install/default/lib/esy/Esy.cmx" {"Esy.cmx"}
+  "_build/install/default/lib/esy/Esy.cmt" {"Esy.cmt"}
+  "_build/install/default/lib/esy/Esy.ml-gen" {"Esy.ml-gen"}
+  "_build/install/default/lib/esy/Esy__EsyRc.cmi" {"Esy__EsyRc.cmi"}
+  "_build/install/default/lib/esy/Esy__EsyRc.cmx" {"Esy__EsyRc.cmx"}
+  "_build/install/default/lib/esy/Esy__EsyRc.cmt" {"Esy__EsyRc.cmt"}
+  "_build/install/default/lib/esy/EsyRc.ml" {"EsyRc.ml"}
+  "_build/install/default/lib/esy/Esy__Fs.cmi" {"Esy__Fs.cmi"}
+  "_build/install/default/lib/esy/Esy__Fs.cmx" {"Esy__Fs.cmx"}
+  "_build/install/default/lib/esy/Esy__Fs.cmt" {"Esy__Fs.cmt"}
+  "_build/install/default/lib/esy/Esy__Fs.cmti" {"Esy__Fs.cmti"}
+  "_build/install/default/lib/esy/Fs.mli" {"Fs.mli"}
+  "_build/install/default/lib/esy/Fs.ml" {"Fs.ml"}
+  "_build/install/default/lib/esy/Esy__Json.cmi" {"Esy__Json.cmi"}
+  "_build/install/default/lib/esy/Esy__Json.cmx" {"Esy__Json.cmx"}
+  "_build/install/default/lib/esy/Esy__Json.cmt" {"Esy__Json.cmt"}
+  "_build/install/default/lib/esy/Json.ml" {"Json.ml"}
+  "_build/install/default/lib/esy/Esy__LockfileLexer.cmi" {"Esy__LockfileLexer.cmi"}
+  "_build/install/default/lib/esy/Esy__LockfileLexer.cmx" {"Esy__LockfileLexer.cmx"}
+  "_build/install/default/lib/esy/Esy__LockfileLexer.cmt" {"Esy__LockfileLexer.cmt"}
+  "_build/install/default/lib/esy/LockfileLexer.ml" {"LockfileLexer.ml"}
+  "_build/install/default/lib/esy/Esy__LockfileLexerSupport.cmi" {"Esy__LockfileLexerSupport.cmi"}
+  "_build/install/default/lib/esy/Esy__LockfileLexerSupport.cmx" {"Esy__LockfileLexerSupport.cmx"}
+  "_build/install/default/lib/esy/Esy__LockfileLexerSupport.cmt" {"Esy__LockfileLexerSupport.cmt"}
+  "_build/install/default/lib/esy/LockfileLexerSupport.ml" {"LockfileLexerSupport.ml"}
+  "_build/install/default/lib/esy/Esy__LockfileParser.cmi" {"Esy__LockfileParser.cmi"}
+  "_build/install/default/lib/esy/Esy__LockfileParser.cmx" {"Esy__LockfileParser.cmx"}
+  "_build/install/default/lib/esy/Esy__LockfileParser.cmt" {"Esy__LockfileParser.cmt"}
+  "_build/install/default/lib/esy/LockfileParser.ml" {"LockfileParser.ml"}
+  "_build/install/default/lib/esy/Esy__LwtTaskQueue.cmi" {"Esy__LwtTaskQueue.cmi"}
+  "_build/install/default/lib/esy/Esy__LwtTaskQueue.cmx" {"Esy__LwtTaskQueue.cmx"}
+  "_build/install/default/lib/esy/Esy__LwtTaskQueue.cmt" {"Esy__LwtTaskQueue.cmt"}
+  "_build/install/default/lib/esy/Esy__LwtTaskQueue.cmti" {"Esy__LwtTaskQueue.cmti"}
+  "_build/install/default/lib/esy/LwtTaskQueue.mli" {"LwtTaskQueue.mli"}
+  "_build/install/default/lib/esy/LwtTaskQueue.ml" {"LwtTaskQueue.ml"}
+  "_build/install/default/lib/esy/Esy__Memoize.cmi" {"Esy__Memoize.cmi"}
+  "_build/install/default/lib/esy/Esy__Memoize.cmx" {"Esy__Memoize.cmx"}
+  "_build/install/default/lib/esy/Esy__Memoize.cmt" {"Esy__Memoize.cmt"}
+  "_build/install/default/lib/esy/Memoize.re" {"Memoize.re"}
+  "_build/install/default/lib/esy/Esy__Package.cmi" {"Esy__Package.cmi"}
+  "_build/install/default/lib/esy/Esy__Package.cmx" {"Esy__Package.cmx"}
+  "_build/install/default/lib/esy/Esy__Package.cmt" {"Esy__Package.cmt"}
+  "_build/install/default/lib/esy/Package.ml" {"Package.ml"}
+  "_build/install/default/lib/esy/Esy__PackageBuilder.cmi" {"Esy__PackageBuilder.cmi"}
+  "_build/install/default/lib/esy/Esy__PackageBuilder.cmx" {"Esy__PackageBuilder.cmx"}
+  "_build/install/default/lib/esy/Esy__PackageBuilder.cmt" {"Esy__PackageBuilder.cmt"}
+  "_build/install/default/lib/esy/Esy__PackageBuilder.cmti" {"Esy__PackageBuilder.cmti"}
+  "_build/install/default/lib/esy/PackageBuilder.mli" {"PackageBuilder.mli"}
+  "_build/install/default/lib/esy/PackageBuilder.ml" {"PackageBuilder.ml"}
+  "_build/install/default/lib/esy/Esy__ParseUtil.cmi" {"Esy__ParseUtil.cmi"}
+  "_build/install/default/lib/esy/Esy__ParseUtil.cmx" {"Esy__ParseUtil.cmx"}
+  "_build/install/default/lib/esy/Esy__ParseUtil.cmt" {"Esy__ParseUtil.cmt"}
+  "_build/install/default/lib/esy/ParseUtil.ml" {"ParseUtil.ml"}
+  "_build/install/default/lib/esy/Esy__Path.cmi" {"Esy__Path.cmi"}
+  "_build/install/default/lib/esy/Esy__Path.cmx" {"Esy__Path.cmx"}
+  "_build/install/default/lib/esy/Esy__Path.cmt" {"Esy__Path.cmt"}
+  "_build/install/default/lib/esy/Path.re" {"Path.re"}
+  "_build/install/default/lib/esy/Esy__Perf.cmi" {"Esy__Perf.cmi"}
+  "_build/install/default/lib/esy/Esy__Perf.cmx" {"Esy__Perf.cmx"}
+  "_build/install/default/lib/esy/Esy__Perf.cmt" {"Esy__Perf.cmt"}
+  "_build/install/default/lib/esy/Perf.ml" {"Perf.ml"}
+  "_build/install/default/lib/esy/Esy__Queue.cmi" {"Esy__Queue.cmi"}
+  "_build/install/default/lib/esy/Esy__Queue.cmx" {"Esy__Queue.cmx"}
+  "_build/install/default/lib/esy/Esy__Queue.cmt" {"Esy__Queue.cmt"}
+  "_build/install/default/lib/esy/Esy__Queue.cmti" {"Esy__Queue.cmti"}
+  "_build/install/default/lib/esy/Queue.mli" {"Queue.mli"}
+  "_build/install/default/lib/esy/Queue.ml" {"Queue.ml"}
+  "_build/install/default/lib/esy/Esy__Run.cmi" {"Esy__Run.cmi"}
+  "_build/install/default/lib/esy/Esy__Run.cmx" {"Esy__Run.cmx"}
+  "_build/install/default/lib/esy/Esy__Run.cmt" {"Esy__Run.cmt"}
+  "_build/install/default/lib/esy/Esy__Run.cmti" {"Esy__Run.cmti"}
+  "_build/install/default/lib/esy/Run.mli" {"Run.mli"}
+  "_build/install/default/lib/esy/Run.ml" {"Run.ml"}
+  "_build/install/default/lib/esy/Esy__RunAsync.cmi" {"Esy__RunAsync.cmi"}
+  "_build/install/default/lib/esy/Esy__RunAsync.cmx" {"Esy__RunAsync.cmx"}
+  "_build/install/default/lib/esy/Esy__RunAsync.cmt" {"Esy__RunAsync.cmt"}
+  "_build/install/default/lib/esy/Esy__RunAsync.cmti" {"Esy__RunAsync.cmti"}
+  "_build/install/default/lib/esy/RunAsync.mli" {"RunAsync.mli"}
+  "_build/install/default/lib/esy/RunAsync.ml" {"RunAsync.ml"}
+  "_build/install/default/lib/esy/Esy__Sandbox.cmi" {"Esy__Sandbox.cmi"}
+  "_build/install/default/lib/esy/Esy__Sandbox.cmx" {"Esy__Sandbox.cmx"}
+  "_build/install/default/lib/esy/Esy__Sandbox.cmt" {"Esy__Sandbox.cmt"}
+  "_build/install/default/lib/esy/Sandbox.re" {"Sandbox.re"}
+  "_build/install/default/lib/esy/Esy__SandboxTools.cmi" {"Esy__SandboxTools.cmi"}
+  "_build/install/default/lib/esy/Esy__SandboxTools.cmx" {"Esy__SandboxTools.cmx"}
+  "_build/install/default/lib/esy/Esy__SandboxTools.cmt" {"Esy__SandboxTools.cmt"}
+  "_build/install/default/lib/esy/SandboxTools.re" {"SandboxTools.re"}
+  "_build/install/default/lib/esy/Esy__ShellParamExpansion.cmi" {"Esy__ShellParamExpansion.cmi"}
+  "_build/install/default/lib/esy/Esy__ShellParamExpansion.cmx" {"Esy__ShellParamExpansion.cmx"}
+  "_build/install/default/lib/esy/Esy__ShellParamExpansion.cmt" {"Esy__ShellParamExpansion.cmt"}
+  "_build/install/default/lib/esy/ShellParamExpansion.ml" {"ShellParamExpansion.ml"}
+  "_build/install/default/lib/esy/Esy__ShellParamExpansionParser.cmi" {"Esy__ShellParamExpansionParser.cmi"}
+  "_build/install/default/lib/esy/Esy__ShellParamExpansionParser.cmx" {"Esy__ShellParamExpansionParser.cmx"}
+  "_build/install/default/lib/esy/Esy__ShellParamExpansionParser.cmt" {"Esy__ShellParamExpansionParser.cmt"}
+  "_build/install/default/lib/esy/ShellParamExpansionParser.ml" {"ShellParamExpansionParser.ml"}
+  "_build/install/default/lib/esy/Esy__ShellParamExpansionSupport.cmi" {"Esy__ShellParamExpansionSupport.cmi"}
+  "_build/install/default/lib/esy/Esy__ShellParamExpansionSupport.cmx" {"Esy__ShellParamExpansionSupport.cmx"}
+  "_build/install/default/lib/esy/Esy__ShellParamExpansionSupport.cmt" {"Esy__ShellParamExpansionSupport.cmt"}
+  "_build/install/default/lib/esy/ShellParamExpansionSupport.ml" {"ShellParamExpansionSupport.ml"}
+  "_build/install/default/lib/esy/Esy__ShellSplit.cmi" {"Esy__ShellSplit.cmi"}
+  "_build/install/default/lib/esy/Esy__ShellSplit.cmx" {"Esy__ShellSplit.cmx"}
+  "_build/install/default/lib/esy/Esy__ShellSplit.cmt" {"Esy__ShellSplit.cmt"}
+  "_build/install/default/lib/esy/ShellSplit.ml" {"ShellSplit.ml"}
+  "_build/install/default/lib/esy/Esy__Std.cmi" {"Esy__Std.cmi"}
+  "_build/install/default/lib/esy/Esy__Std.cmx" {"Esy__Std.cmx"}
+  "_build/install/default/lib/esy/Esy__Std.cmt" {"Esy__Std.cmt"}
+  "_build/install/default/lib/esy/Std.re" {"Std.re"}
+  "_build/install/default/lib/esy/Esy__System.cmi" {"Esy__System.cmi"}
+  "_build/install/default/lib/esy/Esy__System.cmx" {"Esy__System.cmx"}
+  "_build/install/default/lib/esy/Esy__System.cmt" {"Esy__System.cmt"}
+  "_build/install/default/lib/esy/System.ml" {"System.ml"}
+  "_build/install/default/lib/esy/Esy__Task.cmi" {"Esy__Task.cmi"}
+  "_build/install/default/lib/esy/Esy__Task.cmx" {"Esy__Task.cmx"}
+  "_build/install/default/lib/esy/Esy__Task.cmt" {"Esy__Task.cmt"}
+  "_build/install/default/lib/esy/Task.ml" {"Task.ml"}
+  "_build/install/default/lib/esy/Esy__TermTree.cmi" {"Esy__TermTree.cmi"}
+  "_build/install/default/lib/esy/Esy__TermTree.cmx" {"Esy__TermTree.cmx"}
+  "_build/install/default/lib/esy/Esy__TermTree.cmt" {"Esy__TermTree.cmt"}
+  "_build/install/default/lib/esy/TermTree.ml" {"TermTree.ml"}
+  "_build/install/default/lib/esy/Esy.cma" {"Esy.cma"}
+  "_build/install/default/lib/esy/Esy.cmxa" {"Esy.cmxa"}
+  "_build/install/default/lib/esy/Esy.a" {"Esy.a"}
+  "_build/install/default/lib/esy/Esy.cmxs" {"Esy.cmxs"}
+  "_build/install/default/lib/esy/esy.dune" {"esy.dune"}
 ]
 bin: [
   "_build/install/default/bin/esy" {"esy"}

--- a/esy.lock
+++ b/esy.lock
@@ -7,8 +7,8 @@
   resolved "https://registry.yarnpkg.com/@esy-ocaml/esy-installer/-/esy-installer-0.0.0.tgz#6b0e2bd4ee43531ac74793fe55cfcc3aca197a66"
 
 "@esy-ocaml/merlin@*":
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/@esy-ocaml/merlin/-/merlin-3.0.5.tgz#f1459f159f56fb0dd73e64b77ed432b1d3d15bd7"
+  version "3.0.5004"
+  resolved "https://registry.yarnpkg.com/@esy-ocaml/merlin/-/merlin-3.0.5004.tgz#e92a1cb8448b230874837dcf7da29def41f46170"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
     "@esy-ocaml/substs" "^0.0.1"
@@ -68,22 +68,22 @@
   peerDependencies:
     ocaml "*"
 
-"@opam/base@ >= 100000000.10.0  < 100000000.11.0":
-  version "100000000.10.0"
-  uid "61a1898496c450e7f69b8cc9372c37d3"
-  resolved "@opam/base@100000000.10.0-0f4c76c362a664261940c4884d42abfb.tgz"
+"@opam/base@ >= 100000000.11.0", "@opam/base@ >= 100000000.11.0  < 100000000.12.0":
+  version "100000000.11.0"
+  uid b68c5ff6069f377ad1cb9f6a1af07e94
+  resolved "@opam/base@100000000.11.0-b68c5ff6069f377ad1cb9f6a1af07e94.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
     "@esy-ocaml/substs" "^0.0.1"
-    "@opam/jbuilder" " >= 1.0.0-beta12"
-    "@opam/sexplib" " >= 100000000.10.0  < 100000000.11.0"
+    "@opam/jbuilder" " >= 1.0.0-beta181"
+    "@opam/sexplib0" " >= 100000000.11.0  < 100000000.12.0"
   peerDependencies:
     ocaml " >= 4.4.1000"
 
 "@opam/biniou@ >= 1.2.0":
   version "1.2.0"
   uid af4880e80be63bbb3043fb7184882eb8
-  resolved "@opam/biniou@1.2.0-6fd1adb146321db74c08abc202b12119.tgz"
+  resolved "@opam/biniou@1.2.0-af4880e80be63bbb3043fb7184882eb8.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
     "@esy-ocaml/substs" "^0.0.1"
@@ -148,22 +148,22 @@
     ocaml "*"
 
 "@opam/cppo@ >= 1.1.0", "@opam/cppo@ >= 1.6.0", "@opam/cppo@*":
-  version "1.6.0"
-  uid "349808856d0a52266567126c6e1a482c"
-  resolved "@opam/cppo@1.6.0-e7f9ad67562d5952779e822a0a37d129.tgz"
+  version "1.6.4"
+  uid "0caf37d16727e17fbcd4e9b41a467f91"
+  resolved "@opam/cppo@1.6.4-0caf37d16727e17fbcd4e9b41a467f91.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
     "@esy-ocaml/substs" "^0.0.1"
     "@opam/base-bytes" "*"
     "@opam/base-unix" "*"
-    "@opam/jbuilder" " >= 1.0.0-beta10"
+    "@opam/jbuilder" " >= 1.0.0-beta17"
   peerDependencies:
-    ocaml " < 4.7.0"
+    ocaml "*"
 
 "@opam/cppo_ocamlbuild@*":
   version "1.6.0"
   uid "76c36d0e895b7ef5a207f158d017d4da"
-  resolved "@opam/cppo_ocamlbuild@1.6.0-6fd85090225019f09a636edd7e6d011e.tgz"
+  resolved "@opam/cppo_ocamlbuild@1.6.0-76c36d0e895b7ef5a207f158d017d4da.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
     "@esy-ocaml/substs" "^0.0.1"
@@ -174,9 +174,9 @@
     ocaml "*"
 
 "@opam/easy-format@*":
-  version "1.3.0"
-  uid f5b814cc29a75774dbb5c990c4d16072
-  resolved "@opam/easy-format@1.3.0-45fc67548f2c8453460628bbada5e55a.tgz"
+  version "1.3.1"
+  uid "0c2f9b085eba4175086013e7ef48ba05"
+  resolved "@opam/easy-format@1.3.1-0c2f9b085eba4175086013e7ef48ba05.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
     "@esy-ocaml/substs" "^0.0.1"
@@ -214,21 +214,10 @@
   peerDependencies:
     ocaml " >= 4.1.0"
 
-"@opam/jbuilder@ >= 1.0.0-beta10", "@opam/jbuilder@ >= 1.0.0-beta12", "@opam/jbuilder@ >= 1.0.0-beta7", "@opam/jbuilder@*", "@opam/jbuilder@^1.0.0-beta16":
-  version "1.0.0-beta16"
-  uid "851f0253157da21f055187b3f296fdae"
-  resolved "@opam/jbuilder@1.0.0-beta16-268cea30119d82b294b8a8333019a3d6.tgz"
-  dependencies:
-    "@esy-ocaml/esy-installer" "^0.0.0"
-    "@esy-ocaml/substs" "^0.0.1"
-    "@opam/ocamlfind" "*"
-  peerDependencies:
-    ocaml " >= 4.2.3000"
-
-"@opam/jbuilder@ >= 1.0.0-beta14", "@opam/jbuilder@^1.0.0-beta18":
-  version "1.0.0-beta18"
-  uid "281d8c71c86a42346d78ad4090b8b945"
-  resolved "@opam/jbuilder@1.0.0-beta18-281d8c71c86a42346d78ad4090b8b945.tgz"
+"@opam/jbuilder@ >= 1.0.0-beta10", "@opam/jbuilder@ >= 1.0.0-beta11", "@opam/jbuilder@ >= 1.0.0-beta12", "@opam/jbuilder@ >= 1.0.0-beta14", "@opam/jbuilder@ >= 1.0.0-beta17", "@opam/jbuilder@ >= 1.0.0-beta181", "@opam/jbuilder@ >= 1.0.0-beta7", "@opam/jbuilder@*", "@opam/jbuilder@^1.0.0-beta16", "@opam/jbuilder@^1.0.0-beta18":
+  version "1.0.0-beta191"
+  uid "7b3aa95089fb10c87585ea70b0f755bc"
+  resolved "@opam/jbuilder@1.0.0-beta191-7b3aa95089fb10c87585ea70b0f755bc.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
     "@esy-ocaml/substs" "^0.0.1"
@@ -250,7 +239,7 @@
   peerDependencies:
     ocaml " >= 4.1.0"
 
-"@opam/lwt@^3.3.0", "@opam/lwt@*":
+"@opam/lwt@*", "@opam/lwt@^3.3.0":
   version "3.3.0"
   uid d6527433462fadf2f1b8168dbb5cf10e
   resolved "@opam/lwt@3.3.0-d6527433462fadf2f1b8168dbb5cf10e.tgz"
@@ -295,7 +284,7 @@
 "@opam/merlin-extend@ >= 0.3.0":
   version "0.3.0"
   uid d688ddc39d2c47f4c3083de2fa51bf7e
-  resolved "@opam/merlin-extend@0.3.0-ef0dc69e7f68ffcb4519d921e363ba96.tgz"
+  resolved "@opam/merlin-extend@0.3.0-d688ddc39d2c47f4c3083de2fa51bf7e.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
     "@esy-ocaml/substs" "^0.0.1"
@@ -304,21 +293,10 @@
   peerDependencies:
     ocaml " >= 4.2.3000"
 
-"@opam/num@*":
-  version "1.1.0"
-  uid c64f9fc6e953860619021ca270ab9d57
-  resolved "@opam/num@1.1.0-1a8983432f97ff1b76cf80d16336913d.tgz"
-  dependencies:
-    "@esy-ocaml/esy-installer" "^0.0.0"
-    "@esy-ocaml/substs" "^0.0.1"
-    "@opam/ocamlfind" " >= 1.7.3"
-  peerDependencies:
-    ocaml " >= 4.6.0"
-
-"@opam/ocaml-compiler-libs@ >= 100000000.10.0  < 100000000.11.0":
-  version "100000000.10.0"
-  uid "8fa775ba888d5647dac83db8c2fcdfd6"
-  resolved "@opam/ocaml-compiler-libs@100000000.10.0-ec320bfae5b49e944cee71222fbf6557.tgz"
+"@opam/ocaml-compiler-libs@ >= 100000000.11.0":
+  version "100000000.11.0"
+  uid "6bbef43e036aa696a6b8891516fd385a"
+  resolved "@opam/ocaml-compiler-libs@100000000.11.0-6bbef43e036aa696a6b8891516fd385a.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
     "@esy-ocaml/substs" "^0.0.1"
@@ -326,14 +304,14 @@
   peerDependencies:
     ocaml " >= 4.4.1000"
 
-"@opam/ocaml-migrate-parsetree@ >= 0.4.0", "@opam/ocaml-migrate-parsetree@ >= 1.0.0", "@opam/ocaml-migrate-parsetree@*":
-  version "1.0.7"
-  uid "8dd63da93ee2ed29313f5b50471c94ae"
-  resolved "@opam/ocaml-migrate-parsetree@1.0.7-8dd63da93ee2ed29313f5b50471c94ae.tgz"
+"@opam/ocaml-migrate-parsetree@ >= 1.0.0", "@opam/ocaml-migrate-parsetree@ >= 1.0.7", "@opam/ocaml-migrate-parsetree@ >= 1.0.9", "@opam/ocaml-migrate-parsetree@*":
+  version "1.0.9"
+  uid bb0aa50339ab53730b3e84f02c8f29df
+  resolved "@opam/ocaml-migrate-parsetree@1.0.9-bb0aa50339ab53730b3e84f02c8f29df.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
     "@esy-ocaml/substs" "^0.0.1"
-    "@opam/jbuilder" " >= 1.0.0-beta10"
+    "@opam/jbuilder" " >= 1.0.0-beta181"
     "@opam/ocamlfind" "*"
     "@opam/result" "*"
   peerDependencies:
@@ -349,10 +327,10 @@
   peerDependencies:
     ocaml " >= 4.3.0"
 
-"@opam/ocamlfind@", "@opam/ocamlfind@ >= 1.5.0", "@opam/ocamlfind@ >= 1.5.2", "@opam/ocamlfind@ >= 1.5.3", "@opam/ocamlfind@ >= 1.6.0", "@opam/ocamlfind@ >= 1.6.1", "@opam/ocamlfind@ >= 1.7.3", "@opam/ocamlfind@ >= 1.7.3--1", "@opam/ocamlfind@*":
+"@opam/ocamlfind@", "@opam/ocamlfind@ >= 1.5.0", "@opam/ocamlfind@ >= 1.5.2", "@opam/ocamlfind@ >= 1.5.3", "@opam/ocamlfind@ >= 1.6.0", "@opam/ocamlfind@ >= 1.6.1", "@opam/ocamlfind@ >= 1.7.3--1", "@opam/ocamlfind@*":
   version "1.7.3--1"
-  uid "2e5446e160cfd1aae7944b2f7add39b7"
-  resolved "@opam/ocamlfind@1.7.3--1-2e5446e160cfd1aae7944b2f7add39b7.tgz"
+  uid "8bdb2749715bb44e0e6d09503deb7fd7"
+  resolved "@opam/ocamlfind@1.7.3--1-8bdb2749715bb44e0e6d09503deb7fd7.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
     "@esy-ocaml/substs" "^0.0.1"
@@ -363,7 +341,7 @@
 "@opam/ocp-build@ >= 1.99.6--beta":
   version "1.99.20--beta"
   uid e257cd415f77a7b2e9714bfd95aafbe2
-  resolved "@opam/ocp-build@1.99.20--beta-010d08eecfe9a9f3c6d108928965a467.tgz"
+  resolved "@opam/ocp-build@1.99.20--beta-e257cd415f77a7b2e9714bfd95aafbe2.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
     "@esy-ocaml/substs" "^0.0.1"
@@ -385,36 +363,7 @@
   peerDependencies:
     ocaml "*"
 
-"@opam/ppx_ast@ >= 100000000.10.0  < 100000000.11.0":
-  version "100000000.10.0"
-  uid c8ef9a150180e7f0b91193de2e8fcafd
-  resolved "@opam/ppx_ast@100000000.10.0-86d6a315d4e6ab6dbbf6cc9c03c4dcfa.tgz"
-  dependencies:
-    "@esy-ocaml/esy-installer" "^0.0.0"
-    "@esy-ocaml/substs" "^0.0.1"
-    "@opam/jbuilder" " >= 1.0.0-beta12"
-    "@opam/ocaml-compiler-libs" " >= 100000000.10.0  < 100000000.11.0"
-    "@opam/ocaml-migrate-parsetree" " >= 0.4.0"
-  peerDependencies:
-    ocaml " >= 4.4.1000"
-
-"@opam/ppx_core@ >= 100000000.10.0  < 100000000.11.0":
-  version "100000000.10.0"
-  uid "524ee9981e92b66ea1cfcccf3f8d9fdf"
-  resolved "@opam/ppx_core@100000000.10.0-7e08a01f506234b6572026b8421aff4d.tgz"
-  dependencies:
-    "@esy-ocaml/esy-installer" "^0.0.0"
-    "@esy-ocaml/substs" "^0.0.1"
-    "@opam/base" " >= 100000000.10.0  < 100000000.11.0"
-    "@opam/jbuilder" " >= 1.0.0-beta12"
-    "@opam/ocaml-compiler-libs" " >= 100000000.10.0  < 100000000.11.0"
-    "@opam/ppx_ast" " >= 100000000.10.0  < 100000000.11.0"
-    "@opam/ppx_traverse_builtins" " >= 100000000.10.0  < 100000000.11.0"
-    "@opam/stdio" " >= 100000000.10.0  < 100000000.11.0"
-  peerDependencies:
-    ocaml " >= 4.4.1000"
-
-"@opam/ppx_derivers@*":
+"@opam/ppx_derivers@ >= 1.0.0", "@opam/ppx_derivers@*":
   version "1.0.0"
   uid "8f34e516ed653f2d9d6fbae0d01e64d8"
   resolved "@opam/ppx_derivers@1.0.0-8f34e516ed653f2d9d6fbae0d01e64d8.tgz"
@@ -446,7 +395,7 @@
 "@opam/ppx_deriving_yojson@^3.1.0":
   version "3.1.0"
   uid "8c7c66c0c254daf2603e46b74b9a01b5"
-  resolved "@opam/ppx_deriving_yojson@3.1.0-1d6b71b8c5e2a367eb62a2f5915d5dfe.tgz"
+  resolved "@opam/ppx_deriving_yojson@3.1.0-8c7c66c0c254daf2603e46b74b9a01b5.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
     "@esy-ocaml/substs" "^0.0.1"
@@ -459,20 +408,6 @@
     "@opam/yojson" "*"
   peerDependencies:
     ocaml "*"
-
-"@opam/ppx_driver@ >= 100000000.10.0  < 100000000.11.0":
-  version "100000000.10.1"
-  uid "872ddd621127b22b5c0b34dafd2b8607"
-  resolved "@opam/ppx_driver@100000000.10.1-e573e21a7a71dba337544a91d68eee6e.tgz"
-  dependencies:
-    "@esy-ocaml/esy-installer" "^0.0.0"
-    "@esy-ocaml/substs" "^0.0.1"
-    "@opam/jbuilder" " >= 1.0.0-beta12"
-    "@opam/ocaml-migrate-parsetree" " >= 1.0.0"
-    "@opam/ppx_core" " >= 100000000.10.0  < 100000000.11.0"
-    "@opam/ppx_optcomp" " >= 100000000.10.0  < 100000000.11.0"
-  peerDependencies:
-    ocaml " >= 4.4.1000"
 
 "@opam/ppx_import@^1.4.0":
   version "1.4.0"
@@ -490,59 +425,30 @@
     ocaml " >= 4.2.0"
 
 "@opam/ppx_inline_test@^100000000.10.0":
-  version "100000000.10.0"
-  uid ed94a85602c5dde00832c53f9f7884ac
-  resolved "@opam/ppx_inline_test@100000000.10.0-46268d1ce4555e87f4d1c6a83fe0188a.tgz"
+  version "100000000.11.0"
+  uid fa511c34bae584084fe524adfede89c6
+  resolved "@opam/ppx_inline_test@100000000.11.0-fa511c34bae584084fe524adfede89c6.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
     "@esy-ocaml/substs" "^0.0.1"
-    "@opam/base" " >= 100000000.10.0  < 100000000.11.0"
-    "@opam/jbuilder" " >= 1.0.0-beta12"
-    "@opam/ocaml-migrate-parsetree" " >= 0.4.0"
-    "@opam/ppx_core" " >= 100000000.10.0  < 100000000.11.0"
-    "@opam/ppx_driver" " >= 100000000.10.0  < 100000000.11.0"
-    "@opam/ppx_metaquot" " >= 100000000.10.0  < 100000000.11.0"
+    "@opam/base" " >= 100000000.11.0  < 100000000.12.0"
+    "@opam/jbuilder" " >= 1.0.0-beta181"
+    "@opam/ocaml-migrate-parsetree" " >= 1.0.0"
+    "@opam/ppxlib" " >= 0.1.0"
   peerDependencies:
     ocaml " >= 4.4.1000"
 
 "@opam/ppx_let@^100000000.9.0":
-  version "100000000.10.0"
-  uid d6340180ecf177e329d004857b4ad93d
-  resolved "@opam/ppx_let@100000000.10.0-53932fd1834bf08e5c4e912dd84229d4.tgz"
+  version "100000000.11.0"
+  uid "0ae2159a63f1dc79956e07e4cd303981"
+  resolved "@opam/ppx_let@100000000.11.0-0ae2159a63f1dc79956e07e4cd303981.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
     "@esy-ocaml/substs" "^0.0.1"
-    "@opam/jbuilder" " >= 1.0.0-beta12"
-    "@opam/ocaml-migrate-parsetree" " >= 0.4.0"
-    "@opam/ppx_core" " >= 100000000.10.0  < 100000000.11.0"
-    "@opam/ppx_driver" " >= 100000000.10.0  < 100000000.11.0"
-  peerDependencies:
-    ocaml " >= 4.4.1000"
-
-"@opam/ppx_metaquot@ >= 100000000.10.0  < 100000000.11.0":
-  version "100000000.10.0"
-  uid d4448b38e21b0cafd2931de4182a5627
-  resolved "@opam/ppx_metaquot@100000000.10.0-eeb784604af5b82a103e5dde8c74a02d.tgz"
-  dependencies:
-    "@esy-ocaml/esy-installer" "^0.0.0"
-    "@esy-ocaml/substs" "^0.0.1"
-    "@opam/jbuilder" " >= 1.0.0-beta12"
-    "@opam/ocaml-migrate-parsetree" " >= 0.4.0"
-    "@opam/ppx_core" " >= 100000000.10.0  < 100000000.11.0"
-    "@opam/ppx_driver" " >= 100000000.10.0  < 100000000.11.0"
-    "@opam/ppx_traverse_builtins" " >= 100000000.10.0  < 100000000.11.0"
-  peerDependencies:
-    ocaml " >= 4.4.1000"
-
-"@opam/ppx_optcomp@ >= 100000000.10.0  < 100000000.11.0":
-  version "100000000.10.0"
-  uid "053c049836f5eb4d7fb6ace06c7e890e"
-  resolved "@opam/ppx_optcomp@100000000.10.0-2db0236047b14a4d4d66747bdb3189d9.tgz"
-  dependencies:
-    "@esy-ocaml/esy-installer" "^0.0.0"
-    "@esy-ocaml/substs" "^0.0.1"
-    "@opam/jbuilder" " >= 1.0.0-beta12"
-    "@opam/ppx_core" " >= 100000000.10.0  < 100000000.11.0"
+    "@opam/base" " >= 100000000.11.0  < 100000000.12.0"
+    "@opam/jbuilder" " >= 1.0.0-beta181"
+    "@opam/ocaml-migrate-parsetree" " >= 1.0.0"
+    "@opam/ppxlib" " >= 0.1.0"
   peerDependencies:
     ocaml " >= 4.4.1000"
 
@@ -559,47 +465,51 @@
 
 "@opam/ppx_tools_versioned@ >= 5.0.1":
   version "5.1.0"
-  uid "8c474fc8622c3cdf7683533fae007ea5"
-  resolved "@opam/ppx_tools_versioned@5.1.0-8c474fc8622c3cdf7683533fae007ea5.tgz"
+  uid "563cec821710613b61de9bf99ebebe65"
+  resolved "@opam/ppx_tools_versioned@5.1.0-563cec821710613b61de9bf99ebebe65.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
     "@esy-ocaml/substs" "^0.0.1"
-    "@opam/ocaml-migrate-parsetree" " >= 0.4.0"
+    "@opam/ocaml-migrate-parsetree" " >= 1.0.7"
     "@opam/ocamlfind" " >= 1.5.0"
   peerDependencies:
     ocaml " >= 4.2.0"
 
-"@opam/ppx_traverse_builtins@ >= 100000000.10.0  < 100000000.11.0":
-  version "100000000.10.0"
-  uid "20e5d7a860d5908e647f9fec3ca62399"
-  resolved "@opam/ppx_traverse_builtins@100000000.10.0-a2ef026844ed1382a4f6ae253fecacc1.tgz"
+"@opam/ppxlib@ >= 0.1.0":
+  version "0.2.0"
+  uid "13c15ee8edd6fa714c280cdc3fb9326c"
+  resolved "@opam/ppxlib@0.2.0-13c15ee8edd6fa714c280cdc3fb9326c.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
     "@esy-ocaml/substs" "^0.0.1"
-    "@opam/jbuilder" " >= 1.0.0-beta12"
+    "@opam/base" " >= 100000000.11.0"
+    "@opam/jbuilder" " >= 1.0.0-beta181"
+    "@opam/ocaml-compiler-libs" " >= 100000000.11.0"
+    "@opam/ocaml-migrate-parsetree" " >= 1.0.9"
+    "@opam/ppx_derivers" " >= 1.0.0"
+    "@opam/stdio" " >= 100000000.11.0"
   peerDependencies:
     ocaml " >= 4.4.1000"
 
 "@opam/re@^1.7.1":
-  version "1.7.1"
-  uid "13ec06721b6d9e0f19b2f954d5654d53"
-  resolved "@opam/re@1.7.1-e00c0af36ff712e9c64b1a50b313ee24.tgz"
+  version "1.7.3"
+  uid "98b9a57656724b0540d0e404ad8a6024"
+  resolved "@opam/re@1.7.3-98b9a57656724b0540d0e404ad8a6024.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
     "@esy-ocaml/substs" "^0.0.1"
-    "@opam/base-bytes" "*"
-    "@opam/ocamlbuild" "*"
-    "@opam/ocamlfind" "*"
+    "@opam/jbuilder" " >= 1.0.0-beta10"
   peerDependencies:
-    ocaml "*"
+    ocaml " >= 4.2.3000"
 
 "@opam/result@*":
-  version "1.2.0"
-  uid "5c62071e67f4a84e28ceeaac2969d1ae"
-  resolved "@opam/result@1.2.0-5c62071e67f4a84e28ceeaac2969d1ae.tgz"
+  version "1.3.0"
+  uid "9a01d033485a02ccc143441a46adeb53"
+  resolved "@opam/result@1.3.0-9a01d033485a02ccc143441a46adeb53.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
     "@esy-ocaml/substs" "^0.0.1"
+    "@opam/jbuilder" " >= 1.0.0-beta11"
   peerDependencies:
     ocaml "*"
 
@@ -617,28 +527,26 @@
   peerDependencies:
     ocaml " >= 4.1.0"
 
-"@opam/sexplib@ >= 100000000.10.0  < 100000000.11.0":
-  version "100000000.10.0"
-  uid b9d188a02815394de53995872f854a63
-  resolved "@opam/sexplib@100000000.10.0-04b36fb8d85586a7db9db0314b4da5fa.tgz"
+"@opam/sexplib0@ >= 100000000.11.0  < 100000000.12.0":
+  version "100000000.11.0"
+  uid "10c8e60e028dd16eb8811cfef7796c76"
+  resolved "@opam/sexplib0@100000000.11.0-10c8e60e028dd16eb8811cfef7796c76.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
     "@esy-ocaml/substs" "^0.0.1"
-    "@opam/jbuilder" " >= 1.0.0-beta12"
-    "@opam/num" "*"
+    "@opam/jbuilder" " >= 1.0.0-beta181"
   peerDependencies:
     ocaml " >= 4.4.1000"
 
-"@opam/stdio@ >= 100000000.10.0  < 100000000.11.0":
-  version "100000000.10.0"
-  uid "1d609fa241244c86cd7029e29ee910b3"
-  resolved "@opam/stdio@100000000.10.0-048b90814aaf3ff22912757a907f8790.tgz"
+"@opam/stdio@ >= 100000000.11.0":
+  version "100000000.11.0"
+  uid "27da8885d79d100990c21e366639857c"
+  resolved "@opam/stdio@100000000.11.0-27da8885d79d100990c21e366639857c.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
     "@esy-ocaml/substs" "^0.0.1"
-    "@opam/base" " >= 100000000.10.0  < 100000000.11.0"
-    "@opam/jbuilder" " >= 1.0.0-beta12"
-    "@opam/sexplib" " >= 100000000.10.0  < 100000000.11.0"
+    "@opam/base" " >= 100000000.11.0  < 100000000.12.0"
+    "@opam/jbuilder" " >= 1.0.0-beta181"
   peerDependencies:
     ocaml " >= 4.4.1000"
 
@@ -667,9 +575,9 @@
     ocaml " >= 3.12.0"
 
 "@opam/yojson@*":
-  version "1.4.0"
-  uid "139a44cad85290f31b72aecca4e60c65"
-  resolved "@opam/yojson@1.4.0-c155d6491e9922eec9e88e06b4339e36.tgz"
+  version "1.4.1"
+  uid "1d23ddc5148ccb2ca2e11f0a854d35dd"
+  resolved "@opam/yojson@1.4.1-1d23ddc5148ccb2ca2e11f0a854d35dd.tgz"
   dependencies:
     "@esy-ocaml/esy-installer" "^0.0.0"
     "@esy-ocaml/substs" "^0.0.1"

--- a/test-e2e/build/build-not-enough-deps-test.sh
+++ b/test-e2e/build/build-not-enough-deps-test.sh
@@ -7,6 +7,6 @@ doTest () {
   set -e
 
   # test that error output has relevant info
-  echo "$out" | grep "missing dependency dep"
+  echo "$out" | grep "invalid dependency dep: unable to resolve package"
   echo "$out" | grep "While processing package:"
 }

--- a/test-e2e/common/fixtures/simple-project/package.json
+++ b/test-e2e/common/fixtures/simple-project/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "esy": {},
   "author": "Andrey Popp <8mayday@gmail.com> (http://andreypopp.com/)",
   "license": "MIT"
 }

--- a/test/jbuild
+++ b/test/jbuild
@@ -3,7 +3,7 @@
   (library_flags (-linkall))
   (libraries (esy ppx_inline_test.runtime-lib))
   (modules (:standard \ Test_runner))
-  (preprocess (pps (ppx_inline_test ppx_driver.runner)))
+  (preprocess (pps (ppx_inline_test ppxlib.runner)))
   )
  )
 


### PR DESCRIPTION
We skip packages w/o "esy" section inside package.json.

That makes esy usable with dependency graphs which include circular references. Note that circular references are not allowed still for esy packages but are allowed for other non-esy packages inside `node_modules`.

We still inclide esy packages referenced by non-esy packages:
```
        root
          |
         ...
          |
    non-esy-package
          |
      esy-package
```
So given the diagram above the root package will still have esy-package as a dependency in a build graph.