### PR TITLE
Support for multiple package sources and opam-urls.txt

### DIFF
--- a/esy-lib/Curl.mli
+++ b/esy-lib/Curl.mli
@@ -6,12 +6,19 @@ type response =
   | Success of string
   | NotFound
 
+type headers = string StringMap.t
+
 type url = string
 
 val getOrNotFound :
   ?accept : string
   -> url
   -> response RunAsync.t
+
+(** Return map of headers for the urls, all header names are lowercased *)
+val head :
+  url
+  -> headers RunAsync.t
 
 val get :
   ?accept : string

--- a/esyi/Config.re
+++ b/esyi/Config.re
@@ -3,6 +3,7 @@ type t = {
   basePath: Path.t,
   lockfilePath: Path.t,
   cacheTarballsPath: Path.t,
+  opamArchivesIndexPath: Path.t,
   esyOpamOverride: checkout,
   opamRepository: checkout,
   npmRegistry: string,
@@ -65,6 +66,8 @@ let make =
         };
       let%bind () = Fs.createDir(cacheTarballsPath);
 
+      let opamArchivesIndexPath = Path.(cachePath / "opam-urls.txt");
+
       let opamRepository = {
         let defaultRemote = "https://github.com/ocaml/opam-repository";
         let defaultLocal = Path.(cachePath / "opam-repository");
@@ -86,6 +89,7 @@ let make =
         basePath,
         lockfilePath: Path.(basePath / "esyi.lock.json"),
         cacheTarballsPath,
+        opamArchivesIndexPath,
         opamRepository,
         esyOpamOverride,
         npmRegistry,

--- a/esyi/Config.rei
+++ b/esyi/Config.rei
@@ -6,6 +6,7 @@ type t = {
   basePath: Path.t,
   lockfilePath: Path.t,
   cacheTarballsPath: Path.t,
+  opamArchivesIndexPath: Path.t,
 
   esyOpamOverride: checkout,
   opamRepository: checkout,

--- a/esyi/Fetch.ml
+++ b/esyi/Fetch.ml
@@ -178,7 +178,7 @@ module Layout = struct
       let version = Package.Version.Npm (SemverVersion.Version.parseExn version) in
       let record = Record.{
         name; version;
-        source = Package.Source.NoSource; opam = None; files = [];
+        source = Package.Source.NoSource, []; opam = None; files = [];
       } in
       Solution.make record dependencies
 
@@ -457,7 +457,8 @@ module Layout = struct
       let record = Solution.record root in
       let path = Path.(path / "node_modules" // v record.Record.name) in
       let sourcePath =
-        match record.Record.source with
+        let main, _ = record.Record.source in
+        match main with
         | Package.Source.Archive _
         | Package.Source.Git _
         | Package.Source.Github _

--- a/esyi/FetchStorage.ml
+++ b/esyi/FetchStorage.ml
@@ -13,10 +13,11 @@ module Dist = struct
     Fmt.pf fmt "%s@%a" dist.name Package.Version.pp dist.version
 end
 
-let packageKey (pkg : Solution.Record.t) =
-  let version = Package.Version.toString pkg.version in
-  match pkg.opam with
-  | None -> Printf.sprintf "%s__%s" pkg.name version
+let cacheId source (record : Solution.Record.t) =
+  let source = Package.Source.toString source in
+  match record.opam with
+  | None ->
+    Printf.sprintf "%s__%s" record.name source
   | Some opam ->
     let manifestHash =
       opam.opam
@@ -38,37 +39,37 @@ let packageKey (pkg : Solution.Record.t) =
         |> String.Sub.v ~start:0 ~stop:8
         |> String.Sub.to_string
       in
-      Printf.sprintf "%s__%s__%s__%s" pkg.name version manifestHash overrideHash
-    | None -> Printf.sprintf "%s__%s__%s" pkg.name version manifestHash
+      Printf.sprintf "%s__%s__%s__%s" record.name source manifestHash overrideHash
+    | None -> Printf.sprintf "%s__%s__%s" record.name source manifestHash
     end
 
-let fetch ~(cfg : Config.t) ({Solution.Record. name; version; source; opam; files} as record) =
+let fetch ~(cfg : Config.t) (record : Solution.Record.t) =
   let open RunAsync.Syntax in
 
-  let key = packageKey record in
-
-  let doFetch path =
+  let doFetch path source =
     match source with
 
     | Package.Source.LocalPath _ ->
-      let msg = "Fetching " ^ name ^ ": NOT IMPLEMENTED" in
+      let msg = "Fetching " ^ record.name ^ ": NOT IMPLEMENTED" in
       failwith msg
 
     | Package.Source.LocalPathLink _ ->
       (* this case is handled separately *)
-      return ()
+      return `Done
 
     | Package.Source.NoSource ->
-      return ()
+      return `Done
 
     | Package.Source.Archive {url; checksum}  ->
       let f tempPath =
         let%bind () = Fs.createDir tempPath in
         let tarballPath = Path.(tempPath / Filename.basename url) in
-        let%bind () = Curl.download ~output:tarballPath url in
-        let%bind () = Checksum.checkFile ~path:tarballPath checksum in
-        let%bind () = Tarball.unpack ~stripComponents:1 ~dst:path tarballPath in
-        return ()
+        match%lwt Curl.download ~output:tarballPath url with
+        | Ok () ->
+          let%bind () = Checksum.checkFile ~path:tarballPath checksum in
+          let%bind () = Tarball.unpack ~stripComponents:1 ~dst:path tarballPath in
+          return `Done
+        | Error err -> return (`TryNext err)
       in
       Fs.withTempDir f
 
@@ -85,7 +86,7 @@ let fetch ~(cfg : Config.t) ({Solution.Record. name; version; source; opam; file
           Curl.download ~output:tarballPath url
         in
         let%bind () =  Tarball.unpack ~stripComponents:1 ~dst:path tarballPath in
-        return ()
+        return `Done
       in
       Fs.withTempDir f
 
@@ -93,115 +94,157 @@ let fetch ~(cfg : Config.t) ({Solution.Record. name; version; source; opam; file
       let%bind () = Git.clone ~dst:path ~remote:git.remote () in
       let%bind () = Git.checkout ~ref:git.commit ~repo:path () in
       let%bind () = Fs.rmPath Path.(path / ".git") in
-      return ()
+      return `Done
+  in
+
+  let commit path source =
+    let key = cacheId source record in
+
+    let removeEsyJsonIfExists () =
+      let esyJson = Path.(path / "esy.json") in
+      match%bind Fs.exists(esyJson) with
+      | true -> Fs.unlink(esyJson)
+      | false -> return ()
     in
 
-    let complete path =
-
-      let removeEsyJsonIfExists () =
-        let esyJson = Path.(path / "esy.json") in
-        match%bind Fs.exists(esyJson) with
-        | true -> Fs.unlink(esyJson)
-        | false -> return ()
-      in
-
-      let%bind () =
-        match opam with
-        | Some { name; version; opam; override } ->
-          let%bind () = removeEsyJsonIfExists() in
-          let data =
-            Format.asprintf
-              "name: \"%a\"\nversion: \"%a\"\n%a"
-              Package.Opam.OpamName.pp name
-              Package.Opam.OpamVersion.pp version
-              Package.Opam.OpamFile.pp opam
-          in
-          let%bind () = Fs.createDir Path.(path / "_esy") in
-          let%bind () = Fs.writeFile ~data Path.(path / "_esy" / "opam") in
-          let%bind () =
-            match override with
-            | Some override ->
-              let json = Package.OpamOverride.to_yojson override in
-              Fs.writeJsonFile ~json Path.(path / "_esy" / "override.json")
-            | None -> return ()
-          in
-          return ()
-        | None -> return ()
-      in
-
-      let%bind () =
-        let f {Package.File. name; content} =
-          let name = Path.append path name in
-          let dirname = Path.parent name in
-          let%bind () = Fs.createDir dirname in
-          (* TODO: move this to the place we read data from *)
-          let contents =
-            if String.get content (String.length content - 1) == '\n'
-            then content
-            else content ^ "\n"
-          in
-          let%bind () = Fs.writeFile ~data:contents name in
-          return()
+    let%bind () =
+      match record.opam with
+      | Some { name; version; opam; override } ->
+        let%bind () = removeEsyJsonIfExists() in
+        let data =
+          Format.asprintf
+            "name: \"%a\"\nversion: \"%a\"\n%a"
+            Package.Opam.OpamName.pp name
+            Package.Opam.OpamVersion.pp version
+            Package.Opam.OpamFile.pp opam
         in
-        List.map ~f files |> RunAsync.List.waitAll
-      in
-
-      let%bind () =
-        let addResolvedFieldToPackageJson filename =
-          match%bind Fs.readJsonFile filename with
-          | `Assoc items ->
-            let json = `Assoc (("_resolved", `String key)::items) in
-            let data = Yojson.Safe.pretty_to_string json in
-            Fs.writeFile ~data filename
-          | _ -> error "invalid package.json"
+        let%bind () = Fs.createDir Path.(path / "_esy") in
+        let%bind () = Fs.writeFile ~data Path.(path / "_esy" / "opam") in
+        let%bind () =
+          match override with
+          | Some override ->
+            let json = Package.OpamOverride.to_yojson override in
+            Fs.writeJsonFile ~json Path.(path / "_esy" / "override.json")
+          | None -> return ()
         in
-
-        let esyJson = Path.(path / "esy.json") in
-        let packageJson = Path.(path / "package.json") in
-        if%bind Fs.exists esyJson
-        then addResolvedFieldToPackageJson esyJson
-        else if%bind Fs.exists packageJson
-        then addResolvedFieldToPackageJson packageJson
-        else return ()
-      in
-
-      return ()
-
+        return ()
+      | None -> return ()
     in
 
+    let%bind () =
+      let f {Package.File. name; content} =
+        let name = Path.append path name in
+        let dirname = Path.parent name in
+        let%bind () = Fs.createDir dirname in
+        (* TODO: move this to the place we read data from *)
+        let contents =
+          if String.get content (String.length content - 1) == '\n'
+          then content
+          else content ^ "\n"
+        in
+        let%bind () = Fs.writeFile ~data:contents name in
+        return()
+      in
+      List.map ~f record.files |> RunAsync.List.waitAll
+    in
+
+    let%bind () =
+      let addResolvedFieldToPackageJson filename =
+        match%bind Fs.readJsonFile filename with
+        | `Assoc items ->
+          let json = `Assoc (("_resolved", `String key)::items) in
+          let data = Yojson.Safe.pretty_to_string json in
+          Fs.writeFile ~data filename
+        | _ -> error "invalid package.json"
+      in
+
+      let esyJson = Path.(path / "esy.json") in
+      let packageJson = Path.(path / "package.json") in
+      if%bind Fs.exists esyJson
+      then addResolvedFieldToPackageJson esyJson
+      else if%bind Fs.exists packageJson
+      then addResolvedFieldToPackageJson packageJson
+      else return ()
+    in
+
+    return ()
+  in
+
+  let doFetchIfNeeded source =
+    let key = cacheId source record in
     let tarballPath = Path.(cfg.cacheTarballsPath // v key |> addExt "tgz") in
 
-    let dist = {Dist. tarballPath = Some tarballPath; name; version; source} in
+    let dist = {
+      Dist.
+      tarballPath = Some tarballPath;
+      name = record.name;
+      version = record.version;
+      source;
+    } in
     let%bind tarballIsInCache = Fs.exists tarballPath in
 
     match source, tarballIsInCache with
     | Source.LocalPathLink _, _ ->
-      return dist
-
+      return (`Done dist)
     | _, true ->
-      return dist
+      return (`Done dist)
     | _, false ->
       Fs.withTempDir (fun sourcePath ->
-        let%bind () =
+        let%bind fetched =
           let msg = Format.asprintf "fetching %a" Package.Source.pp source in
           RunAsync.withContext msg (
             let%bind () = Fs.createDir sourcePath in
-            let%bind () = doFetch sourcePath in
-            let%bind () = complete sourcePath in
-            return ()
+            match%bind doFetch sourcePath source with
+            | `Done ->
+              let%bind () = commit sourcePath source in
+              return `Done
+            | `TryNext err -> return (`TryNext err)
           )
         in
 
-        let%bind () =
-          let%bind () = Fs.createDir (Path.parent tarballPath) in
-          let tempTarballPath = Path.(tarballPath |> addExt ".tmp") in
-          let%bind () = Tarball.create ~filename:tempTarballPath sourcePath in
-          let%bind () = Fs.rename ~src:tempTarballPath tarballPath in
-          return ()
-        in
-
-        return dist
+        match fetched with
+        | `Done ->
+          let%bind () =
+            let%bind () = Fs.createDir (Path.parent tarballPath) in
+            let tempTarballPath = Path.(tarballPath |> addExt ".tmp") in
+            let%bind () = Tarball.create ~filename:tempTarballPath sourcePath in
+            let%bind () = Fs.rename ~src:tempTarballPath tarballPath in
+            return ()
+          in
+          return (`Done dist)
+        | `TryNext err -> return (`TryNext err)
       )
+    in
+
+    let rec tryFetch errs sources =
+      match sources with
+      | source::nextSources ->
+        begin match%bind doFetchIfNeeded source with
+        | `Done dist -> return dist
+        | `TryNext err ->
+          tryFetch ((source, err)::errs) nextSources
+        end
+      | [] ->
+        Logs_lwt.err (fun m ->
+          let ppErr fmt (source, err) =
+            Fmt.pf fmt
+              "source: %a@\nerror: %a"
+              Package.Source.pp source
+              Run.ppError err
+          in
+          m "unable to fetch %a:@[<v 2>@\n%a@]"
+            Solution.Record.pp record
+            Fmt.(list ~sep:(unit "@\n") ppErr) errs
+        );%lwt
+        error "installation error"
+    in
+
+    let sources =
+      let main, mirrors = record.source in
+      main::mirrors
+    in
+
+    tryFetch [] sources
 
 let install ~cfg:_ ~path dist =
   let open RunAsync.Syntax in

--- a/esyi/Manifest.ml
+++ b/esyi/Manifest.ml
@@ -144,7 +144,7 @@ let toPackage ?name ?version (manifest : t) =
     version;
     dependencies = Dependencies.NpmFormula manifest.dependencies;
     devDependencies = Dependencies.NpmFormula manifest.devDependencies;
-    source;
+    source = source, [];
     opam = None;
     kind =
       if manifest.hasEsyManifest

--- a/esyi/OpamRegistry.ml
+++ b/esyi/OpamRegistry.ml
@@ -215,7 +215,7 @@ module Manifest = struct
         name;
         version;
         kind = Package.Esy;
-        source;
+        source = source, [];
         opam = Some {
           Package.Opam.
           name = opamName;

--- a/esyi/OpamRegistry.ml
+++ b/esyi/OpamRegistry.ml
@@ -14,6 +14,117 @@ module OpamFiles = Memoize.Make(struct
   type value = OpamFile.OPAM.t RunAsync.t
 end)
 
+module OpamArchivesIndex : sig
+  type t
+
+  type record = {
+    url: string;
+    md5: string
+  }
+
+  val init : cfg:Config.t -> unit -> t RunAsync.t
+  val find : name:OpamPackage.Name.t -> version:OpamPackage.Version.t -> t -> record option
+
+end = struct
+  type t = {
+    index : record StringMap.t;
+    cacheKey : (string option [@default None]);
+  } [@@deriving yojson]
+
+  and record = {
+    url: string;
+    md5: string
+  }
+
+  let baseUrl = "https://opam.ocaml.org/"
+  let url = baseUrl ^ "/urls.txt"
+
+  let parse response =
+
+    let parseBase =
+      Re.(compile (seq [bos; str "archives/"; group (rep1 any); str "+opam.tar.gz"; eos]))
+    in
+
+    let attrs = OpamFile.File_attributes.read_from_string response in
+    let f attr index =
+      let base = OpamFilename.(Base.to_string (Attribute.base attr)) in
+      let md5 =
+        let hash = OpamFilename.Attribute.md5 attr in
+        OpamHash.contents hash
+      in
+      match Re.exec_opt parseBase base with
+      | Some m ->
+        let id = Re.Group.get m 1 in
+        let url = baseUrl ^ base in
+        let record = {url; md5} in
+        StringMap.add id record index
+      | None -> index
+    in
+    OpamFilename.Attribute.Set.fold f attrs StringMap.empty
+
+  let download () =
+    let open RunAsync.Syntax in
+    Logs_lwt.app (fun m -> m "downloading opam index...");%lwt
+    let%bind data = Curl.get url in
+    return (parse data)
+
+  let init ~cfg () =
+    let open RunAsync.Syntax in
+    let filename = cfg.Config.opamArchivesIndexPath in
+
+    let cacheKeyOfHeaders headers =
+      let contentLength = StringMap.find_opt "content-length" headers in
+      let lastModified = StringMap.find_opt "last-modified" headers in
+      match contentLength, lastModified with
+      | Some a, Some b -> Some Digest.(a ^ "__" ^ b |> string |> to_hex)
+      | _ -> None
+    in
+
+    let save index =
+      let json = to_yojson index in
+      Fs.writeJsonFile ~json filename
+    in
+
+    let downloadAndSave () =
+      let%bind headers = Curl.head url in
+      let cacheKey = cacheKeyOfHeaders headers in
+      let%bind index =
+        let%bind index = download () in
+        return {cacheKey; index}
+      in
+      let%bind () = save index in
+      return index
+    in
+
+    if%bind Fs.exists filename
+    then
+      let%bind json = Fs.readJsonFile filename in
+      let%bind index = RunAsync.ofRun (Json.parseJsonWith of_yojson json) in
+      let%bind headers = Curl.head url in
+      begin match index.cacheKey, cacheKeyOfHeaders headers with
+      | Some cacheKey, Some currCacheKey ->
+        if cacheKey = currCacheKey
+        then return index
+        else
+          let%bind index =
+            let%bind index = download () in
+            return {index; cacheKey = Some currCacheKey}
+          in
+          let%bind () = save index in
+          return index
+      | _ -> downloadAndSave ()
+      end
+    else downloadAndSave ()
+
+  let find ~name ~version index =
+    let key =
+      let name = OpamPackage.Name.to_string name in
+      let version = OpamPackage.Version.to_string version in
+      name ^ "." ^ version
+    in
+    StringMap.find_opt key index.index
+end
+
 type t = {
   init : unit -> registry RunAsync.t;
   lock : Lwt_mutex.t;
@@ -25,6 +136,7 @@ and registry = {
   overrides : OpamOverrides.t;
   pathsCache : OpamPathsByVersion.t;
   opamCache : OpamFiles.t;
+  archiveIndex : OpamArchivesIndex.t;
 }
 
 type resolution = {
@@ -76,6 +188,7 @@ module Manifest = struct
     opam: OpamFile.OPAM.t;
     url: OpamFile.URL.t option;
     override : Override.t;
+    archive : OpamArchivesIndex.record option;
   }
 
   let ofFile ~name ~version ?url registry =
@@ -89,9 +202,11 @@ module Manifest = struct
         return (Some (OpamFile.URL.read_from_string data))
       | None -> return None
     in
-    return {name; version; opam; url; path; override = Override.empty;}
+    let archive = OpamArchivesIndex.find ~name ~version registry.archiveIndex in
+    return {name; version; opam; url; path; override = Override.empty; archive}
 
-  let toPackage ~name ~version {name = opamName; version = opamVersion; opam; url; path; override} =
+  let toPackage ~name ~version
+    {name = opamName; version = opamVersion; opam; url; path; override; archive} =
     let open RunAsync.Syntax in
     let context = Format.asprintf "processing %a opam package" Path.pp path in
     RunAsync.withContext context (
@@ -140,20 +255,39 @@ module Manifest = struct
           return (main, mirrors)
         in
 
-        match override.Override.opam.Override.Opam.source with
-        | Some source ->
-          let main = Package.Source (Package.Source.Archive {
-            url = source.url;
-            checksum = Checksum.Md5, source.checksum;
-          }) in
-          return (main, [])
-        | None -> begin
-          match url with
-          | Some url -> sourceOfOpamUrl url
-          | None ->
-            let main = Package.Source Package.Source.NoSource in
+        let%bind main, mirrors =
+          match override.Override.opam.Override.Opam.source with
+          | Some source ->
+            let main = Package.Source (Package.Source.Archive {
+              url = source.url;
+              checksum = Checksum.Md5, source.checksum;
+            }) in
             return (main, [])
-          end
+          | None -> begin
+            match url with
+            | Some url -> sourceOfOpamUrl url
+            | None ->
+              let main = Package.Source Package.Source.NoSource in
+              return (main, [])
+            end
+        in
+
+        let main, mirrors =
+          match archive with
+          | Some archive ->
+            let mirrors = main::mirrors in
+            let main =
+              Package.Source (Package.Source.Archive {
+                url = archive.url;
+                checksum = Checksum.Md5, archive.md5;
+              })
+            in
+            main, mirrors
+          | None ->
+            main, mirrors
+        in
+
+        return (main, mirrors)
       ) in
 
       let translateFormula f =
@@ -273,12 +407,14 @@ let make ~cfg () =
     in
 
     let%bind overrides = OpamOverrides.init ~cfg () in
+    let%bind archiveIndex = OpamArchivesIndex.init ~cfg () in
 
     return {
       repoPath;
       pathsCache = OpamPathsByVersion.make ();
       opamCache = OpamFiles.make ();
       overrides;
+      archiveIndex;
     }
   in {init; lock = Lwt_mutex.create (); registry = None;}
 

--- a/esyi/OpamRegistry.mli
+++ b/esyi/OpamRegistry.mli
@@ -8,14 +8,7 @@ type resolution = {
 }
 
 module Manifest : sig
-  type t = {
-    name : OpamPackage.Name.t;
-    version : OpamPackage.Version.t;
-    path : Path.t;
-    opam : OpamFile.OPAM.t;
-    url : OpamFile.URL.t option;
-    override : Package.OpamOverride.t;
-  }
+  type t
 
   val toPackage :
     name : string

--- a/esyi/Package.ml
+++ b/esyi/Package.ml
@@ -838,7 +838,7 @@ end
 type t = {
   name : string;
   version : Version.t;
-  source : source;
+  source : source * source list;
   dependencies: Dependencies.t;
   devDependencies: Dependencies.t;
   opam : Opam.t option;

--- a/esyi/Package.mli
+++ b/esyi/Package.mli
@@ -240,7 +240,7 @@ end
 type t = {
   name : string;
   version : Version.t;
-  source : source;
+  source : source * source list;
   dependencies: Dependencies.t;
   devDependencies: Dependencies.t;
   opam : Opam.t option;

--- a/esyi/Solution.ml
+++ b/esyi/Solution.ml
@@ -13,6 +13,28 @@ module Record = struct
     } [@@deriving yojson]
   end
 
+  module Source = struct
+    type t = Package.Source.t * Package.Source.t list
+
+    let to_yojson = function
+      | main, [] -> Package.Source.to_yojson main
+      | main, mirrors -> `List (List.map ~f:Package.Source.to_yojson (main::mirrors))
+
+    let of_yojson (json : Json.t) =
+      let open Result.Syntax in
+      match json with
+      | `String _ ->
+        let%bind source = Package.Source.of_yojson json in
+        return (source, [])
+      | `List _ ->
+        begin match%bind Json.Parse.list Package.Source.of_yojson json with
+        | main::mirrors -> return (main, mirrors)
+        | [] -> error "expected a non empty array or a string"
+        end
+      | _ -> error "expected a non empty array or a string"
+
+  end
+
   type t = {
     name: string;
     version: Version.t;
@@ -131,15 +153,21 @@ module LockfileV1 = struct
       | Version.Source _ -> record.version
     in
     let source =
-      match record.source with
-      | Source.LocalPathLink p ->
-        Source.LocalPathLink (f p)
-      | Source.LocalPath p ->
-        Source.LocalPath (f p)
-      | Source.Archive _
-      | Source.Git _
-      | Source.Github _
-      | Source.NoSource -> record.source
+      let f source =
+        match source with
+        | Source.LocalPathLink p ->
+          Source.LocalPathLink (f p)
+        | Source.LocalPath p ->
+          Source.LocalPath (f p)
+        | Source.Archive _
+        | Source.Git _
+        | Source.Github _
+        | Source.NoSource -> source
+      in
+      let main, mirrors = record.source in
+      let main = f main in
+      let mirrors = List.map ~f mirrors in
+      main, mirrors
     in
     {record with source; version}
 

--- a/esyi/Solution.mli
+++ b/esyi/Solution.mli
@@ -19,7 +19,7 @@ module Record : sig
   type t = {
     name: string;
     version: Package.Version.t;
-    source: Package.Source.t;
+    source: Package.Source.t * Package.Source.t list;
     files : Package.File.t list;
     opam : Opam.t option;
   }


### PR DESCRIPTION
- Allow `Package.t` to hold multiple sources (main and mirrors)
- Allow `Solution.Record.t` to hold multiple sources (main and mirrors)
- Read http/https `mirrors` from `opam` files
- Download and cache `opam-urls.txt` and use archives as sources for opam packages.