### PR TITLE
Install devDependencies as regular dependencies for the root project

### DIFF
--- a/esyi/OpamFile.re
+++ b/esyi/OpamFile.re
@@ -439,7 +439,7 @@ let getSubsts = opamvalue =>
   |> List.map(~f=filename => ["substs", filename ++ ".in"]);
 
 let parseManifest =
-    (info: (PackageName.t, Version.t), {file_contents, file_name}) => {
+    (~name: PackageName.t, ~version: Version.t, {file_contents, file_name}) => {
   let (deps, buildDeps, devDeps) =
     processDeps(file_name, findVariable("depends", file_contents));
   let (depopts, _, _) =
@@ -511,7 +511,6 @@ let parseManifest =
   let devDependencies = Dependencies.(empty |> addMany(~reqs=devDeps));
   let optDependencies = Dependencies.(empty |> addMany(~reqs=depopts));
 
-  let (name, version) = info;
   {
     name,
     version,

--- a/esyi/OpamFile.rei
+++ b/esyi/OpamFile.rei
@@ -26,12 +26,18 @@ type manifest = {
   peerDependencies: PackageInfo.Dependencies.t,
   optDependencies: PackageInfo.Dependencies.t,
   available: [ | `IsNotAvailable | `Ok],
-  /* TODO optDependencies (depopts) */
   source: PackageInfo.Source.t,
   exportedEnv: PackageJson.ExportedEnv.t,
 };
 
-let parseManifest : ((PackageName.t, OpamVersion.Version.t), OpamParserTypes.opamfile) => manifest;
-let parseUrlFile : OpamParserTypes.opamfile => PackageInfo.SourceSpec.t;
+let parseManifest : (
+  ~name: PackageName.t,
+  ~version: OpamVersion.Version.t,
+  OpamParserTypes.opamfile
+) => manifest;
+
+let parseUrlFile : (
+  OpamParserTypes.opamfile
+) => PackageInfo.SourceSpec.t;
 
 let toPackageJson : (manifest, PackageInfo.Version.t) => PackageInfo.OpamInfo.t;

--- a/esyi/OpamFile.rei
+++ b/esyi/OpamFile.rei
@@ -31,15 +31,6 @@ type manifest = {
   exportedEnv: PackageJson.ExportedEnv.t,
 };
 
-module ThinManifest : {
-  type t = {
-    name: PackageName.t,
-    opamFile: Path.t,
-    urlFile: Path.t,
-    version: OpamVersion.Version.t,
-  };
-};
-
 let parseManifest : ((PackageName.t, OpamVersion.Version.t), OpamParserTypes.opamfile) => manifest;
 let parseUrlFile : OpamParserTypes.opamfile => PackageInfo.SourceSpec.t;
 

--- a/esyi/OpamOverrides.re
+++ b/esyi/OpamOverrides.re
@@ -188,14 +188,14 @@ let apply = (manifest: OpamFile.manifest, override: Override.t) => {
     install:
       Option.orDefault(~default=manifest.install, override.Override.install),
     dependencies:
-      PackageInfo.Dependencies.merge(
+      PackageInfo.Dependencies.override(
+        ~override=override.Override.dependencies,
         manifest.dependencies,
-        override.Override.dependencies,
       ),
     peerDependencies:
-      PackageInfo.Dependencies.merge(
+      PackageInfo.Dependencies.override(
+        ~override=override.Override.peerDependencies,
         manifest.peerDependencies,
-        override.Override.peerDependencies,
       ),
     files,
     source,

--- a/esyi/OpamOverrides.re
+++ b/esyi/OpamOverrides.re
@@ -1,4 +1,5 @@
 module PackageNameMap = Map.Make(OpamFile.PackageName);
+module Dependencies = PackageInfo.Dependencies;
 
 module Override = {
   module Opam = {
@@ -188,13 +189,13 @@ let apply = (manifest: OpamFile.manifest, override: Override.t) => {
     install:
       Option.orDefault(~default=manifest.install, override.Override.install),
     dependencies:
-      PackageInfo.Dependencies.override(
-        ~override=override.Override.dependencies,
+      Dependencies.overrideMany(
+        ~reqs=Dependencies.toList(override.Override.dependencies),
         manifest.dependencies,
       ),
     peerDependencies:
-      PackageInfo.Dependencies.override(
-        ~override=override.Override.peerDependencies,
+      Dependencies.overrideMany(
+        ~reqs=Dependencies.toList(override.Override.peerDependencies),
         manifest.peerDependencies,
       ),
     files,

--- a/esyi/OpamRegistry.mli
+++ b/esyi/OpamRegistry.mli
@@ -1,11 +1,18 @@
 type t
 
+type pkg = {
+  name: OpamFile.PackageName.t;
+  opam: Path.t;
+  url: Path.t;
+  version: OpamVersion.Version.t;
+}
+
 val init : cfg:Config.t -> unit -> t RunAsync.t
 
 val versions :
   t
   -> name : OpamFile.PackageName.t
-  -> (OpamVersion.Version.t * OpamFile.ThinManifest.t) list RunAsync.t
+  -> (OpamVersion.Version.t * pkg) list RunAsync.t
 
 val version :
     t

--- a/esyi/PackageInfo.mli
+++ b/esyi/PackageInfo.mli
@@ -88,12 +88,14 @@ module Req : sig
   val spec : t -> VersionSpec.t
 end
 
+(** A collection of dependencies *)
 module Dependencies : sig
   type t = Req.t list
+  val pp : t Fmt.t
   val empty : 'a list
   val of_yojson : Json.t -> (Req.t list, string) result
   val to_yojson : t -> [> `Assoc of (string * [> `String of string ]) list ]
-  val merge : Req.t list -> Req.t list -> Req.t list
+  val override : override:t -> t -> t
 end
 
 module Resolutions : sig

--- a/esyi/PackageInfo.mli
+++ b/esyi/PackageInfo.mli
@@ -88,14 +88,34 @@ module Req : sig
   val spec : t -> VersionSpec.t
 end
 
-(** A collection of dependencies *)
+(**
+ * A collection of dependency requests.
+ *
+ * There maybe possible multiple requests of the same name.
+ * TODO: Make sure there's no requests of the same name possible and provide
+ *       explicit API for conjuction/override.
+ *)
 module Dependencies : sig
-  type t = Req.t list
+  type t
+
+  val empty : t
+
+  val add : req:Req.t -> t -> t
+  val addMany : reqs:Req.t list -> t -> t
+
+  val override : req:Req.t -> t -> t
+  val overrideMany : reqs:Req.t list -> t -> t
+
+  val map : f:(Req.t -> Req.t) -> t -> t
+
+  val findByName : name:string -> t -> Req.t option
+
+  val toList : t -> Req.t list
+
   val pp : t Fmt.t
-  val empty : 'a list
-  val of_yojson : Json.t -> (Req.t list, string) result
-  val to_yojson : t -> [> `Assoc of (string * [> `String of string ]) list ]
-  val override : override:t -> t -> t
+
+  val of_yojson : Json.t -> (t, string) result
+  val to_yojson : t -> Json.t
 end
 
 module Resolutions : sig

--- a/esyi/Solution.ml
+++ b/esyi/Solution.ml
@@ -1,3 +1,4 @@
+module Dependencies = PackageInfo.Dependencies
 module Version = PackageInfo.Version
 module Source = PackageInfo.Source
 module Req = PackageInfo.Req
@@ -86,13 +87,13 @@ let dependenciesHash (manifest : PackageJson.t) =
       ~resolutions:manifest.PackageJson.resolutions
     |> hashDependencies
       ~prefix:"dependencies"
-      ~dependencies:manifest.PackageJson.dependencies
+      ~dependencies:(Dependencies.toList manifest.PackageJson.dependencies)
     |> hashDependencies
       ~prefix:"buildDependencies"
-      ~dependencies:manifest.PackageJson.buildDependencies
+      ~dependencies:(Dependencies.toList manifest.PackageJson.buildDependencies)
     |> hashDependencies
       ~prefix:"devDependencies"
-      ~dependencies:manifest.PackageJson.devDependencies
+      ~dependencies:(Dependencies.toList manifest.PackageJson.devDependencies)
   in
   Digest.to_hex digest
 

--- a/esyi/Universe.ml
+++ b/esyi/Universe.ml
@@ -1,3 +1,4 @@
+module Dependencies = PackageInfo.Dependencies
 module Version = PackageInfo.Version
 module VersionSpec = PackageInfo.VersionSpec
 module Req = PackageInfo.Req
@@ -230,7 +231,11 @@ let toCudf ?(installed=Package.Set.empty) univ =
         cudfVersionMap
     in
 
-    let depends = List.map ~f:encodeReq pkg.dependencies in
+    let depends =
+      pkg.dependencies
+      |> Dependencies.toList
+      |> List.map ~f:encodeReq
+    in
     let cudfName = CudfName.ofString pkg.name in
     let cudfPkg = {
       Cudf.default_package with

--- a/esyi/bin/esyi.re
+++ b/esyi/bin/esyi.re
@@ -108,7 +108,8 @@ module Api = {
     let manifest = {
       let manifest =
         OpamFile.parseManifest(
-          (name, version),
+          ~name,
+          ~version,
           OpamParser.file(Path.toString(path)),
         );
       OpamFile.{...manifest, source: PackageInfo.Source.NoSource};

--- a/jbuild-ignore
+++ b/jbuild-ignore
@@ -1,2 +1,5 @@
 node_modules
+esy-install
 reason
+test-e2e
+linux-build/

--- a/test-e2e/pkg-tests/pkg-tests-specs/sources/devDependencies.js
+++ b/test-e2e/pkg-tests/pkg-tests-specs/sources/devDependencies.js
@@ -69,65 +69,13 @@ module.exports = (makeTemporaryEnv: PackageDriver) => {
 
           await expect(crawlLayout(path)).resolves.toMatchObject({
             dependencies: {
-              devDep: {
-                name: 'devDep',
-                dependencies: {
-                  ok: {
-                    name: 'ok',
-                    version: '1.0.0',
-                  },
-                },
-              },
-            },
-          });
-        },
-      ),
-    );
-
-    test(
-      `it should allow to duplicate conflicting deps between devDependencies and runtime deps`,
-      makeTemporaryEnv(
-        {
-          name: 'root',
-          version: '1.0.0',
-          dependencies: {ok: `1.0.0`},
-          devDependencies: {devDep: `1.0.0`},
-        },
-        async ({path, run, source}) => {
-          await definePackage({
-            name: 'devDep',
-            version: '1.0.0',
-            dependencies: {
-              ok: '2.0.0',
-            },
-          });
-          await definePackage({
-            name: 'ok',
-            version: '1.0.0',
-            dependencies: {},
-          });
-          await definePackage({
-            name: 'ok',
-            version: '2.0.0',
-            dependencies: {},
-          });
-
-          await run(`install`);
-
-          await expect(crawlLayout(path)).resolves.toMatchObject({
-            dependencies: {
               ok: {
                 name: 'ok',
                 version: '1.0.0',
               },
               devDep: {
                 name: 'devDep',
-                dependencies: {
-                  ok: {
-                    name: 'ok',
-                    version: '2.0.0',
-                  },
-                },
+                dependencies: {},
               },
             },
           });
@@ -217,91 +165,22 @@ module.exports = (makeTemporaryEnv: PackageDriver) => {
           const layout = await crawlLayout(path);
           await expect(layout).toMatchObject({
             dependencies: {
+              ok: {
+                name: 'ok',
+              },
               devDep: {
                 name: 'devDep',
-                dependencies: {
-                  ok: {
-                    name: 'ok',
-                  },
-                },
+                dependencies: {},
               },
               devDep2: {
                 name: 'devDep2',
-                dependencies: {
-                  ok: {
-                    name: 'ok',
-                  },
-                },
+                dependencies: {},
               },
             },
           });
-          expect(layout).not.toHaveProperty('dependencies.ok');
         },
       ),
     );
 
-    test(
-      `it should handle two devDeps having conflicting dep`,
-      makeTemporaryEnv(
-        {
-          name: 'root',
-          version: '1.0.0',
-          devDependencies: {devDep: `1.0.0`, devDep2: '1.0.0'},
-        },
-        async ({path, run, source}) => {
-          await definePackage({
-            name: 'devDep',
-            version: '1.0.0',
-            dependencies: {
-              ok: '^1',
-            },
-          });
-          await definePackage({
-            name: 'devDep2',
-            version: '1.0.0',
-            dependencies: {
-              ok: '^2',
-            },
-          });
-          await definePackage({
-            name: 'ok',
-            version: '1.0.0',
-            dependencies: {},
-          });
-          await definePackage({
-            name: 'ok',
-            version: '2.0.0',
-            dependencies: {},
-          });
-
-          await run(`install`);
-
-          const layout = await crawlLayout(path);
-          await expect(layout).toMatchObject({
-            dependencies: {
-              devDep: {
-                name: 'devDep',
-                dependencies: {
-                  ok: {
-                    name: 'ok',
-                    version: '1.0.0',
-                  },
-                },
-              },
-              devDep2: {
-                name: 'devDep2',
-                dependencies: {
-                  ok: {
-                    name: 'ok',
-                    version: '2.0.0',
-                  },
-                },
-              },
-            },
-          });
-          expect(layout).not.toHaveProperty('dependencies.ok');
-        },
-      ),
-    );
   });
 };


### PR DESCRIPTION
`devDependencies` now override `dependencies` for the root project.

This enables the workflow where you specify constraint in `dependencies` but specify an exact version of a package in `devDependencies` — useful for `ocaml` dependency:
```
  "dependencies": {
    "ocaml": ">= 4.2.0"
  },
  "devDependencies": {
    "ocaml": "4.6.1"
  }
```