### PR TITLE
[WIP] Initial bootstrapped Windows build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,6 @@ install:
     - npm run bootstrap:install-dependencies
 
 build_script:
-    - echo TODO
+    - npm run bootstrap:build
 
 test: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,11 @@ platform:
     - x86
 
 install:
+    - npm install -g rimraf
+    - rimraf C:\cygwin
+    - rimraf C:\cygwin64
+    - rimraf C:\mingw-w64
+    - rimraf C:\MinGw
     - npm install
     - npm run bootstrap:install-opam
     - npm run bootstrap:install-dependencies

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,9 @@ platform:
     - x64
     - x86
 
+cache:
+    - '%LocalAppData%\.opam'
+
 install:
     - npm install -g rimraf
     - rimraf C:\cygwin

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,13 @@
+platform:
+    - x64
+    - x86
+
+install:
+    - npm install
+    - npm run bootstrap:install-opam
+    - npm run bootstrap:install-dependencies
+
+build_script:
+    - echo TODO
+
+test: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,4 +17,8 @@ install:
 build_script:
     - npm run bootstrap:build
 
+artifacts:
+    - path: _release
+      name: esy-windows
+
 test: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,5 @@
 platform:
     - x64
-    - x86
 
 cache:
     - '%LocalAppData%\.opam'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,7 @@ install:
     - npm run bootstrap:install-dependencies
 
 build_script:
+    - npm run cygwin:check-dll
     - npm run bootstrap:build
 
 artifacts:

--- a/esy/System.ml
+++ b/esy/System.ml
@@ -21,4 +21,4 @@ let gethost () =
   | "Cygwin" -> Cygwin
   | _ -> Other
 
-let host = uname ()
+let host = gethost ()

--- a/esy/System.ml
+++ b/esy/System.ml
@@ -1,6 +1,7 @@
 type system =
   | Darwin
   | Linux
+  | Windows
   | Cygwin
   | Other
 
@@ -11,6 +12,13 @@ let uname () =
   match String.lowercase_ascii(uname) with
   | "linux" -> Linux
   | "darwin" -> Darwin
+  | _ -> Other
+
+let gethost () =
+  match Sys.os_type with
+  | "Unix" -> uname ()
+  | "Win32" -> Windows
+  | "Cygwin" -> Cygwin
   | _ -> Other
 
 let host = uname ()

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "bootstrap:install-opam": "esy-bash ./scripts/bootstrap/install-opam-windows.sh",
     "bootstrap:install-dependencies": "esy-bash ./scripts/bootstrap/install-opam-dependencies.sh",
     "bootstrap:build": "esy-bash ./scripts/bootstrap/build-bootstrap.sh",
