### PR TITLE
Improvements to esyi

### DIFF
--- a/esy-lib/Fs.ml
+++ b/esy-lib/Fs.ml
@@ -30,7 +30,11 @@ let openFile ~mode ~perm path =
 let readJsonFile (path : Path.t) =
   let open RunAsync.Syntax in
   let%bind data = readFile path in
-  return (Yojson.Safe.from_string data)
+  try return (Yojson.Safe.from_string data)
+  with Yojson.Json_error msg ->
+    let msg = Format.asprintf
+      "error reading JSON file: %a@\n%s" Path.pp path msg
+    in error msg
 
 let writeJsonFile ~json path =
   let data = Yojson.Safe.pretty_to_string json in

--- a/esy-lib/Git.ml
+++ b/esy-lib/Git.ml
@@ -89,10 +89,9 @@ let lsRemote ?ref ~remote () =
 let isCommitLikeRe = Str.regexp "^[0-9abcdef]+$"
 let isCommitLike v =
   let len = String.length v in
-  match len with
-  | 40 | 6 ->
-    Str.string_match isCommitLikeRe v 0
-  | _ -> false
+  if len >= 6
+  then Str.string_match isCommitLikeRe v 0
+  else false
 
 module ShallowClone = struct
 

--- a/esy-lib/Git.ml
+++ b/esy-lib/Git.ml
@@ -76,12 +76,10 @@ let lsRemote ?ref ~remote () =
     | Some ref -> Cmd.(cmd % ref)
     | None -> cmd
   in
-  let ref = Option.orDefault ~default:"master" ref in
   let%bind out = ChildProcess.runOut cmd in
   match out |> String.trim |> String.split_on_char '\n' with
   | [] ->
-    let msg = Printf.sprintf "Unable to resolve ref: %s" ref in
-    error msg
+    return None
   | line::_ ->
     let commit = line |> String.split_on_char '\t' |> List.hd in
     if commit = ""

--- a/esy-lib/Tarball.ml
+++ b/esy-lib/Tarball.ml
@@ -46,22 +46,27 @@ let run cmd =
 
 let unpackWithTar ?stripComponents ~dst filename =
   let open RunAsync.Syntax in
-  Fs.withTempDir begin fun out ->
-    let%bind () = run Cmd.(v "tar" % "xf" % p filename % "-C" % p out) in
-    let%bind out = stripComponentFrom ?stripComponents out in
-    let%bind () = copyAll ~src:out ~dst () in
-    return ()
-  end
+  let unpack out = run Cmd.(v "tar" % "xf" % p filename % "-C" % p out) in
+  match stripComponents with
+  | Some stripComponents ->
+    Fs.withTempDir begin fun out ->
+      let%bind () = unpack out in
+      let%bind out = stripComponentFrom ~stripComponents out in
+      copyAll ~src:out ~dst ()
+    end
+  | None -> unpack dst
 
 let unpackWithUnzip ?stripComponents ~dst filename =
   let open RunAsync.Syntax in
-  Fs.withTempDir begin fun out ->
-    let cmd = Cmd.(v "unzip" % "-q" % "-d" % p out % p filename) in
-    let%bind () = ChildProcess.run cmd in
-    let%bind out = stripComponentFrom ?stripComponents out in
-    let%bind () = copyAll ~src:out ~dst () in
-    return ()
-  end
+  let unpack out = run Cmd.(v "unzip" % "-q" % "-d" % p out % p filename) in
+  match stripComponents with
+  | Some stripComponents ->
+    Fs.withTempDir begin fun out ->
+      let%bind () = unpack out in
+      let%bind out = stripComponentFrom ~stripComponents out in
+      copyAll ~src:out ~dst ()
+    end
+  | None -> unpack dst
 
 let unpack ?stripComponents ~dst filename =
   match Path.get_ext filename with

--- a/esyi/Fetch.ml
+++ b/esyi/Fetch.ml
@@ -48,6 +48,7 @@ module Manifest = struct
     name : string;
     bin : (Bin.t option [@default None]);
     scripts : (Scripts.t [@default Scripts.empty]);
