### PR TITLE
Validate checksum of download packages

### DIFF
--- a/esy-lib/Checksum.ml
+++ b/esy-lib/Checksum.ml
@@ -1,0 +1,27 @@
+type t =
+| Md5 of string
+| Sha1 of string
+[@@deriving eq, ord]
+
+let pp fmt v =
+  match v with
+  | Md5 v -> Fmt.pf fmt "md5:%s" v
+  | Sha1 v -> Fmt.pf fmt "sha1:%s" v
+
+let show v =
+  match v with
+  | Md5 v -> "md5:" ^ v
+  | Sha1 v -> "sha1:" ^ v
+
+let parse v =
+  match Astring.String.cut ~sep:":" v with
+  | Some ("md5", v) -> Ok (Md5 v)
+  | Some ("sha1", v) -> Ok (Sha1 v)
+  | Some (kind, _) -> Error ("unknown checkum kind: " ^ kind)
+  | None -> Ok (Sha1 v)
+
+let to_yojson v = `String (show v)
+let of_yojson json =
+  match json with
+  | `String v -> parse v
+  | _ -> Error "expected string"

--- a/esy-lib/Checksum.ml
+++ b/esy-lib/Checksum.ml
@@ -1,22 +1,44 @@
 type t =
 | Md5 of string
 | Sha1 of string
+| Sha256 of string
+| Sha512 of string
 [@@deriving eq, ord]
+
+let name (checksum : t) =
+  match checksum with
+  | Md5 _ -> "md5"
+  | Sha1 _ -> "sha1"
+  | Sha256 _ -> "sha256"
+  | Sha512 _ -> "sha512"
+
+let contents (checksum : t) =
+  match checksum with
+  | Md5 v
+  | Sha1 v
+  | Sha256 v
+  | Sha512 v -> v
 
 let pp fmt v =
   match v with
   | Md5 v -> Fmt.pf fmt "md5:%s" v
   | Sha1 v -> Fmt.pf fmt "sha1:%s" v
+  | Sha256 v -> Fmt.pf fmt "sha256:%s" v
+  | Sha512 v -> Fmt.pf fmt "sha512:%s" v
 
 let show v =
   match v with
   | Md5 v -> "md5:" ^ v
   | Sha1 v -> "sha1:" ^ v
+  | Sha256 v -> "sha256:" ^ v
+  | Sha512 v -> "sha512:" ^ v
 
 let parse v =
   match Astring.String.cut ~sep:":" v with
   | Some ("md5", v) -> Ok (Md5 v)
   | Some ("sha1", v) -> Ok (Sha1 v)
+  | Some ("sha256", v) -> Ok (Sha256 v)
+  | Some ("sha512", v) -> Ok (Sha512 v)
   | Some (kind, _) -> Error ("unknown checkum kind: " ^ kind)
   | None -> Ok (Sha1 v)
 
