### PR TITLE
Try to find sandbox by climbing from the cwd

### DIFF
--- a/esy-lib/ChildProcess.ml
+++ b/esy-lib/ChildProcess.ml
@@ -42,7 +42,7 @@ let resolveCmdInEnv ~env prg =
       | None -> ""
     in
     String.split_on_char ':' v
-  in Run.liftOfBosError (Cmd.resolveCmd path prg)
+  in Run.ofBosError (Cmd.resolveCmd path prg)
 
 let withProcess ?(env=`CurrentEnv) ?(resolveProgramInEnv=false) ?stdin ?stdout ?stderr cmd f =
   let open RunAsync.Syntax in
@@ -60,7 +60,7 @@ let withProcess ?(env=`CurrentEnv) ?(resolveProgramInEnv=false) ?stdin ?stdout ?
     | `CustomEnv env -> Some env
   in
 
-  let%bind cmd = RunAsync.liftOfRun (
+  let%bind cmd = RunAsync.ofRun (
       let open Run.Syntax in
       match Bos.Cmd.to_list cmd with
       | [] -> error "empty command"
@@ -127,7 +127,7 @@ let runOut ?(env=`CurrentEnv) ?(resolveProgramInEnv=false) ?stdin ?stderr cmd =
     | `CustomEnv env -> Some env
   in
 
-  let%bind cmd = RunAsync.liftOfRun (
+  let%bind cmd = RunAsync.ofRun (
       let open Run.Syntax in
       match Bos.Cmd.to_list cmd with
       | [] -> error "empty command"

--- a/esy-lib/Path.re
+++ b/esy-lib/Path.re
@@ -2,6 +2,33 @@ include Fpath;
 
 let addExt = add_ext;
 let toString = to_string;
+let isPrefix = is_prefix;
+let remPrefix = rem_prefix;
+
+let user = () => Run.ofBosError(Bos.OS.Dir.user());
+let current = () => Run.ofBosError(Bos.OS.Dir.current());
+
+/**
+ * Convert a path to a string and replace a prefix to ~ if it's happened to be a
+ * a user home directory.
+ */
+let toPrettyString = p =>
+  Run.Syntax.(
+    {
+      let%bind path = {
+        let%bind user = user();
+        switch (remPrefix(user, p)) {
+        | Some(p) => return(append(v("~"), p))
+        | None => return(p)
+        };
+      };
+      return(toString(path));
+    }
+  );
+
+/*
+ * yojson protocol
+ */
 
 let of_yojson = (json: Yojson.Safe.json) =>
   switch (json) {

--- a/esy-lib/Run.ml
+++ b/esy-lib/Run.ml
@@ -61,19 +61,15 @@ let formatError (msg, context) =
   | [] -> Printf.sprintf "Error: %s" msg
   | context -> Printf.sprintf "Error: %s\n%s" msg (String.concat "\n" context)
 
-let liftOfStringError v =
+let ofStringError v =
   match v with
   | Ok v -> Ok v
   | Error line -> Error (line, [])
 
-let ofStringError = liftOfStringError
-
-let liftOfBosError v =
+let ofBosError v =
   match v with
   | Ok v -> Ok v
   | Error (`Msg line) -> Error (line, [])
-
-let ofBosError = liftOfBosError
 
 let ofOption ?err = function
   | Some v -> return v
@@ -83,20 +79,6 @@ let ofOption ?err = function
     | None -> "not found"
     in error err
 
-let foldLeft ~f ~init xs =
-  let rec fold acc xs =  match acc, xs with
-    | Error err, _ -> Error err
-    | Ok acc, [] -> Ok acc
-    | Ok acc, x::xs -> fold (f acc x) xs
-  in
-  fold (Ok init) xs
-
-let rec waitAll = function
-  | [] -> return ()
-  | x::xs ->
-    let f () = waitAll xs in
-    bind ~f x
-
 let runExn ?err = function
   | Ok v -> v
   | Error (msg, ctx) ->
@@ -105,3 +87,15 @@ let runExn ?err = function
     | None -> msg
     in
     failwith (formatError (msg, ctx))
+
+module List = struct
+
+  let foldLeft ~f ~init xs =
+    let rec fold acc xs =  match acc, xs with
+      | Error err, _ -> Error err
+      | Ok acc, [] -> Ok acc
+      | Ok acc, x::xs -> fold (f acc x) xs
+    in
+    fold (Ok init) xs
+
+end

--- a/esy-lib/RunAsync.ml
+++ b/esy-lib/RunAsync.ml
@@ -20,25 +20,6 @@ let bind ~f v =
   in
   Lwt.bind v waitForPromise
 
-let joinAll xs =
-  let rec _joinAll xs res = match xs with
-    | [] ->
-      return (List.rev res)
-    | x::xs ->
-      let f v = _joinAll xs (v::res) in
-      bind ~f x
-  in
-  _joinAll xs []
-
-let waitAll xs =
-  let rec _waitAll xs = match xs with
-    | [] -> return ()
-    | x::xs ->
-      let f () = _waitAll xs in
-      bind ~f x
-  in
-  _waitAll xs
-
 module Syntax = struct
   let return = return
   let error = error