+    "cygwin:check-dll": "esy-bash where cygwin1.dll",
     "postinstall": "esy-bash ./scripts/postinstall.sh"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "description": "Esy sandboxes for compiled languages",
   "dependencies": {
     "@esy-ocaml/esy-opam": "0.0.15",
-    "esy-solve-cudf": "^0.0.3",
     "esy-bash": "^0.1.9"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -5,10 +5,11 @@
   "description": "Esy sandboxes for compiled languages",
   "dependencies": {
     "@esy-ocaml/esy-opam": "0.0.15",
-    "esy-solve-cudf": "^0.0.3"
+    "esy-solve-cudf": "^0.0.3",
+    "esy-bash": "^0.1.9"
   },
   "scripts": {
-    "postinstall": "bash ./scripts/postinstall.sh"
+    "postinstall": "esy-bash ./scripts/postinstall.sh"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "esy-bash": "^0.1.9"
   },
   "scripts": {
+    "bootstrap:install-opam": "esy-bash ./scripts/bootstrap/install-opam-windows.sh",
+    "bootstrap:install-dependencies": "esy-bash ./scripts/bootstrap/install-opam-dependencies.sh",
     "postinstall": "esy-bash ./scripts/postinstall.sh"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "bootstrap:install-opam": "esy-bash ./scripts/bootstrap/install-opam-windows.sh",
     "bootstrap:install-dependencies": "esy-bash ./scripts/bootstrap/install-opam-dependencies.sh",
+    "bootstrap:build": "esy-bash ./scripts/bootstrap/build-bootstrap.sh",
     "postinstall": "esy-bash ./scripts/postinstall.sh"
   },
   "repository": {

--- a/scripts/bootstrap/Makefile.bootstrap
+++ b/scripts/bootstrap/Makefile.bootstrap
@@ -1,0 +1,179 @@
+.DELETE_ON_ERROR:
+
+ESY_EXT := $(shell command -v esy 2> /dev/null)
+
+RELEASE_TAG ?= latest
+BIN = $(PWD)/node_modules/.bin
+PROJECTS = esy esy-build-package esyi
+
+#
+# Tools
+#
+
+.DEFAULT: help
+
+define HELP
+
+ Run "make bootstrap" if this is your first time with esy development. After
+ that you can use "bin/esy" executable to run the development version of esy
+ command. Enjoy!
+
+ Common tasks:
+
+   bootstrap           Bootstrap the development environment
+   test                Run tests
+   clean               Clean build artefacts
+
+ Release tasks:
+
+   publish             Build release and run 'npm publish'
+   build-release       Produce an npm package ready to be published (useful for debug)
+
+   bump-major-version  Bump major package version (commits & tags)
+   bump-minor-version  Bump minor package version (commits & tags)
+   bump-patch-version  Bump patch package version (commits & tags)
+
+ Website tasks:
+
+   site-serve          Serve site locally
+   site-publish        Publish site to https://esy.sh (powered by GitHub Pages)
+                       Note that the current USER environment variable will be used as a
+                       GitHub user used for push. You can override it by setting GIT_USER
+                       env: make GIT_USER=anna publish
+
+ Other tasks:
+
+   refmt               Reformal all *.re source with refmt
+
+endef
+export HELP
+
+help:
+	@echo "$$HELP"
+
+bootstrap:
+	@git submodule init
+	@git submodule update
+	@make -C esy-install bootstrap
+	@make build-dev
+	@make -C test-e2e bootstrap
+	@make -C test-e2e/pkg-tests bootstrap
+	@ln -s $$(esy which fastreplacestring) $(PWD)/bin/fastreplacestring
+	@make -C site bootstrap
+
+doctoc:
+	@$(BIN)/doctoc --notitle ./README.md
+
+clean:
+	@jbuilder clean
+
+build:
+	@jbuilder build -j 4 $(TARGETS)
+
+b: build-dev
+build-dev:
+	@jbuilder build -j 4 --dev $(TARGETS)
+
+#
+# Test
+#
+
+JEST = $(BIN)/jest --runInBand
+
+test-unit::
+	@jbuilder build --dev @runtest
+
+test-e2e::
+	@make -C test-e2e test
+
+test-e2e-esyi::
+	@make -C test-e2e/pkg-tests test
+
+test-opam::
+	$(MAKE) -C __tests__/opam
+
+
+test::
+	@echo "Running test suite: unit tests"
+	@$(MAKE) test-unit
+	@echo "Running test suite: e2e"
+	@$(MAKE) test-e2e
+	@echo "Running test suite: e2e installer"
+	@$(MAKE) test-e2e-esyi
+
+ci:: test
+
+#
+# Release
+#
+
+RELEASE_ROOT = _release
+RELEASE_FILES = \
+	bin/esy \
+	bin/fastreplacestring.exe \
+	bin/esy-install.js \
+	bin/esyInstallRelease.js \
+	scripts/postinstall.sh \
+	package.json \
+	_build/default/esy-build-package/bin/esyBuildPackageCommand.exe \
+	_build/default/esy/bin/esyCommand.exe
+
+build-release:
+	@$(MAKE) build
+	@$(MAKE) build-release-copy-artifacts
+
+build-release-copy-artifacts:
+	@$(MAKE) -j $(RELEASE_FILES:%=$(RELEASE_ROOT)/%)
+
+$(RELEASE_ROOT)/_build/default/esy/bin/esyCommand.exe:
+	@mkdir -p $(@D)
+	@cp _build/default/esy/bin/esyCommand.exe $(@)
+
+$(RELEASE_ROOT)/_build/default/esy-build-package/bin/esyBuildPackageCommand.exe:
+	@mkdir -p $(@D)
+	@cp _build/default/esy-build-package/bin/esyBuildPackageCommand.exe $(@)
+
+$(RELEASE_ROOT)/_build/default/esyi/bin/esyi-darwin.exe:
+	@mkdir -p $(@D)
+	@cp _build/default/esyi/bin/esyi.exe $(@)
+
+$(RELEASE_ROOT)/_build/default/esyi/bin/esyi.exe:
+	@mkdir -p $(@D)
+	@touch $(@)
+
+$(RELEASE_ROOT)/bin/esy-install.js:
+	@$(MAKE) -C esy-install BUILD=../$(@) build
+
+$(RELEASE_ROOT)/bin/fastreplacestring-darwin:
+	@mkdir -p $(@D)
+	@cp $$(esy which fastreplacestring) $(@)
+
+$(RELEASE_ROOT)/%: $(PWD)/%
+	@mkdir -p $(@D)
+	@cp $(<) $(@)
+
+publish: build-release
+	@(cd $(RELEASE_ROOT) && npm publish --access public --tag $(RELEASE_TAG))
+	@git push && git push --tags
+
+bump-major-version:
+	@npm version major
+
+bump-minor-version:
+	@npm version minor
+
+bump-patch-version:
+	@npm version patch
+
+refmt::
+	@find $(PROJECTS) -name '*.re' \
+		| xargs -n1 esy refmt --in-place --print-width 80
+
+## Website
+
+site-start:
+	@$(MAKE) -C site start
+site-build:
+	@$(MAKE) -C site build
+site-publish:
+	@$(MAKE) -C site publish

--- a/scripts/bootstrap/build-bootstrap.sh
+++ b/scripts/bootstrap/build-bootstrap.sh
@@ -2,10 +2,10 @@
 
 cp scripts/bootstrap/Makefile.bootstrap Makefile
 
-# Not sure why this needs to be run multiple times..
-# https://github.com/esy/esy/issues/213
-make bootstrap
-make bootstrap
-make bootstrap
+make _release/bin/esy-install.js
+make _release/bin/esyInstallRelease.js
+make _release/scripts/postinstall.sh
+make _release/package.json
+make _release/_build/default/esy-build-package/bin/esyBuildPackageCommand.exe
+make _release/_build/default/esy/bin/esyCommand.exe
 
-make build-release

--- a/scripts/bootstrap/build-bootstrap.sh
+++ b/scripts/bootstrap/build-bootstrap.sh
@@ -2,6 +2,9 @@
 
 cp scripts/bootstrap/Makefile.bootstrap Makefile
 
+jbuilder build _build/default/esy-build-package/bin/esyBuildPackageCommand.exe
+jbuilder build _build/default/esy/bin/esyCommand.exe
+
 make _release/bin/esy-install.js
 make _release/bin/esyInstallRelease.js
 make _release/scripts/postinstall.sh

--- a/scripts/bootstrap/build-bootstrap.sh
+++ b/scripts/bootstrap/build-bootstrap.sh
@@ -2,6 +2,9 @@
 
 cp scripts/bootstrap/Makefile.bootstrap Makefile
 
+make bootstrap
+make bootstrap
+
 jbuilder build _build/default/esy-build-package/bin/esyBuildPackageCommand.exe
 jbuilder build _build/default/esy/bin/esyCommand.exe
 
@@ -11,4 +14,3 @@ make _release/scripts/postinstall.sh
 make _release/package.json
 make _release/_build/default/esy-build-package/bin/esyBuildPackageCommand.exe
 make _release/_build/default/esy/bin/esyCommand.exe
-

--- a/scripts/bootstrap/build-bootstrap.sh
+++ b/scripts/bootstrap/build-bootstrap.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env sh
 
 cp scripts/bootstrap/Makefile.bootstrap Makefile
+
+# Not sure why this needs to be run multiple times..
+# https://github.com/esy/esy/issues/213
 make bootstrap
+make bootstrap
+make bootstrap
+
 make build-release

--- a/scripts/bootstrap/build-bootstrap.sh
+++ b/scripts/bootstrap/build-bootstrap.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+
+cp scripts/bootstrap/Makefile.bootstrap Makefile
+make bootstrap
+make build-release

--- a/scripts/bootstrap/install-opam-dependencies.sh
+++ b/scripts/bootstrap/install-opam-dependencies.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env sh
+
+# install-opam-dependencies.sh
+#
+# This installs OPAM dependencies such that `esy` can be built without depending on `esy` itself.
+
+opam install --yes ocaml-migrate-parsetree
+opam install --yes reason
+opam install --yes cmdliner
+opam install --yes lwt
+opam install --yes menhir
+opam install --yes ppx_let
+opam install --yes ppx_deriving_yojson
+opam install --yes lwt_ppx
+opam install --yes yojson
+opam install --yes bos
+opam install --yes re

--- a/scripts/bootstrap/install-opam-windows.sh
+++ b/scripts/bootstrap/install-opam-windows.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env sh
+
+# Helper script to setup the OPAM repository & OCaml/Reason build tools
+#
+# Uses the forked OPAM repository for Windows here:
+# https://github.com/fdopen/opam-repository-mingw
+#
+# Other aspects of the script are based on the ocaml-ci-scripts:
+# https://github.com/ocaml/ocaml-ci-scripts/blob/master/appveyor-opam.sh
+
+SWITCH=${OPAM_SWITCH:-'4.06.1+mingw64c'}
+OPAM_URL='https://github.com/fdopen/opam-repository-mingw/releases/download/0.0.0.1/opam64.tar.xz'
+OPAM_ARCH=opam64
+
+if [ "$PROCESSOR_ARCHITECTURE" != "AMD64" ] && \
+       [ "$PROCESSOR_ARCHITEW6432" != "AMD64" ]; then
+    OPAM_URL='https://github.com/fdopen/opam-repository-mingw/releases/download/0.0.0.1/opam32.tar.xz'
+    OPAM_ARCH=opam32
+fi
+
+export OPAM_LINT="false"
+export CYGWIN='winsymlinks:native'
+export OPAMYES=1
+
+get() {
+  wget --quiet https://raw.githubusercontent.com/${fork_user}/ocaml-ci-scripts/${fork_branch}/$@
+}
+
+set -eu
+
+curl -fsSL -o "${OPAM_ARCH}.tar.xz" "${OPAM_URL}"
+tar -xf "${OPAM_ARCH}.tar.xz"
+"${OPAM_ARCH}/install.sh" --quiet
+
+opam init -a default "https://github.com/fdopen/opam-repository-mingw.git" --comp "$SWITCH" --switch "$SWITCH"
+opam update
+
+echo $(ocaml-env cygwin)
+echo $(opam config env)
+
+opam install depext-cygwinports depext

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -20,6 +20,9 @@ case $(uname) in
       mv esy-build-package/bin/esyBuildPackageCommand-linux.exe esy-build-package/bin/esyBuildPackageCommand.exe)
     ;;
   *)