@@ -25,3 +47,43 @@ let of_yojson json =
   match json with
   | `String v -> parse v
   | _ -> Error "expected string"
+
+let md5sum =
+  match System.host with
+  | System.Unix
+  | System.Darwin -> Cmd.(v "md5" % "-q")
+  | System.Linux
+  | System.Cygwin
+  | System.Windows
+  | System.Unknown -> Cmd.(v "md5sum")
+let sha1sum = Cmd.(v "shasum" % "--algorithm" % "1")
+let sha256sum = Cmd.(v "shasum" % "--algorithm" % "256")
+let sha512sum = Cmd.(v "shasum" % "--algorithm" % "512")
+
+let checkFile ~path (checksum : t) =
+  let open RunAsync.Syntax in
+
+  let%bind value =
+    let cmd =
+      match checksum with
+      | Md5 _ -> md5sum
+      | Sha1 _ -> sha1sum
+      | Sha256 _ -> sha256sum
+      | Sha512 _ -> sha512sum
+    in
+    let%bind out = ChildProcess.runOut Cmd.(cmd % p path) in
+    match Astring.String.cut ~sep:" " out with
+    | Some (v, _) -> return v
+    | None -> return (String.trim out)
+  in
+
+  let cvalue = contents checksum in
+  if cvalue = value
+  then return ()
+  else
+    let msg =
+      Printf.sprintf
+        "%s checksum mismatch: expected %s but got %s"
+        (name checksum) cvalue value
+    in
+    error msg

--- a/esy-lib/Checksum.ml
+++ b/esy-lib/Checksum.ml
@@ -1,46 +1,41 @@
-type t =
-| Md5 of string
-| Sha1 of string
-| Sha256 of string
-| Sha512 of string
+type t = kind * string
 [@@deriving eq, ord]
 
-let name (checksum : t) =
-  match checksum with
-  | Md5 _ -> "md5"
-  | Sha1 _ -> "sha1"
-  | Sha256 _ -> "sha256"
-  | Sha512 _ -> "sha512"
+and kind =
+| Md5
+| Sha1
+| Sha256
+| Sha512
 
-let contents (checksum : t) =
-  match checksum with
-  | Md5 v
-  | Sha1 v
-  | Sha256 v
-  | Sha512 v -> v
+let name (kind, _) =
+  match kind with
+  | Md5 -> "md5"
+  | Sha1 -> "sha1"
+  | Sha256 -> "sha256"
+  | Sha512 -> "sha512"
 
 let pp fmt v =
   match v with
-  | Md5 v -> Fmt.pf fmt "md5:%s" v
-  | Sha1 v -> Fmt.pf fmt "sha1:%s" v
-  | Sha256 v -> Fmt.pf fmt "sha256:%s" v
-  | Sha512 v -> Fmt.pf fmt "sha512:%s" v
+  | Md5, v -> Fmt.pf fmt "md5:%s" v
+  | Sha1, v -> Fmt.pf fmt "sha1:%s" v
+  | Sha256, v -> Fmt.pf fmt "sha256:%s" v
+  | Sha512, v -> Fmt.pf fmt "sha512:%s" v
 
 let show v =
   match v with
-  | Md5 v -> "md5:" ^ v
-  | Sha1 v -> "sha1:" ^ v
-  | Sha256 v -> "sha256:" ^ v
-  | Sha512 v -> "sha512:" ^ v
+  | Md5, v -> "md5:" ^ v
+  | Sha1, v -> "sha1:" ^ v
+  | Sha256, v -> "sha256:" ^ v
+  | Sha512, v -> "sha512:" ^ v
 
 let parse v =
   match Astring.String.cut ~sep:":" v with
-  | Some ("md5", v) -> Ok (Md5 v)
-  | Some ("sha1", v) -> Ok (Sha1 v)
-  | Some ("sha256", v) -> Ok (Sha256 v)
-  | Some ("sha512", v) -> Ok (Sha512 v)
+  | Some ("md5", v) -> Ok (Md5, v)
+  | Some ("sha1", v) -> Ok (Sha1, v)
+  | Some ("sha256", v) -> Ok (Sha256, v)
+  | Some ("sha512", v) -> Ok (Sha512, v)
   | Some (kind, _) -> Error ("unknown checkum kind: " ^ kind)
-  | None -> Ok (Sha1 v)
+  | None -> Ok (Sha1, v)
 
 let to_yojson v = `String (show v)
 let of_yojson json =
@@ -66,10 +61,10 @@ let checkFile ~path (checksum : t) =
   let%bind value =
     let cmd =
       match checksum with
-      | Md5 _ -> md5sum
-      | Sha1 _ -> sha1sum
-      | Sha256 _ -> sha256sum
-      | Sha512 _ -> sha512sum
+      | Md5, _ -> md5sum
+      | Sha1, _ -> sha1sum
+      | Sha256, _ -> sha256sum
+      | Sha512, _ -> sha512sum
     in
     let%bind out = ChildProcess.runOut Cmd.(cmd % p path) in
     match Astring.String.cut ~sep:" " out with
@@ -77,7 +72,7 @@ let checkFile ~path (checksum : t) =
     | None -> return (String.trim out)
   in
 
