### PR TITLE
Windows: Include windows binaries in NPM release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,7 @@ RELEASE_ROOT = _release
 RELEASE_FILES = \
 	platform-linux \
 	platform-darwin \
+	platform-windows-x64 \
 	bin/esy \
 	bin/esyi \
 	bin/esyInstallRelease.js \

--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,7 @@ console.log(
 			"bin/",
 			"postinstall.js",
 			"platform-linux/",
-			"platform-darwin/"
+			"platform-darwin/",
 			"platform-windows-x64/"
 		]
 	}, null, 2));

--- a/Makefile
+++ b/Makefile
@@ -155,8 +155,8 @@ $(RELEASE_ROOT)/%: $(PWD)/%
 	@mkdir -p $(@D)
 	@cp $(<) $(@)
 
-$(RELEASE_ROOT)/platform-linux $(RELEASE_ROOT)/platform-darwin: PLATFORM=$(@:$(RELEASE_ROOT)/platform-%=%)
-$(RELEASE_ROOT)/platform-linux $(RELEASE_ROOT)/platform-darwin:
+$(RELEASE_ROOT)/platform-linux $(RELEASE_ROOT)/platform-darwin $(RELEASE_ROOT)/platform-windows-x64: PLATFORM=$(@:$(RELEASE_ROOT)/platform-%=%)
+$(RELEASE_ROOT)/platform-linux $(RELEASE_ROOT)/platform-darwin $(RELEASE_ROOT)/platform-windows-x64:
 	@wget \
 		-q --show-progress \
 		-O $(RELEASE_ROOT)/$(PLATFORM).tgz \

--- a/Makefile
+++ b/Makefile
@@ -190,6 +190,7 @@ console.log(
 			"postinstall.js",
 			"platform-linux/",
 			"platform-darwin/"
+			"platform-windows-x64/"
 		]
 	}, null, 2));
 endef
@@ -198,44 +199,8 @@ export MAKE_PACKAGE_JSON
 $(RELEASE_ROOT)/package.json:
 	@node -e "$$MAKE_PACKAGE_JSON" > $(@)
 
-define POSTINSTALL_JS
-var path = require('path');
-var fs = require('fs');
-var platform = process.platform;
-
-switch (platform) {
-  case 'linux':
-  case 'darwin':
-    fs.renameSync(
-      path.join(__dirname, 'platform-' + platform, '_build'),
-      path.join(__dirname, '_build')
-    );
-    fs.renameSync(
-      path.join(__dirname, 'platform-' + platform, 'bin', 'fastreplacestring'),
-      path.join(__dirname, 'bin', 'fastreplacestring')
-    );
-
-    fs.unlinkSync(path.join(__dirname, 'bin', 'esy'));
-    fs.symlinkSync(
-      path.join(__dirname, '_build', 'default', 'esy', 'bin', 'esyCommand.exe'),
-      path.join(__dirname, 'bin', 'esy')
-  	);
-
-		fs.unlinkSync(path.join(__dirname, 'bin', 'esyi'));
-    fs.symlinkSync(
-      path.join(__dirname, '_build', 'default', 'esyi', 'bin', 'esyi.exe'),
-      path.join(__dirname, 'bin', 'esyi')
-  	);
-    break;
-  default:
-    console.warn("error: no release built for the " + platform + " platform");
-    process.exit(1);
-}
-endef
-export POSTINSTALL_JS
-
 $(RELEASE_ROOT)/postinstall.js:
-	@echo "$$POSTINSTALL_JS" > $(@)
+	@cp scripts/release-postinstall.js $(@)
 
 #
 # Platform Specific Release

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,7 @@ build_script:
     - npm run bootstrap:make-release-package
 
 artifacts:
-    - path: _platformrelease/*.tar.gz
+    - path: _platformrelease/*.tgz
       name: Windows Build
       type: File
 

--- a/scripts/bootstrap/make-release-package.js
+++ b/scripts/bootstrap/make-release-package.js
@@ -39,7 +39,7 @@ const pack = async () => {
     const cygwinPackFolder = await toCygwinPath(packFolder)
 
     console.log(`Creating archive from ${cygwinPackFolder} in ${cygwinDestFolder}.`)
-    await bashExec(`tar -czvf ${cygwinDestFolder}/esy-${version}-windows-${arch}.tar.gz -C ${cygwinPackFolder} .`)
+    await bashExec(`tar -czvf ${cygwinDestFolder}/esy-${version}-windows-${arch}.tgz -C ${cygwinPackFolder} .`)
 }
 
 pack()

--- a/scripts/bootstrap/make-release-package.js
+++ b/scripts/bootstrap/make-release-package.js
@@ -39,7 +39,7 @@ const pack = async () => {
     const cygwinPackFolder = await toCygwinPath(packFolder)
 
     console.log(`Creating archive from ${cygwinPackFolder} in ${cygwinDestFolder}.`)
-    await bashExec(`tar -czvf ${cygwinDestFolder}/esy-windows-${version}-${arch}.tar.gz -C ${cygwinPackFolder} .`)
+    await bashExec(`tar -czvf ${cygwinDestFolder}/esy-${version}-windows-${arch}.tar.gz -C ${cygwinPackFolder} .`)
 }
 
 pack()

--- a/scripts/bootstrap/make-release-package.js
+++ b/scripts/bootstrap/make-release-package.js
@@ -39,7 +39,7 @@ const pack = async () => {
     const cygwinPackFolder = await toCygwinPath(packFolder)
 
     console.log(`Creating archive from ${cygwinPackFolder} in ${cygwinDestFolder}.`)
-    await bashExec(`tar -czvf ${cygwinDestFolder}/esy-${version}-windows-${arch}.tgz -C ${cygwinPackFolder} .`)
+    await bashExec(`tar -czvf ${cygwinDestFolder}/esy-v${version}-windows-${arch}.tgz -C ${cygwinPackFolder} .`)
 }
 
 pack()

--- a/scripts/release-postinstall.js
+++ b/scripts/release-postinstall.js
@@ -11,6 +11,7 @@
 var path = require('path');
 var cp = require('child_process');
 var fs = require('fs');
+var os = require('os');
 var platform = process.platform;
 
 const copyPlatformBinaries = (platformPath) => {

--- a/scripts/release-postinstall.js
+++ b/scripts/release-postinstall.js
@@ -1,0 +1,59 @@
+/**
+ * release-postinstall.js
+ *
+ * This script is bundled with the `npm` package and executed on release.
+ * Since we have a 'fat' NPM package (with all platform binaries bundled),
+ * this postinstall script extracts them and puts the current platform's
+ * bits in the right place.
+ */
+
+
+var path = require('path');
+var cp = require('child_process');
+var fs = require('fs');
+var platform = process.platform;
+
+const copyPlatformBinaries = (platformPath) => {
+    fs.renameSync(
+        path.join(__dirname, 'platformPath-' + platformPath, '_build'),
+        path.join(__dirname, '_build')
+    );
+    fs.renameSync(
+        path.join(__dirname, 'platformPath-' + platformPath, 'bin', 'fastreplacestring'),
+        path.join(__dirname, 'bin', 'fastreplacestring')
+    );
+
+    fs.unlinkSync(path.join(__dirname, 'bin', 'esy'));
+    fs.symlinkSync(
+        path.join(__dirname, '_build', 'default', 'esy', 'bin', 'esyCommand.exe'),
+        path.join(__dirname, 'bin', 'esy')
+    );
+
+    fs.unlinkSync(path.join(__dirname, 'bin', 'esyi'));
+    fs.symlinkSync(
+        path.join(__dirname, '_build', 'default', 'esyi', 'bin', 'esyi.exe'),
+        path.join(__dirname, 'bin', 'esyi')
+    );
+}
+
+switch (platform) {
+    case 'win32':
+        if (os.arch() !== "x64") {
+            console.warn("error: x86 is currently not supported on Windows");
+            process.exit(1);
+        }
+
+        copyPlatformBinaries("windows-x64");
+
+        console.log("Installing cygwin sandbox...");
+        cp.execSync("npm install esy-bash");
+        console.log("Cygwin installed successfully.");
+        break;
+    case 'linux':
+    case 'darwin':
+        copyPlatformBinaries(platform);
+        break;
+    default:
+        console.warn("error: no release built for the " + platform + " platform");
+        process.exit(1);
+}

--- a/scripts/release-postinstall.js
+++ b/scripts/release-postinstall.js
@@ -16,11 +16,11 @@ var platform = process.platform;
 
 const copyPlatformBinaries = (platformPath) => {
     fs.renameSync(
-        path.join(__dirname, 'platformPath-' + platformPath, '_build'),
+        path.join(__dirname, 'platform-' + platformPath, '_build'),
         path.join(__dirname, '_build')
     );
     fs.renameSync(
-        path.join(__dirname, 'platformPath-' + platformPath, 'bin', 'fastreplacestring'),
+        path.join(__dirname, 'platform-' + platformPath, 'bin', 'fastreplacestring'),
         path.join(__dirname, 'bin', 'fastreplacestring')
     );
 


### PR DESCRIPTION
This change updates our `make release` command to include the `x64` build of the windows binaries (we don't build `x86` today, at the moment).

Changes:
- Download the built `windows-x64.tgz` artifact
- Update the `postinstall.js` script to handle the windows case (which will need to fork based on architecture)
- Install `esy-bash` on Windows. Note that _this will incur network traffic_ on `esy install`, but I'm not sure a good way around this - we need the Cygwin layer and the cygwin executable itself + utilities would be heavyweight to include for all platforms. @jordwalke @andreypopp - any ideas here?

Note that `npm install` of the Windows will fail until we address andreypopp/esy-solve-cudf#1 - that `postinstall` step references `bash` and won't work by default on Windows:
```
E:\esy-release-test> npm install .\esy-0.1.32.tgz

> esy-solve-cudf@0.1.0 postinstall E:\esy-release-test\node_modules\esy-solve-cudf
> bash ./postinstall.sh

'bash' is not recognized as an internal or external command,
operable program or batch file.
npm WARN enoent ENOENT: no such file or directory, open 'E:\esy-release-test\package.json'
npm WARN esy-release-test No description
npm WARN esy-release-test No repository field.
npm WARN esy-release-test No README data
npm WARN esy-release-test No license field.

npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! esy-solve-cudf@0.1.0 postinstall: `bash ./postinstall.sh`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the esy-solve-cudf@0.1.0 postinstall script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     C:\Users\bryph\AppData\Roaming\npm-cache\_logs\2018-07-18T23_16_16_923Z-debug.log
```
