### PR TITLE
Copy sources using OCaml code instead of rsync

### DIFF
--- a/esy-build-package/Build.re
+++ b/esy-build-package/Build.re
@@ -422,7 +422,7 @@ let runCommand = (b, cmd) => {
     };
   let path =
     switch (Astring.String.Map.find("PATH", env)) {
-    | Some(path) => String.split_on_char(System.envSep.[0], path)
+    | Some(path) => String.split_on_char(System.Environment.sep.[0], path)
     | None => []
     };
 
@@ -447,7 +447,7 @@ let runCommandInteractive = (b, cmd) => {
     };
   let path =
     switch (Astring.String.Map.find("PATH", env)) {
-    | Some(path) => String.split_on_char(System.envSep.[0], path)
+    | Some(path) => String.split_on_char(System.Environment.sep.[0], path)
     | None => []
     };
   let%bind ((), (_runInfo, runStatus)) = {

--- a/esy-lib/Cmd.ml
+++ b/esy-lib/Cmd.ml
@@ -87,7 +87,7 @@ let checkIfCommandIsAvailable fullPath =
 let resolveCmd path cmd =
   let open Result.Syntax in
   let find p =
-    let p = let open Path in (v p) / cmd in
+    let p = Path.(v p / cmd) in
     let%bind p = EsyBash.normalizePathForWindows p in
     checkIfCommandIsAvailable p
     in

--- a/esy-lib/System.ml
+++ b/esy-lib/System.ml
@@ -35,7 +35,26 @@ module Platform = struct
 
 end
 
-let envSep =
-  match Platform.host with
-  | Platform.Windows -> ";"
-  | _ -> ":"
+module Environment = struct
+
+  let sep =
+    match Platform.host with
+    | Platform.Windows -> ";"
+    | _ -> ":"
+
+  let current =
+    let f map item =
+      let idx = String.index item '=' in
+      let name = String.sub item 0 idx in
+      let value = String.sub item (idx + 1) (String.length item - idx - 1) in
+      StringMap.add name value map
+    in
+    let items = Unix.environment () in
+    Array.fold_left f StringMap.empty items
+
+  let path =
+    match StringMap.find_opt "PATH" current with
+    | Some path -> String.split_on_char sep.[0] path
+    | None -> []
+
+end

--- a/esy-lib/System.mli
+++ b/esy-lib/System.mli
@@ -16,5 +16,10 @@ module Platform : sig
   val host : t
 end
 
-(** Environment variable separator which is used for $PATH and etc *)
-val envSep : string
+module Environment : sig
+  (** Environment variable separator which is used for $PATH and etc *)
+  val sep : string
+
+  (** Value of $PATH environment variable. *)
+  val path : string list
+end

--- a/esy/Task.ml
+++ b/esy/Task.ml
@@ -694,21 +694,21 @@ let ofPackage
             name = "PATH";
             value =
               let value = ConfigPath.(task.paths.installPath / "bin" |> toString) in
-              Value (value ^ System.envSep ^ "$PATH")
+              Value (value ^ System.Environment.sep ^ "$PATH")
           }
           and manPath = Environment.{
             origin = Some task.pkg;
             name = "MAN_PATH";
             value =
               let value = ConfigPath.(task.paths.installPath / "bin" |> toString) in
-              Value (value ^ System.envSep ^ "$MAN_PATH")
+              Value (value ^ System.Environment.sep ^ "$MAN_PATH")
           }
           and ocamlpath = Environment.{
             origin = Some task.pkg;
             name = "OCAMLPATH";
             value =
               let value = ConfigPath.(task.paths.installPath / "lib" |> toString) in
-              Value (value ^ System.envSep ^ "$OCAMLPATH")
+              Value (value ^ System.Environment.sep ^ "$OCAMLPATH")
           } in
           path::manPath::ocamlpath::task.globalEnv
         in


### PR DESCRIPTION
This removes the requirement on `rsync`, instead using OCaml code. For `ocaml@4.2` source tree OCaml code takes `0.75s` while `rsync` takes `0.71s`, the diff is neglible given that source tree relocation is only performed for immutable packages (build once).