@@ -48,7 +29,6 @@ module Syntax = struct
   end
 end
 
-let liftOfRun = Lwt.return
 let ofRun = Lwt.return
 
 let ofOption ?err v =
@@ -63,3 +43,24 @@ let ofOption ?err v =
 let runExn ?err v =
   let v = Lwt_main.run v in
   Run.runExn ?err v
+
+module List = struct
+  let joinAll xs =
+    let rec _joinAll xs res = match xs with
+      | [] ->
+        return (List.rev res)
+      | x::xs ->
+        let f v = _joinAll xs (v::res) in
+        bind ~f x
+    in
+    _joinAll xs []
+
+  let waitAll xs =
+    let rec _waitAll xs = match xs with
+      | [] -> return ()
+      | x::xs ->
+        let f () = _waitAll xs in
+        bind ~f x
+    in
+    _waitAll xs
+end

--- a/esy/Build.ml
+++ b/esy/Build.ml
@@ -3,7 +3,7 @@ module StringSet = Set.Make(String)
 let waitForDependencies dependencies =
   dependencies
   |> List.map (fun (_, dep) -> dep)
-  |> RunAsync.waitAll
+  |> RunAsync.List.waitAll
 
 let buildTask ?(quiet=false) ?force ?stderrout ~buildOnly cfg (task : Task.t) =
   let f () =
@@ -59,7 +59,7 @@ let runTask
       in
       match%lwt Fs.readFile infoPath with
       | Ok data ->
-        let%bind buildInfo = RunAsync.liftOfRun (
+        let%bind buildInfo = RunAsync.ofRun (
           Json.parseStringWith EsyBuildPackage.BuildInfo.of_yojson data
         ) in
         begin match buildInfo.EsyBuildPackage.BuildInfo.sourceModTime with

--- a/esy/Config.ml
+++ b/esy/Config.ml
@@ -98,7 +98,7 @@ let create
       esyInstallJsCommand;
     }
   in
