### PR TITLE
esyi: add --cache-tarballs-path

### DIFF
--- a/esyi/Config.re
+++ b/esyi/Config.re
@@ -2,7 +2,7 @@ type t = {
   esySolveCmd: Cmd.t,
   basePath: Path.t,
   lockfilePath: Path.t,
-  tarballCachePath: Path.t,
+  cacheTarballsPath: Path.t,
   esyOpamOverride: checkout,
   opamRepository: checkout,
   npmRegistry: string,
@@ -35,6 +35,7 @@ let make =
     (
       ~npmRegistry=?,
       ~cachePath=?,
+      ~cacheTarballsPath=?,
       ~opamRepository=?,
       ~esyOpamOverride=?,
       ~solveTimeout=8.0,
@@ -57,8 +58,12 @@ let make =
           ),
         );
 
-      let tarballCachePath = Path.(cachePath / "tarballs");
-      let%bind () = Fs.createDir(tarballCachePath);
+      let cacheTarballsPath =
+        switch (cacheTarballsPath) {
+        | Some(cacheTarballsPath) => cacheTarballsPath
+        | None => Path.(cachePath / "tarballs")
+        };
+      let%bind () = Fs.createDir(cacheTarballsPath);
 
       let opamRepository = {
         let defaultRemote = "https://github.com/ocaml/opam-repository";
@@ -80,7 +85,7 @@ let make =
         esySolveCmd,
         basePath,
         lockfilePath: Path.(basePath / "esyi.lock.json"),
-        tarballCachePath,
+        cacheTarballsPath,
         opamRepository,
         esyOpamOverride,
         npmRegistry,

--- a/esyi/Config.rei
+++ b/esyi/Config.rei
@@ -5,7 +5,7 @@ type t = {
 
   basePath: Path.t,
   lockfilePath: Path.t,
-  tarballCachePath: Path.t,
+  cacheTarballsPath: Path.t,
 
   esyOpamOverride: checkout,
   opamRepository: checkout,
@@ -33,6 +33,7 @@ and checkoutCfg = [
 let make : (
     ~npmRegistry: string=?,
     ~cachePath: Fpath.t=?,
+    ~cacheTarballsPath: Fpath.t=?,
     ~opamRepository: checkoutCfg=?,
     ~esyOpamOverride: checkoutCfg=?,
     ~solveTimeout: float=?,

--- a/esyi/FetchStorage.ml
+++ b/esyi/FetchStorage.ml
@@ -169,7 +169,7 @@ let fetch ~(cfg : Config.t) ({Solution.Record. name; version; source; opam; file
 
     in
 
-    let tarballPath = Path.(cfg.tarballCachePath // v key |> addExt "tgz") in
+    let tarballPath = Path.(cfg.cacheTarballsPath // v key |> addExt "tgz") in
 
     let dist = {Dist. tarballPath = Some tarballPath; name; version; source} in
     let%bind tarballIsInCache = Fs.exists tarballPath in

--- a/esyi/bin/esyi.re
+++ b/esyi/bin/esyi.re
@@ -157,6 +157,15 @@ module CommandLineInterface = {
     );
   };
 
+  let cacheTarballsPath = {
+    let doc = "Specifies tarballs cache directory.";
+    Arg.(
+      value
+      & opt(some(Cli.pathConv), None)
+      & info(["cache-tarballs-path"], ~docs, ~doc)
+    );
+  };
+
   let cachePathArg = {
     let doc = "Specifies cache directory..";
     let env = Arg.env_var("ESYI__CACHE", ~doc);
@@ -194,6 +203,7 @@ module CommandLineInterface = {
         (
           cachePath,
           sandboxPath,
+          cacheTarballsPath,
           opamRepository,
           esyOpamOverride,
           npmRegistry,
@@ -224,6 +234,7 @@ module CommandLineInterface = {
         ~esySolveCmd,
         ~createProgressReporter,
         ~cachePath?,
+        ~cacheTarballsPath?,
         ~npmRegistry?,
         ~opamRepository?,
         ~esyOpamOverride?,
@@ -236,6 +247,7 @@ module CommandLineInterface = {
       const(parse)
       $ cachePathArg
       $ sandboxPathArg
+      $ cacheTarballsPath
       $ opamRepositoryArg
       $ esyOpamOverrideArg
       $ npmRegistryArg


### PR DESCRIPTION
This is the analogue of "offline mirrors" feature of yarn:

    esy install --cache-tarballs-path ./_cache

will fetch tarballs into _cache directory and then subsequent

    esy install --cache-tarballs-path ./_cache

commands will use this directory to get packages sources from.

Such directory could be shipped to an offline machine and then `esy install` could still be used to perform installation.