### PR TITLE
Refactoring: Remove unused PathLike module in Environment.ml

### DIFF
--- a/esy/Environment.ml
+++ b/esy/Environment.ml
@@ -193,14 +193,3 @@ end = struct
     let%bind value = Value.ofBindings bindings in
     Ok (value, bindings)
 end
-
-module PathLike = struct
-
-  let make (name : string) (value : string list) =
-    let sep = match System.host, name with
-      | System.Cygwin, "OCAMLPATH" -> ";"
-      | _ -> ":"
-    in
-    value |> String.concat sep
-
-end


### PR DESCRIPTION
While I was searching around for places to update the path separator, I discovered this seemingly unused module in `Environment`. If it's unused, it's probably worth removing, so we don't have extra 'sources of truth'. 

My understanding is that this functionality is more completely represented here: https://github.com/esy/esy/blob/b9bc54232f102557820d0249e1ebd34e24c72666/esy/Task.ml#L21