+    esy : (Json.t option [@default None]);
   } [@@deriving of_yojson { strict = false }]
 
   let ofDir path =
@@ -659,7 +660,7 @@ let fetch ~cfg:(cfg : Config.t) (solution : Solution.t) =
     let queue = LwtTaskQueue.create ~concurrency:1 () in
 
     let f = function
-      | (installation, Some manifest) ->
+      | (installation, Some ({Manifest. esy = None; _} as manifest)) ->
         let msg =
           Format.asprintf
             "running lifecycle %a"
@@ -669,6 +670,7 @@ let fetch ~cfg:(cfg : Config.t) (solution : Solution.t) =
           queue
           (runLifecycle ~installation ~manifest)
         |> RunAsync.withContext msg
+      | (_installation, Some {Manifest. esy = Some _; _})
       | (_installation, None) -> return ()
     in
 

--- a/esyi/OpamRegistry.mli
+++ b/esyi/OpamRegistry.mli
@@ -24,7 +24,7 @@ module Manifest : sig
     -> Package.t RunAsync.t
 end
 
-val init : cfg:Config.t -> unit -> t RunAsync.t
+val make : cfg:Config.t -> unit -> t
 
 val versions :
   ?ocamlVersion:OpamVersion.Version.t

--- a/esyi/Resolver.ml
+++ b/esyi/Resolver.ml
@@ -103,10 +103,10 @@ type t = {
 
 let make ?ocamlVersion ?opamRegistry ~cfg () =
   let open RunAsync.Syntax in
-  let%bind opamRegistry =
+  let opamRegistry =
     match opamRegistry with
-    | Some opamRegistry -> return opamRegistry
-    | None -> OpamRegistry.init ~cfg ()
+    | Some opamRegistry -> opamRegistry
+    | None -> OpamRegistry.make ~cfg ()
   in
   let npmRegistryQueue = LwtTaskQueue.create ~concurrency:25 () in
   return {

--- a/esyi/Solver.ml
+++ b/esyi/Solver.ml
@@ -624,7 +624,7 @@ let solve ~cfg ~resolutions (root : Package.t) =
     | _ -> failwith "only npm formulas are supported for the root manifest"
   in
 
-  let%bind opamRegistry = OpamRegistry.init ~cfg () in
+  let opamRegistry = OpamRegistry.make ~cfg () in
 
   let%bind ocamlVersion, reqs =
     match ocamlReq with

--- a/test-e2e/common/symlink-workflow-test.sh
+++ b/test-e2e/common/symlink-workflow-test.sh
@@ -5,7 +5,7 @@ doTest () {
 
   cd ./app || exit 1
 
-  run esy install
+  run esy install --skip-repository-update
 
   run esy build
   assertStdout 'esy dep' 'HELLO'

--- a/test-e2e/common/symlink-workflow-test.sh
+++ b/test-e2e/common/symlink-workflow-test.sh
@@ -12,11 +12,8 @@ doTest () {
   assertStdout 'esy another-dep' 'HELLO'
 
   info "modify dep sources"
-  cat <<EOF > ../dep/dep
-  #!/bin/bash
-
-  echo HELLO_MODIFIED
-EOF
+  printf "#!/bin/bash\necho HELLO_MODIFIED\n" > ../dep/dep
+  cat ../dep/dep
 
   run esy build
   assertStdout 'esy dep' 'HELLO_MODIFIED'

--- a/test-e2e/common/symlink-workflow-test.sh
+++ b/test-e2e/common/symlink-workflow-test.sh
@@ -5,7 +5,7 @@ doTest () {
 
   cd ./app || exit 1
 
-  run esy install --skip-repository-update
+  run esy install
 
   run esy build
   assertStdout 'esy dep' 'HELLO'


### PR DESCRIPTION
Few fixes and improvements to `esyi`:

- Allow `repo/name#commit` where `commit` is between 6 and 40 chars (inclusive), previously only 6 or 40 were allowed
- Speedup installation by doing all work with `tar` (special case for unpacking tarballs with `--strip-components=0`)
- Fix progress reporter to clean its status on error
- Fix progress reporter to be noop in case no tty is available or `CI` env var is set
- Provide nice error message in case lockfile is corrupted

