### PR TITLE
Regression - Fix escaping of backslash in ShellParamExpansion

### DIFF
--- a/esy/ShellParamExpansion.ml
+++ b/esy/ShellParamExpansion.ml
@@ -32,4 +32,4 @@ let render ?(fallback=Some "") ~(scope : scope) v =
       end
   in
   let%bind segments = Result.List.foldLeft ~f ~init:[] tokens in
-  Ok (segments |> List.rev |> String.concat "" |> EsyLib.Path.normalizePathSlashes)
+  Ok (segments |> List.rev |> String.concat "")

--- a/test-e2e/build/build-no-deps-backslash-test.sh
+++ b/test-e2e/build/build-no-deps-backslash-test.sh
@@ -1,0 +1,7 @@
+# Regression test for slash case hit in PR 232
+
+doTest () {
+  initFixture ./fixtures/no-deps
+  run esy build
+  expectStdout "// no-deps-backslash //" esy x no-deps-backslash
+}

--- a/test-e2e/build/build-no-deps-backslash-test.sh
+++ b/test-e2e/build/build-no-deps-backslash-test.sh
@@ -1,7 +1,7 @@
 # Regression test for slash case hit in PR 232
 
 doTest () {
-  initFixture ./fixtures/no-deps
+  initFixture ./fixtures/no-deps-backslash
   run esy build
-  expectStdout "// no-deps-backslash //" esy x no-deps-backslash
+  expectStdout "\\ no-deps-backslash \\" esy x no-deps-backslash
 }

--- a/test-e2e/build/fixtures/no-deps-backslash/package.json
+++ b/test-e2e/build/fixtures/no-deps-backslash/package.json
@@ -9,7 +9,9 @@
         "-c",
         "echo '#!/bin/bash\necho \\\\ #{self.name}  \\\\' > #{self.target_dir / self.name}"
       ],
-      "chmod +x $cur__target_dir/$cur__name"
+      "chmod +x $cur__target_dir/$cur__name",
+      "echo File: #{self.target_dir / self.name",
+      "cat #{self.target_dir / self.name}"
     ],
     "install": [
       "cp $cur__target_dir/$cur__name $cur__bin/$cur__name"

--- a/test-e2e/build/fixtures/no-deps-backslash/package.json
+++ b/test-e2e/build/fixtures/no-deps-backslash/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "no-deps-backslash",
+  "version": "1.0.0",
+  "license": "MIT",
+  "esy": {
+    "build": [
+      [
+        "bash",
+        "-c",
+        "echo '#!/bin/bash\necho \\\\ #{self.name}  \\\\' > #{self.target_dir / self.name}"
+      ],
+      "chmod +x $cur__target_dir/$cur__name"
+    ],
+    "install": [
+      "cp $cur__target_dir/$cur__name $cur__bin/$cur__name"
+    ]
+  }
+}

--- a/test-e2e/build/fixtures/no-deps-backslash/package.json
+++ b/test-e2e/build/fixtures/no-deps-backslash/package.json
@@ -7,11 +7,9 @@
       [
         "bash",
         "-c",
-        "echo '#!/bin/bash\necho \\\\ #{self.name}  \\\\' > #{self.target_dir / self.name}"
+        "echo '#!/bin/bash\necho \\\\\\\\ #{self.name}  \\\\\\\\' > #{self.target_dir / self.name}"
       ],
-      "chmod +x $cur__target_dir/$cur__name",
-      "echo File: #{self.target_dir / self.name}",
-      "cat #{self.target_dir / self.name}"
+      "chmod +x $cur__target_dir/$cur__name"
     ],
     "install": [
       "cp $cur__target_dir/$cur__name $cur__bin/$cur__name"

--- a/test-e2e/build/fixtures/no-deps-backslash/package.json
+++ b/test-e2e/build/fixtures/no-deps-backslash/package.json
@@ -10,7 +10,7 @@
         "echo '#!/bin/bash\necho \\\\ #{self.name}  \\\\' > #{self.target_dir / self.name}"
       ],
       "chmod +x $cur__target_dir/$cur__name",
-      "echo File: #{self.target_dir / self.name",
+      "echo File: #{self.target_dir / self.name}",
       "cat #{self.target_dir / self.name}"
     ],
     "install": [


### PR DESCRIPTION
Based on @andreypopp 's comments on #232  - it looks like the escaping of the backslash `\` is causing issues, as some packages depend on that character.

I'll revert the fix and add unit tests to cover this case.