-  value |> Run.liftOfBosError |> RunAsync.liftOfRun
+  value |> Run.ofBosError |> RunAsync.ofRun
 
 module type ABSTRACT_PATH = sig
   (**

--- a/esy/Environment.ml
+++ b/esy/Environment.ml
@@ -26,7 +26,7 @@ let renderPath ~storePath ~localStorePath ~sandboxPath value =
   | "sandbox" -> Some (Path.to_string sandboxPath)
   | _ -> None
   in
-  Run.liftOfBosError (EsyBuildPackage.PathSyntax.render lookup value)
+  Run.ofBosError (EsyBuildPackage.PathSyntax.render lookup value)
 
 let bindingListPp = pp
 let bindingListEq = equal
@@ -77,7 +77,7 @@ let renderToShellSource
     in
     Ok (line::lines, origin)
   in
-  let%bind lines, _ = Run.foldLeft ~f ~init:([], None) bindings in
+  let%bind lines, _ = Run.List.foldLeft ~f ~init:([], None) bindings in
   return (header ^ "\n" ^ (lines |> List.rev |> String.concat "\n"))
 
 let current =

--- a/esy/EsyRc.ml
+++ b/esy/EsyRc.ml
@@ -11,7 +11,7 @@ let ofPath path =
 
   let ofFilename filename =
     let%bind data = Fs.readFile filename in
-    let%bind ast = RunAsync.liftOfRun (P.parse data) in
+    let%bind ast = RunAsync.ofRun (P.parse data) in
     match ast with
     | P.Mapping items ->
       let f acc item =
@@ -32,7 +32,7 @@ let ofPath path =
       begin
       match ListLabels.fold_left ~init:(Ok { prefixPath = None }) ~f items with
       | Ok esyRc -> return esyRc
-      | v -> v |> Run.liftOfBosError |> RunAsync.liftOfRun
+      | v -> v |> Run.ofBosError |> RunAsync.ofRun
       end
     | _ -> error "expected mapping"
   in

--- a/esy/Json.ml
+++ b/esy/Json.ml
@@ -3,7 +3,7 @@ module StringMap = (Map.Make)(String)
 type t = Yojson.Safe.json
 
 let parseJsonWith parser json =
-  Run.liftOfStringError (parser json)
+  Run.ofStringError (parser json)
 
 let parseStringWith parser data =
   let json = Yojson.Safe.from_string data in

--- a/esy/NpmRelease.ml
+++ b/esy/NpmRelease.ml
@@ -295,7 +295,7 @@ let make ~esyInstallRelease ~outputPath ~concurrency ~cfg ~sandbox =
         let outputPrefixPath = Path.(outputPath / "_export") in
         LwtTaskQueue.submit queue (fun () -> Task.exportBuild ~cfg ~outputPrefixPath buildPath)
     in
-    tasks |> ListLabels.map ~f |> RunAsync.waitAll
+    tasks |> ListLabels.map ~f |> RunAsync.List.waitAll
   in
 
   let%bind () =
@@ -315,7 +315,7 @@ let make ~esyInstallRelease ~outputPath ~concurrency ~cfg ~sandbox =
       in
       releaseCfg.releasedBinaries
       |> List.map generateBinaryWrapper
-      |> RunAsync.waitAll
+      |> RunAsync.List.waitAll
     in
 
     let sandboxEntryBin = releaseCfg.name ^ "-sandbox" in

--- a/esy/PackageBuilder.ml
+++ b/esy/PackageBuilder.ml
@@ -15,7 +15,7 @@ let run
   in
 
   let runProcess buildJsonFilename =
-    let%bind command = RunAsync.liftOfRun (
+    let%bind command = RunAsync.ofRun (
       let open Run.Syntax in
       return Cmd.(
         cfg.esyBuildPackageCommand

--- a/esy/Sandbox.re
+++ b/esy/Sandbox.re
@@ -176,8 +176,8 @@ let ofDir = (cfg: Config.t) => {
             path
             |> String.trim
             |> Path.of_string
-            |> Run.liftOfBosError
-            |> RunAsync.liftOfRun;
+            |> Run.ofBosError
+            |> RunAsync.ofRun;
           } else {
             return(path);
           };
@@ -215,7 +215,7 @@ let ofDir = (cfg: Config.t) => {
            let%bind stat = Fs.stat(path);
            return((path, stat.Unix.st_mtime));
          })
-      |> RunAsync.joinAll;
+      |> RunAsync.List.joinAll;
     let sandbox = {root, manifestInfo};
     return(sandbox);
   | _ => error("root package missing esy config")

--- a/esy/Task.ml
+++ b/esy/Task.ml
@@ -493,7 +493,7 @@ let ofPackage
         )
       in
       let%bind injectCamlLdLibraryPath, globalEnv, localEnv =
-        Run.foldLeft ~f ~init:(false, [], []) pkg.exportedEnv
+        Run.List.foldLeft ~f ~init:(false, [], []) pkg.exportedEnv
       in
       let%bind globalEnv = if injectCamlLdLibraryPath then
         let%bind value = CommandExpr.render

--- a/esy/bin/SandboxInfo.ml
+++ b/esy/bin/SandboxInfo.ml
@@ -55,7 +55,7 @@ let writeCache (cfg : Config.t) (info : t) =
       ) in
       let%bind () = Fs.createDirectory sandboxBin in
 
-      let%bind commandEnv = RunAsync.liftOfRun(
+      let%bind commandEnv = RunAsync.ofRun (
           let header =
             let pkg = info.sandbox.root in
             Printf.sprintf "# Command environment for %s@%s" pkg.name pkg.version
@@ -97,7 +97,7 @@ let readCache (cfg : Config.t) =
         in
         info.sandbox.manifestInfo
         |> List.map checkMtime
-        |> RunAsync.joinAll
+        |> RunAsync.List.joinAll
       in
       if List.exists (fun x -> x) isStale
       then return None
@@ -112,7 +112,7 @@ let ofConfig (cfg : Config.t) =
   let makeInfo () =
     let f () =
       let%bind sandbox = Sandbox.ofDir cfg in
-      let%bind task, commandEnv, sandboxEnv = RunAsync.liftOfRun (
+      let%bind task, commandEnv, sandboxEnv = RunAsync.ofRun (
           let open Run.Syntax in
           let%bind task = Task.ofPackage sandbox.root in
           let%bind commandEnv = Task.commandEnv sandbox.root in

--- a/test-e2e/common/anycmd-test.sh
+++ b/test-e2e/common/anycmd-test.sh
@@ -25,4 +25,11 @@ doTest() {
   expectStdout "1" checkExitCode esy bash -c 'exit 1'
   expectStdout "7" checkExitCode esy bash -c 'exit 7'
 
+  # Make sure we can run commands out of subdirectories
+  mkdir subdir
+  pushd subdir
+  touch X
+  expectStdout "X" esy ls -1
+  popd
+
 }

--- a/test-e2e/common/x-anycmd-test.sh
+++ b/test-e2e/common/x-anycmd-test.sh
@@ -23,5 +23,12 @@ doTest() {
   # Make sure exit code is preserved
   expectStdout "1" checkExitCode esy x bash -c 'exit 1'
   expectStdout "7" checkExitCode esy x bash -c 'exit 7'
+
+  # Make sure we can run commands out of subdirectories
+  mkdir subdir
+  pushd subdir
+  touch X
+  expectStdout "X" esy x ls -1
+  popd
 }
 


### PR DESCRIPTION
Previously we tried to find the sandbox path in the cwd, now we look into cwd first and then climb the directory up the filesystem tree.

Note:

* `esy COMMAND` runs in the cwd
* `esy x COMMAND` runs in the cwd
* `esy shell` runs shell in the cwd
* `esy b COMMAND` runs in the *build root* (I think it makes sense but I'm happy to be proved wrong).