-  let cvalue = contents checksum in
+  let _, cvalue = checksum in
   if cvalue = value
   then return ()
   else

--- a/esy-lib/Checksum.mli
+++ b/esy-lib/Checksum.mli
@@ -1,8 +1,10 @@
-type t =
-  | Md5 of string
-  | Sha1 of string
-  | Sha256 of string
-  | Sha512 of string
+type t = kind * string
+
+and kind =
+  | Md5
+  | Sha1
+  | Sha256
+  | Sha512
 
 val equal : t -> t -> bool
 val compare : t -> t -> int

--- a/esy-lib/Checksum.mli
+++ b/esy-lib/Checksum.mli
@@ -1,0 +1,12 @@
+type t =
+  | Md5 of string
+  | Sha1 of string
+
+val equal : t -> t -> bool
+val compare : t -> t -> int
+val pp : t Fmt.t
+val show : t -> string
+val parse : string -> (t, string) result
+
+val to_yojson : t Json.encoder
+val of_yojson : t Json.decoder

--- a/esy-lib/Checksum.mli
+++ b/esy-lib/Checksum.mli
@@ -1,6 +1,8 @@
 type t =
   | Md5 of string
   | Sha1 of string
+  | Sha256 of string
+  | Sha512 of string
 
 val equal : t -> t -> bool
 val compare : t -> t -> int
@@ -10,3 +12,5 @@ val parse : string -> (t, string) result
 
 val to_yojson : t Json.encoder
 val of_yojson : t Json.decoder
+
+val checkFile : path:Path.t -> t -> unit RunAsync.t

--- a/esyi/FetchStorage.ml
+++ b/esyi/FetchStorage.ml
@@ -61,7 +61,7 @@ let fetch ~(cfg : Config.t) ({Solution.Record. name; version; source; opam; file
     | Package.Source.NoSource ->
       return ()
 
-    | Package.Source.Archive (url, _checksum)  ->
+    | Package.Source.Archive {url; checksum = _}  ->
       let f tempPath =
         let%bind () = Fs.createDir tempPath in
         let tarballPath = Path.(tempPath / Filename.basename url) in

--- a/esyi/FetchStorage.ml
+++ b/esyi/FetchStorage.ml
@@ -61,11 +61,12 @@ let fetch ~(cfg : Config.t) ({Solution.Record. name; version; source; opam; file
     | Package.Source.NoSource ->
       return ()
 
-    | Package.Source.Archive {url; checksum = _}  ->
+    | Package.Source.Archive {url; checksum}  ->
       let f tempPath =
         let%bind () = Fs.createDir tempPath in
         let tarballPath = Path.(tempPath / Filename.basename url) in
         let%bind () = Curl.download ~output:tarballPath url in
+        let%bind () = Checksum.checkFile ~path:tarballPath checksum in
         let%bind () = Tarball.unpack ~stripComponents:1 ~dst:path tarballPath in
         return ()
       in

--- a/esyi/Manifest.ml
+++ b/esyi/Manifest.ml
@@ -81,7 +81,7 @@ let ofPackageJson ?(source=Source.NoSource) (pkgJson : PackageJson.t) =
       | Some dist ->
         Source.Archive {
           url = dist.PackageJson.tarball;
-          checksum = Checksum.Sha1 dist.PackageJson.shasum;
+          checksum = Checksum.Sha1, dist.PackageJson.shasum;
         }
       | None -> source;
   }

--- a/esyi/Manifest.ml
+++ b/esyi/Manifest.ml
@@ -81,7 +81,7 @@ let ofPackageJson ?(source=Source.NoSource) (pkgJson : PackageJson.t) =
       | Some dist ->
         Source.Archive {
           url = dist.PackageJson.tarball;
-          checksum = Package.Checksum.Sha1 dist.PackageJson.shasum;
+          checksum = Checksum.Sha1 dist.PackageJson.shasum;
         }
       | None -> source;
   }

--- a/esyi/Manifest.ml
+++ b/esyi/Manifest.ml
@@ -78,7 +78,8 @@ let ofPackageJson ?(source=Source.NoSource) (pkgJson : PackageJson.t) =
     hasEsyManifest = Option.isSome pkgJson.esy;
     source =
       match pkgJson.dist with
-      | Some dist -> Source.Archive (dist.PackageJson.tarball, dist.PackageJson.shasum)
+      | Some dist ->
+        Source.Archive {url = dist.PackageJson.tarball; checksum = dist.PackageJson.shasum}
       | None -> source;
   }
 

--- a/esyi/Manifest.ml
+++ b/esyi/Manifest.ml
@@ -79,7 +79,10 @@ let ofPackageJson ?(source=Source.NoSource) (pkgJson : PackageJson.t) =
     source =
       match pkgJson.dist with
       | Some dist ->
-        Source.Archive {url = dist.PackageJson.tarball; checksum = dist.PackageJson.shasum}
+        Source.Archive {
+          url = dist.PackageJson.tarball;
+          checksum = Package.Checksum.Sha1 dist.PackageJson.shasum;
+        }
       | None -> source;
   }
 

