### PR TITLE
Windows Support: Add .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Declare shell files to have LF endings on checkout
+# On Windows, the default git setting for `core.autocrlf`
+# means that when checking out code, LF endings get converted
+# to CRLF. This causes problems for shell scripts, as bash
+# gets choked up on the extra `\r` character.
+*.sh text eol=LF


### PR DESCRIPTION
Small change to support checking out on Windows machines. 

The default git `core.autocrlf` behavior causes the line endings in shell scripts to get messed up - this fixes it.