### PR TITLE
Windows - Build: Initial bootstrapped build for `esyi`

### DIFF
--- a/scripts/bootstrap/build-bootstrap.sh
+++ b/scripts/bootstrap/build-bootstrap.sh
@@ -33,6 +33,9 @@ make _release/_build/default/esy-build-package/bin/esyBuildPackageCommand.exe
 echo "make: release esy"
 make _release/_build/default/esy/bin/esyCommand.exe
 
+echo "make: release esyi"
+make _release/_build/default/esyi/bin/esyi.exe
+
 echo "make: fastreplacestring"
 make _release/bin/fastreplacestring
 

--- a/scripts/bootstrap/build-bootstrap.sh
+++ b/scripts/bootstrap/build-bootstrap.sh
@@ -12,8 +12,11 @@ cp scripts/bootstrap/Makefile.bootstrap Makefile
 echo "jbuilder:build esy-build-package"
 jbuilder build --dev _build/default/esy-build-package/bin/esyBuildPackageCommand.exe
 
-echo "jbuilder: build esy"
+echo "jbuilder:build esy"
 jbuilder build --dev _build/default/esy/bin/esyCommand.exe
+
+echo "jbuilder:build esyi"
+jbuilder build --dev _build/default/esyi/bin/esyi.exe
 
 echo "make: esy-install"
 make _release/bin/esy-install.js

--- a/scripts/bootstrap/install-opam-dependencies.sh
+++ b/scripts/bootstrap/install-opam-dependencies.sh
@@ -21,6 +21,8 @@ opam install --yes yojson
 opam install --yes bos
 opam install --yes re
 opam install --yes opam-format
+opam install --yes cudf
+opam install --yes dose3
 
 echo "** Installed packages:"
 ocamlfind list


### PR DESCRIPTION
This adds a build step for `esyi` in our bootstrapped script. This will help us have CI validation that `esyi` is building on Windows.

A couple additional OPAM packages are needed for this: `cudf` and `dose3`.

`esyi.exe` builds on Windows after this change, however, it will not run at the moment:

```
info esy install 0.1.32
esyi: not found: esy-solve-cudf/esySolveCudfCommand.exe

esy: error, exiting...
     error running command:
     "E:\esy3\_release\_build\default\esyi\bin\esyi.exe"
```

Next step to look at is building `esy-solve-cudf`. 