--- a/esyi/OpamRegistry.ml
+++ b/esyi/OpamRegistry.ml
@@ -100,7 +100,7 @@ module Manifest = struct
         | Some source ->
           return (Package.Source (Package.Source.Archive {
             url = source.url;
-            checksum = Package.Checksum.Md5 source.checksum;
+            checksum = Checksum.Md5 source.checksum;
           }))
         | None -> begin
           match url with
@@ -110,7 +110,7 @@ module Manifest = struct
             | `http, Some hash ->
               return (Package.Source (Package.Source.Archive {
                 url = path;
-                checksum = Package.Checksum.Md5 hash;
+                checksum = Checksum.Md5 hash;
               }))
             | `http, None ->
               (* TODO: what to do here? fail or resolve? *)

--- a/esyi/OpamRegistry.ml
+++ b/esyi/OpamRegistry.ml
@@ -1,4 +1,5 @@
 module Source = Package.Source
+module Version = Package.Version
 module SourceSpec = Package.SourceSpec
 module String = Astring.String
 module Override = Package.OpamOverride
@@ -105,21 +106,30 @@ module Manifest = struct
         | None -> begin
           match url with
           | Some url ->
-            let {OpamUrl. backend; path; hash; _} = OpamFile.URL.url url in
-            begin match backend, hash with
-            | `http, Some hash ->
+            let%bind checksum =
+              let checksums = OpamFile.URL.checksum url in
+              let f c =
+                match OpamHash.kind c with
+                | `MD5 -> Checksum.Md5 (OpamHash.contents c)
+                | `SHA256 -> Checksum.Sha256 (OpamHash.contents c)
+                | `SHA512 -> Checksum.Sha512 (OpamHash.contents c)
+              in
+              match List.map ~f checksums with
+              | [] ->
+                error (Format.asprintf "no checksum provided for %s@%a" name Version.pp version)
+              | checksum::_ -> return checksum
+            in
+            let u = OpamFile.URL.url url in
+            begin match u.backend with
+            | `http ->
               return (Package.Source (Package.Source.Archive {
-                url = path;
-                checksum = Checksum.Md5 hash;
+                url = OpamUrl.to_string u;
+                checksum;
               }))
-            | `http, None ->
-              (* TODO: what to do here? fail or resolve? *)
-              return (Package.SourceSpec (Package.SourceSpec.Archive {url = path; checksum = None}))
-            | `rsync, _ -> error "unsupported source for opam: rsync"
-            | `hg, _ -> error "unsupported source for opam: hg"
-            | `darcs, _ -> error "unsupported source for opam: darcs"
-            | `git, ref ->
-              return (Package.SourceSpec (Package.SourceSpec.Git {remote = path; ref}))
+            | `rsync -> error "unsupported source for opam: rsync"
+            | `hg -> error "unsupported source for opam: hg"
+            | `darcs -> error "unsupported source for opam: darcs"
+            | `git -> error "unsupported source for opam: git"
             end
           | None -> return (Package.Source Package.Source.NoSource)
           end