+  CYGWIN*)
+    echo "No-op for now on Cygwin."
+    ;;
     echo "Unsupported operating system $(uname), exiting...";
     exit 1
     ;;

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -19,10 +19,10 @@ case $(uname) in
       mv esyi/bin/esyi-linux.exe esyi/bin/esyi.exe && \
       mv esy-build-package/bin/esyBuildPackageCommand-linux.exe esy-build-package/bin/esyBuildPackageCommand.exe)
     ;;
-  *)
   CYGWIN*)
     echo "No-op for now on Cygwin."
     ;;
+  *)
     echo "Unsupported operating system $(uname), exiting...";
     exit 1
     ;;


### PR DESCRIPTION
This is an initial set of changes towards having a bootstrapped Windows build. Because there isn't an `esy` command that works on Windows today, and the `esy` Makefile is dependent on `esy` itself - we need this separate bootstrapping to build via OPAM.

This is a set of initial changes that get `esy` building on appveyor:
- Include an `appveyor.yml`
- Add `esy-bash` to help with some of the bash scripts on Windows (it's a no-op on Linux/Mac)
- Add a few bootstrap scripts:
   - `install-opam-windows.sh` - helpers to install the OPAM windows repository  (based on https://github.com/fdopen/opam-repository-mingw)
   - `install-opam-dependencies.sh` - grabs the dependencies we need to build
   - `build-bootstrap.sh` - our existing `Makefile` depends on `esy`, so this is a slightly minimized version with the `esy` dependencies removed, and a scoped set of build targets.
- Also, first round of blocking fixes for enabling the core `esyCommand.exe` to work on Windows. Mainly, in `System.ml`, we were using `uname` to get the identity of the OS - but this won't work with a Windows native executable, so we check `Sys.os_type` first.

Locally, with these changes, I get an `esyCommand.exe` that works from a windows command prompt:
![image](https://user-images.githubusercontent.com/13532591/42069389-739fd66e-7b06-11e8-8354-41a57582adbe.png)

A few outstanding issues:
- [ ] AppVeyor build has a conflicting `cygwin1.dll` around somewhere - trying to track it down.
- [ ] We should run the `esyCommand.exe` to make sure it's actually built.

This is only the first round of fixes. Subsequent changes will be coming in separate PRs:
- `esy-install.js` fixes on Windows
- Implementation of the `Sandbox` strategy in `esy-build-package` for Windows

There's also an unfortunate nomenclature clash - we have an existing `make bootstrap` target which means something different than the bootstrap scripts I added. Let me know if you have any naming suggestions.



