### PR TITLE
Fix #270 - 'esy x' does not work on Windows

### DIFF
--- a/esy-lib/ChildProcess.ml
+++ b/esy-lib/ChildProcess.ml
@@ -39,7 +39,7 @@ let resolveCmdInEnv ~env prg =
       | Some v  -> v
       | None -> ""
     in
-    String.split_on_char ':' v
+    String.split_on_char System.envSep.[0] v
   in Run.ofBosError (Cmd.resolveCmd path prg)
 
 let withProcess ?(env=`CurrentEnv) ?(resolveProgramInEnv=false) ?stdin ?stdout ?stderr cmd f =

--- a/esy-lib/Cmd.ml
+++ b/esy-lib/Cmd.ml
@@ -66,7 +66,7 @@ let isExecutable (stats : Unix.stats) =
  * as shell commands are provided there (these paths get converted to their cygwin equivalents and checked).
  *)
 let getAdditionalResolvePaths path =
-    match System.host with
+    match System.Platform.host with
     | Windows -> path @ ["/bin"; "/usr/bin"]
     | _ -> path
 

--- a/esy-lib/Cmd.ml
+++ b/esy-lib/Cmd.ml
@@ -84,8 +84,19 @@ let checkIfCommandIsAvailable fullPath =
     in
     List.fold_left ~f:evaluate ~init:(Ok None) extensions
 
+(* 
+ * When running from some contexts, like the ChildProcess, only the system paths are provided.
+ * However, on Windows, we also need to check the equivalent of the `bin` and `usr/bin` folders,
+ * as shell commands are provided there (these paths get converted to their cygwin equivalents and checked).
+ *)
+let getAdditionalResolvePaths path = 
+    match System.host with
+    | Windows -> path @ ["/bin"; "/usr/bin"]
+    | _ -> path
+
 let resolveCmd path cmd =
   let open Result.Syntax in
+  let allPaths = getAdditionalResolvePaths path in
   let find p =
     let p = let open Path in (v p) / cmd in
     let%bind p = EsyBash.normalizePathForWindows p in
@@ -107,7 +118,7 @@ let resolveCmd path cmd =
   match cmd.[0] with
   | '.'
   | '/' -> Ok cmd
-  | _ -> resolve path
+  | _ -> resolve allPaths
 
 let resolveInvocation path (tool, args) =
   let open Result.Syntax in


### PR DESCRIPTION
__Issue:__ The `esy x` command was not working in many cases on Windows, as the `resolveCmd` call would fail to resolve built-in commands.

__Defect:__ There were two blockers:
1) In spinning up the execution sandbox, there was a hardcoded `:` separator - so we'd split the `PATH`s with `:`, which breaks on Windows (which uses a semicolon separator, and may have colons in paths).
2) In this case, we were not looking at Cygwin's `/bin` and `/usr/bin` paths for the built-in utilities. 

__Fix:__ 
1) Use the `System.envSep` platform-specific separator
2) On Windows, we should always include those in our resolveCmd logic - they may not be included in the user's `PATH`.

This is related to #265 and #241 as we often use `esy x` to validate test output, and those tests would fail on Windows due to this bug.