--- a/esyi/OpamRegistry.ml
+++ b/esyi/OpamRegistry.ml
@@ -98,14 +98,20 @@ module Manifest = struct
       let%bind source =
         match override.Override.opam.Override.Opam.source with
         | Some source ->
-          return (Package.Source (Package.Source.Archive {url = source.url; checksum = source.checksum}))
+          return (Package.Source (Package.Source.Archive {
+            url = source.url;
+            checksum = Package.Checksum.Md5 source.checksum;
+          }))
         | None -> begin
           match url with
           | Some url ->
             let {OpamUrl. backend; path; hash; _} = OpamFile.URL.url url in
             begin match backend, hash with
             | `http, Some hash ->
-              return (Package.Source (Package.Source.Archive {url = path; checksum = hash}))
+              return (Package.Source (Package.Source.Archive {
+                url = path;
+                checksum = Package.Checksum.Md5 hash;
+              }))
             | `http, None ->
               (* TODO: what to do here? fail or resolve? *)
               return (Package.SourceSpec (Package.SourceSpec.Archive {url = path; checksum = None}))

--- a/esyi/OpamRegistry.ml
+++ b/esyi/OpamRegistry.ml
@@ -101,7 +101,7 @@ module Manifest = struct
         | Some source ->
           return (Package.Source (Package.Source.Archive {
             url = source.url;
-            checksum = Checksum.Md5 source.checksum;
+            checksum = Checksum.Md5, source.checksum;
           }))
         | None -> begin
           match url with
@@ -110,9 +110,9 @@ module Manifest = struct
               let checksums = OpamFile.URL.checksum url in
               let f c =
                 match OpamHash.kind c with
-                | `MD5 -> Checksum.Md5 (OpamHash.contents c)
-                | `SHA256 -> Checksum.Sha256 (OpamHash.contents c)
-                | `SHA512 -> Checksum.Sha512 (OpamHash.contents c)
+                | `MD5 -> Checksum.Md5, OpamHash.contents c
+                | `SHA256 -> Checksum.Sha256, OpamHash.contents c
+                | `SHA512 -> Checksum.Sha512, OpamHash.contents c
               in
               match List.map ~f checksums with
               | [] ->

--- a/esyi/OpamRegistry.ml
+++ b/esyi/OpamRegistry.ml
@@ -98,17 +98,17 @@ module Manifest = struct
       let%bind source =
         match override.Override.opam.Override.Opam.source with
         | Some source ->
-          return (Package.Source (Package.Source.Archive (source.url, source.checksum)))
+          return (Package.Source (Package.Source.Archive {url = source.url; checksum = source.checksum}))
         | None -> begin
           match url with
           | Some url ->
             let {OpamUrl. backend; path; hash; _} = OpamFile.URL.url url in
             begin match backend, hash with
             | `http, Some hash ->
-              return (Package.Source (Package.Source.Archive (path, hash)))
+              return (Package.Source (Package.Source.Archive {url = path; checksum = hash}))
             | `http, None ->
               (* TODO: what to do here? fail or resolve? *)
