### PR TITLE
Windows: NPM Release - Set up artifact publishing for Windows builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,4 +36,15 @@ artifacts:
       name: Windows Build
       type: File
 
+deploy:
+    - provider: Github
+    - repository: esy/esy
+      auth_token:
+          secure: J4V6+1KHu8UiApItmxPWArb5oMf1WnQyAc9H4GtBzEo620zFin0oRLYQ0DxCz1VW
+      draft: false
+      prerelease: false
+      force_update: true
+      on:
+          appveyor_repo_tag: true
+
 test: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,9 +29,11 @@ build_script:
     - C:\projects\esy\_release\_build\default\esy\bin\esyCommand.exe --help
 # TODO: Incorporate existing test suite - will we need to migrate from bash -> something else?
     - powershell scripts/bootstrap/Test.ps1
+    - npm run bootstrap:make-release-package
 
 artifacts:
-    - path: _release
-      name: esy-windows
+    - path: _platformrelease/*.tar.gz
+      name: Windows Build
+      type: File
 
 test: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,7 +38,7 @@ artifacts:
 
 deploy:
     - provider: Github
-    - repository: esy/esy
+      repository: esy/esy
       auth_token:
           secure: J4V6+1KHu8UiApItmxPWArb5oMf1WnQyAc9H4GtBzEo620zFin0oRLYQ0DxCz1VW
       draft: false

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "bootstrap:install-dependencies": "esy-bash ./scripts/bootstrap/install-opam-dependencies.sh",
     "bootstrap:esy-install": "cd esy-install && yarn install",
     "bootstrap:build": "esy-bash ./scripts/bootstrap/build-bootstrap.sh",
+    "bootstrap:make-release-package": "node ./scripts/bootstrap/make-release-package.js",
     "bootstrap:unit-test": "esy-bash jbuilder runtest test"
   },
   "dependencies": {

--- a/scripts/bootstrap/build-bootstrap.sh
+++ b/scripts/bootstrap/build-bootstrap.sh
@@ -35,3 +35,6 @@ make _release/bin/fastreplacestring
 
 cd _release
 npm install @esy-ocaml/esy-opam
+
+echo "release: copy esy-bash"
+cp -r ../node_modules/esy-bash node_modules/esy-bash

--- a/scripts/bootstrap/make-release-package.js
+++ b/scripts/bootstrap/make-release-package.js
@@ -1,0 +1,45 @@
+const path = require("path")
+const fs = require("fs")
+const os = require("os")
+
+const { bashExec, toCygwinPath } = require("esy-bash")
+
+const rootFolder = path.join(__dirname, "..", "..")
+const packageJson = path.join(rootFolder, "package.json")
+const packFolder = path.join(rootFolder, "_release")
+const destFolder = path.join(rootFolder, "_platformrelease")
+
+const version = require(packageJson).version
+
+const getArch = () => {
+    let arch = os.arch() == ("x32" || "ia32") ? "x86" : "x64"
+
+    if (process.env.APPVEYOR) {
+        arch = process.env.PLATFORM === "x86" ? "x86" : "x64"
+    }
+
+    return arch
+}
+
+const arch = getArch();
+
+const pack = async () => {
+    // If we pack cygwin + all the installed dependencies, the archive by itself
+    // is around 338 MB! If we pack that for both x86 + x64, we'll end up with almost 750 MB.
+    // Doesn't seem acceptable for now. The downside is the user will need to download / install
+    // cygwin as port of a postinstall step (since `esy-bash` is called out as a dependency,
+    // this should happen automatically).
+    console.log("Deleting cygwin from release folder...")
+    await bashExec(`rm -rf ${packFolder}/node_modules/esy-bash`)
+
+    console.log("Creating folder...")
+    await bashExec(`mkdir ${destFolder}`)
+
+    const cygwinDestFolder = await toCygwinPath(destFolder)
+    const cygwinPackFolder = await toCygwinPath(packFolder)
+
+    console.log(`Creating archive from ${cygwinPackFolder} in ${cygwinDestFolder}.`)
+    await bashExec(`tar -czvf ${cygwinDestFolder}/esy-windows-${version}-${arch}.tar.gz -C ${cygwinPackFolder} .`)
+}
+
+pack()


### PR DESCRIPTION
This is the first step in getting the `npm` package set up to work on Windows too - the goal is that Windows developers can run `npm install -g esy` and get started with `esy` just like any other platform.

This PR will:
- Revise the artifact we published to AppVeyor to be more in-line with the other platform-specific artifacts we publish. Since we tend to publish our packages from a non-windows platform, this means making it a `tar.gz` and having the same folder structure.
- Set up tagged builds to attach the released artifacts

In a subsequent PR, I'll hook up the `make release` step to download the windows artifacts and include them in our 'fat' npm package. 

> __NOTE:__ One consideration here was whether or not we should bundle the fully-prepped Cygwin environment. If we did that, there'd be zero friction starting with the `npm` package - however, it's very large at 338 MB. Double that for `x64` and `x86` and all of a sudden our NPM package would be almost a gig! So for  now, on Windows, we'll have to install `esy-bash` (cygwin + utilities) as a postinstall/install step. 