### PR TITLE
README: Update travis build badge to point to master

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 `package.json` workflow for native development with Reason/OCaml.
 
 [![AppVeyor](https://ci.appveyor.com/api/projects/status/0x1mwqeblcgpqyc0?svg=true)](https://ci.appveyor.com/project/esy/esy)
-[![Travis](https://img.shields.io/travis/esy/esy.svg)](https://travis-ci.org/esy/esy)
+[![Travis](https://travis-ci.org/esy/esy.svg?branch=master)](https://travis-ci.org/esy/esy)
 [![npm](https://img.shields.io/npm/v/esy.svg)](https://www.npmjs.com/package/esy)
 [![npm (tag)](https://img.shields.io/npm/v/esy/next.svg)](https://www.npmjs.com/package/esy)
 


### PR DESCRIPTION
Currently, our `README.md` travis build badge grabs the _latest_ build status from Travis - that could be a PR or branch build that is failing.

IMO, it's more useful to see the state of `master`  - we expect that PRs and branches might be failing, but `master` should always be green. 