### PR TITLE
Bundle fastreplacestring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 /_export
 /_build
 /_release
-/bin/fastreplacestring.exe
+/bin/fastreplacestring
 /bin/esyConfig.sh
 .merlin
 npm-debug.log

--- a/Makefile
+++ b/Makefile
@@ -49,11 +49,12 @@ bootstrap:
 ifndef ESY_EXT
 	$(error "esy command is not avaialble, run 'npm install -g esy'")
 endif
-	@make -C esy-install bootstrap
 	@esy install
+	@make -C esy-install bootstrap
 	@make build-dev
 	@make -C test-e2e bootstrap
 	@make -C test-e2e/pkg-tests bootstrap
+	@ln -s $$(esy which fastreplacestring) $(PWD)/bin/fastreplacestring
 
 doctoc:
 	@$(BIN)/doctoc --notitle ./README.md
@@ -102,6 +103,7 @@ test::
 RELEASE_ROOT = _release
 RELEASE_FILES = \
 	bin/esy \
+	bin/fastreplacestring \
 	bin/esy-install.js \
 	bin/esyInstallRelease.js \
 	scripts/postinstall.sh \
@@ -163,6 +165,10 @@ $(RELEASE_ROOT)/_build/default/esyi/bin/esyi.exe:
 
 $(RELEASE_ROOT)/bin/esy-install.js:
 	@$(MAKE) -C esy-install BUILD=../$(@) build
+
+$(RELEASE_ROOT)/bin/fastreplacestring:
+	@mkdir -p $(@D)
+	@cp $$(esy which fastreplacestring) $(@)
 
 $(RELEASE_ROOT)/%: $(PWD)/%
 	@mkdir -p $(@D)

--- a/esy-build-package/bin/esyBuildPackageCommand.re
+++ b/esy-build-package/bin/esyBuildPackageCommand.re
@@ -32,12 +32,12 @@ let createConfig = (copts: commonOpts) => {
     let basedir = Fpath.parent(program);
     let resolution =
       EsyBuildPackage.NodeResolution.resolve(
-        "fastreplacestring/.bin/fastreplacestring.exe",
+        "../../../../bin/fastreplacestring",
         basedir,
       );
     switch%bind (Run.coerceFrmMsgOnly(resolution)) {
     | Some(path) => Ok(Fpath.to_string(path))
-    | None => Ok("fastreplacestring.exe")
+    | None => Error(`Msg("cannot resolve fastreplacestring command"))
     };
   };
   EsyBuildPackage.Config.create(

--- a/esy-install/package.json
+++ b/esy-install/package.json
@@ -71,7 +71,6 @@
     "babel-polyfill": "^6.23.0",
     "cli-argparse": "^1.1.2",
     "debug": "^3.1.0",
-    "fastreplacestring": "git+https://github.com/IwanKaramazow/FastReplaceString.git#0.0.4",
     "fs-extra": "^3.0.1",
     "json-stable-stringify": "https://github.com/substack/json-stable-stringify",
     "json5": "^0.5.1",

--- a/esy-install/yarn.lock
+++ b/esy-install/yarn.lock
@@ -6,10 +6,6 @@
   version "0.0.0"
   uid ""
 
-"@esy-ocaml/esy-opam@0.0.14":
-  version "0.0.14"
-  resolved "https://registry.yarnpkg.com/@esy-ocaml/esy-opam/-/esy-opam-0.0.14.tgz#f7c1ed6246d6e6ff2dff1e9f74b90875b1fa061f"
-
 "@esy-ocaml/esy-opam@0.0.15":
   version "0.0.15"
   resolved "https://registry.yarnpkg.com/@esy-ocaml/esy-opam/-/esy-opam-0.0.15.tgz#97656c8e5774cf84692a680319784cb833cc5b70"
@@ -2095,10 +2091,6 @@ fast-json-stable-stringify@^2.0.0:
 fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
-
-"fastreplacestring@git+https://github.com/IwanKaramazow/FastReplaceString.git#0.0.4":
-  version "0.0.3"
-  resolved "git+https://github.com/IwanKaramazow/FastReplaceString.git#e834cbed0e71d7e0967ab31f1d67f95af7f05e53"
 
 fb-watchman@^2.0.0:
   version "2.0.0"

--- a/esy.json
+++ b/esy.json
@@ -54,7 +54,7 @@
     "@opam/yaml": "*",
     "@opam/re": "^1.7.1",
     "@esy-ocaml/reason": "^3.2.0",
-    "fastreplacestring": "IwanKaramazow/FastReplaceString.git#0.0.4"
+    "fastreplacestring": "esy-ocaml/FastReplaceString.git#44511d"
   },
   "resolutions": {
     "**/@opam/sexplib0": "100000000.11.0",

--- a/esy.lock
+++ b/esy.lock
@@ -892,9 +892,9 @@
   peerDependencies:
     ocaml " >= 4.2.3000"
 
-fastreplacestring@IwanKaramazow/FastReplaceString.git#0.0.4:
+fastreplacestring@esy-ocaml/FastReplaceString.git#44511d:
   version "0.0.3"
-  resolved "https://codeload.github.com/IwanKaramazow/FastReplaceString/tar.gz/e834cbed0e71d7e0967ab31f1d67f95af7f05e53"
+  resolved "https://codeload.github.com/esy-ocaml/FastReplaceString/tar.gz/44511dadb5736df8df3f06f99c25314e6beac34b"
 
 ocaml@~4.6.0:
   version "4.6.1"

--- a/esy/bin/esyCommand.ml
+++ b/esy/bin/esyCommand.ml
@@ -54,7 +54,7 @@ module EsyRuntime = struct
     resolveCommand "../../../../bin/esy-install.js"
 
   let fastreplacestringCommand =
-    resolveCommand "fastreplacestring/.bin/fastreplacestring.exe"
+    resolveCommand "../../../../bin/fastreplacestring"
 
   let esyBuildPackageCommand =
     resolveCommand "../../esy-build-package/bin/esyBuildPackageCommand.exe"

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "license": "MIT",
   "description": "Esy sandboxes for compiled languages",
   "dependencies": {
-    "@esy-ocaml/esy-opam": "0.0.14",
-    "fastreplacestring": "git+https://github.com/IwanKaramazow/FastReplaceString.git#0.0.4"
+    "@esy-ocaml/esy-opam": "0.0.14"
   },
   "scripts": {
     "postinstall": "bash ./scripts/postinstall.sh"


### PR DESCRIPTION
This bundle `fastrepalcestring` with the esy release tarball instead of relying on npm to install it. This also makes sure we build fastreplacestring once on a release machine.