-              return (Package.SourceSpec (Package.SourceSpec.Archive (path, None)))
+              return (Package.SourceSpec (Package.SourceSpec.Archive {url = path; checksum = None}))
             | `rsync, _ -> error "unsupported source for opam: rsync"
             | `hg, _ -> error "unsupported source for opam: hg"
             | `darcs, _ -> error "unsupported source for opam: darcs"

--- a/esyi/Package.ml
+++ b/esyi/Package.ml
@@ -448,25 +448,25 @@ module Req = struct
       make ~name:"pkg" ~spec:"https://some/url#checksum",
       VersionSpec.Source (SourceSpec.Archive {
         url = "https://some/url";
-        checksum = Some (Checksum.Sha1 "checksum");
+        checksum = Some (Checksum.Sha1, "checksum");
       });
 
       make ~name:"pkg" ~spec:"http://some/url#checksum",
       VersionSpec.Source (SourceSpec.Archive {
         url = "http://some/url";
-        checksum = Some (Checksum.Sha1 "checksum");
+        checksum = Some (Checksum.Sha1, "checksum");
       });
 
       make ~name:"pkg" ~spec:"http://some/url#sha1:checksum",
       VersionSpec.Source (SourceSpec.Archive {
         url = "http://some/url";
-        checksum = Some (Checksum.Sha1 "checksum");
+        checksum = Some (Checksum.Sha1, "checksum");
       });
 
       make ~name:"pkg" ~spec:"http://some/url#md5:checksum",
       VersionSpec.Source (SourceSpec.Archive {
         url = "http://some/url";
-        checksum = Some (Checksum.Md5 "checksum");
+        checksum = Some (Checksum.Md5, "checksum");
       });
 
       make ~name:"pkg" ~spec:"file:./some/file",

--- a/esyi/Package.ml
+++ b/esyi/Package.ml
@@ -12,37 +12,6 @@ module Parse = struct
     | None -> Error ("missing " ^ sep)
 end
 
-module Checksum = struct
-
-  type t =
-  | Md5 of string
-  | Sha1 of string
-  [@@deriving eq, ord]
-
-  let pp fmt v =
-    match v with
-    | Md5 v -> Fmt.pf fmt "md5:%s" v
-    | Sha1 v -> Fmt.pf fmt "sha1:%s" v
-
-  let show v =
-    match v with
-    | Md5 v -> "md5:" ^ v
-    | Sha1 v -> "sha1:" ^ v
-
-  let parse v =
-    match String.cut ~sep:":" v with
-    | Some ("md5", v) -> Ok (Md5 v)
-    | Some ("sha1", v) -> Ok (Sha1 v)
-    | Some (kind, _) -> Error ("unknown checkum kind: " ^ kind)
-    | None -> Ok (Sha1 v)
-
-  let to_yojson v = `String (show v)
-  let of_yojson json =
-    match json with
-    | `String v -> parse v
-    | _ -> Error "expected string"
-end
-
 module Source = struct
 
   type t =

--- a/esyi/Package.mli
+++ b/esyi/Package.mli
@@ -7,7 +7,7 @@ type 'a conj = 'a list
  *)
 module Source : sig
   type t =
-      Archive of string * string
+    | Archive of {url : string ; checksum : string}
     | Git of {remote : string; commit : string}
     | Github of {user : string; repo : string; commit : string}
     | LocalPath of Path.t
@@ -55,7 +55,7 @@ end
  *)
 module SourceSpec : sig
   type t =
-      Archive of string * string option
+    | Archive of {url : string ; checksum : string option}
     | Git of {remote : string; ref : string option}
     | Github of {user : string; repo : string; ref : string option}
     | LocalPath of Path.t

--- a/esyi/Package.mli
+++ b/esyi/Package.mli
@@ -1,13 +1,28 @@
 type 'a disj = 'a list
 type 'a conj = 'a list
 
+module Checksum : sig
+  type t =
+    | Md5 of string
+    | Sha1 of string
+
+  val equal : t -> t -> bool
+  val compare : t -> t -> int
+  val pp : t Fmt.t
+  val show : t -> string
+  val parse : string -> (t, string) result
+
+  val to_yojson : t Json.encoder
+  val of_yojson : t Json.decoder
+end
+
 (**
  * This represent the concrete and stable location from which we can download
  * some package.
  *)
 module Source : sig
   type t =
-    | Archive of {url : string ; checksum : string}
+    | Archive of {url : string ; checksum : Checksum.t}
     | Git of {remote : string; commit : string}
     | Github of {user : string; repo : string; commit : string}
     | LocalPath of Path.t
@@ -55,7 +70,7 @@ end
  *)
 module SourceSpec : sig
   type t =
-    | Archive of {url : string ; checksum : string option}
+    | Archive of {url : string ; checksum : Checksum.t option}
     | Git of {remote : string; ref : string option}
     | Github of {user : string; repo : string; ref : string option}
     | LocalPath of Path.t

--- a/esyi/Package.mli
+++ b/esyi/Package.mli
@@ -1,21 +1,6 @@
 type 'a disj = 'a list
 type 'a conj = 'a list
 
-module Checksum : sig
-  type t =
-    | Md5 of string
-    | Sha1 of string
-
-  val equal : t -> t -> bool
-  val compare : t -> t -> int
-  val pp : t Fmt.t
-  val show : t -> string
-  val parse : string -> (t, string) result
-
-  val to_yojson : t Json.encoder
-  val of_yojson : t Json.decoder
-end
-
 (**
  * This represent the concrete and stable location from which we can download
  * some package.

--- a/esyi/Resolver.ml
+++ b/esyi/Resolver.ml
@@ -238,8 +238,8 @@ let resolveSource ~name ~(sourceSpec : SourceSpec.t) (resolver : t) =
     | SourceSpec.NoSource ->
       return (Source.NoSource)
 
-    | SourceSpec.Archive {url = _; checksum = None} ->
-      failwith "archive sources without checksums are not implemented"
+    | SourceSpec.Archive {url; checksum = None} ->
+      failwith ("archive sources without checksums are not implemented: " ^ url)
     | SourceSpec.Archive {url; checksum = Some checksum} ->
       return (Source.Archive {url; checksum})
 

--- a/esyi/Resolver.ml
+++ b/esyi/Resolver.ml
@@ -238,11 +238,11 @@ let resolveSource ~name ~(sourceSpec : SourceSpec.t) (resolver : t) =
     | SourceSpec.NoSource ->
       return (Source.NoSource)
 
-    | SourceSpec.Archive (url, None) ->
+    | SourceSpec.Archive {url; checksum = None} ->
       (* TODO: acquire checksum *)
-      return (Source.Archive (url, "fakechecksum"))
-    | SourceSpec.Archive (url, Some checksum) ->
-      return (Source.Archive (url, checksum))
+      return (Source.Archive {url; checksum = "fakechecksum"})
+    | SourceSpec.Archive {url; checksum = Some checksum} ->
+      return (Source.Archive {url; checksum})
 
     | SourceSpec.LocalPath p ->
       return (Source.LocalPath p)

--- a/esyi/Resolver.ml
+++ b/esyi/Resolver.ml
@@ -238,9 +238,8 @@ let resolveSource ~name ~(sourceSpec : SourceSpec.t) (resolver : t) =
     | SourceSpec.NoSource ->
       return (Source.NoSource)
 
-    | SourceSpec.Archive {url; checksum = None} ->
-      (* TODO: acquire checksum *)
-      return (Source.Archive {url; checksum = "fakechecksum"})
+    | SourceSpec.Archive {url = _; checksum = None} ->
+      failwith "archive sources without checksums are not implemented"
     | SourceSpec.Archive {url; checksum = Some checksum} ->
       return (Source.Archive {url; checksum})
 

--- a/test-e2e-esyi/pkg-integrity.test.js
+++ b/test-e2e-esyi/pkg-integrity.test.js
@@ -1,0 +1,34 @@
+/* @flow */
+
+const tests = require('./setup');
+
+describe('Testing integrity of downloaded packages', function() {
+  test(
+    `it should fail on corrupted tarballs`,
+    tests.makeTemporaryEnv(
+      {
+        name: 'root',
+        version: '1.0.0',
+        esy: {},
+        dependencies: {dep: `1.0.0`},
+      },
+      async ({path, run, source}) => {
+        await tests.definePackage(
+          {
+            name: 'dep',
+            version: '1.0.0',
+            esy: {},
+            dependencies: {},
+          },
+          {shasum: 'dummy-invalid-shasum'},
+        );
+
+        try {
+          await run(`install`);
+        } catch (err) {
+          expect(/sha1 checksum mismatch/.exec(err)).toBeTruthy();
+        }
+      },
+    ),
+  );
+});


### PR DESCRIPTION
Validate checksums of downloaded npm and opam packages.

I use `shasum` and `md5sum` programs for that (mostly because it is simpler and can be done by spawning processes so that it doesn't block lwt event loop).

@bryphe, is it ok to use `shasum` and `md5sum` on windows via cygwin? If not we can use some OCaml/C library for that instead.