### PR TITLE
Improvements for out of source builds with dune

### DIFF
--- a/esy-build-package/Build.re
+++ b/esy-build-package/Build.re
@@ -94,6 +94,7 @@ let make = (~cfg: Config.t, task: Task.t) => {
           @ [
             regex(sourcePath, [".*", "\\.merlin"]),
             regex(sourcePath, ["\\.merlin"]),
+            regex(sourcePath, [".*\\.install"]),
             Subpath(Path.to_string(buildPath)),
             Subpath(Path.to_string(stagePath)),
             Subpath("/private/tmp"),

--- a/esy-build-package/Build.re
+++ b/esy-build-package/Build.re
@@ -150,14 +150,14 @@ module JBuilderLifecycle: LIFECYCLE = {
 
   let prepare = (build: build) =>
     if (isRoot(build)) {
-      OutOfSourceLifecycle.prepare(build);
+      ok;
     } else {
       prepareImpl(build);
     };
 
   let finalize = (build: build) =>
     if (isRoot(build)) {
-      OutOfSourceLifecycle.finalize(build);
+      ok;
     } else {
       commitImpl(build);
     };
@@ -441,7 +441,6 @@ let withBuild = (~commit=false, ~cfg: Config.t, task: Task.t, f) => {
         let items = items |> List.map(Path.toString) |> String.concat(" ");
         let data = "(ignored_subdirs (" ++ items ++ "))\n";
         let%bind () = write(~data, rootPath / "node_modules" / "dune");
-        let%bind () = mkdir(rootPath / "node_modules");
         ok;
       } else {
         ok;

--- a/esy-build-package/Build.re
+++ b/esy-build-package/Build.re
@@ -48,7 +48,15 @@ module OutOfSourceLifecycle: LIFECYCLE = {
   let getRootPath = build => build.sourcePath;
   let getAllowedToWritePaths = (_task, _sourcePath) => [];
   let prepare = _build => Ok();
-  let finalize = _build => Ok();
+  let finalize = (build: build) => {
+    let%bind () =
+      symlink(
+        ~force=true,
+        ~target=build.buildPath,
+        Path.(build.sourcePath / "_build"),
+      );
+    ok;
+  };
 };
 
 /*
@@ -168,10 +176,13 @@ module JBuilderLifecycle: LIFECYCLE = {
 
  */
 module UnsafeLifecycle: LIFECYCLE = {
-  include OutOfSourceLifecycle;
+  let getRootPath = (build: build) => build.sourcePath;
 
   let getAllowedToWritePaths = (_task, sourcePath) =>
     Sandbox.[Subpath(Path.to_string(sourcePath))];
+
+  let prepare = _build => Ok();
+  let finalize = _build => Ok();
 };
 
 let configureBuild = (~cfg: Config.t, task: Task.t) => {

--- a/esy-build-package/BuildInfo.re
+++ b/esy-build-package/BuildInfo.re
@@ -11,16 +11,13 @@ type t = {
 };
 
 let toFile = (path: EsyLib.Path.t, info: t) => {
-  let write = (oc, ()) => {
-    Yojson.Safe.pretty_to_channel(oc, to_yojson(info));
-    Run.ok;
-  };
-  Result.join(Bos.OS.File.with_oc(path, write, ()));
+  let data = Yojson.Safe.pretty_to_string(to_yojson(info));
+  write(~data, path);
 };
 
 let ofFile = (path: EsyLib.Path.t) =>
   if%bind (exists(path)) {
-    let%bind data = Bos.OS.File.read(path);
+    let%bind data = read(path);
     let json = Yojson.Safe.from_string(data);
     switch (of_yojson(json)) {
     | Ok(v) => Ok(Some(v))

--- a/esy-build-package/Run.re
+++ b/esy-build-package/Run.re
@@ -25,10 +25,13 @@ let mkdir = path =>
   | Error(msg) => Error(msg)
   };
 
+let ls = path => Bos.OS.Dir.contents(~dotfiles=true, ~rel=true, path);
 let rm = path => Bos.OS.File.delete(path);
 let rmdir = path => Bos.OS.Dir.delete(~recurse=true, path);
 let symlink = Bos.OS.Path.symlink;
 let symlinkTarget = Bos.OS.Path.symlink_target;
+
+let write = (~data, path) => Bos.OS.File.write(path, data);
 
 let mv = Bos.OS.Path.move;
 

--- a/esy-build-package/Run.re
+++ b/esy-build-package/Run.re
@@ -28,13 +28,7 @@ let mkdir = path =>
 
 let ls = path => Bos.OS.Dir.contents(~dotfiles=true, ~rel=true, path);
 
-let rm = path =>
-  switch (Bos.OS.Path.stat(path)) {
-  | Ok({Unix.st_kind: S_DIR, _}) => Bos.OS.Dir.delete(~recurse=true, path)
-  | Ok(_) => Bos.OS.File.delete(path)
-  | Error(err) => Error(err)
-  };
-
+let rm = path => Bos.OS.Path.delete(~must_exist=false, ~recurse=true, path);
 let lstat = Bos.OS.Path.symlink_stat;
 let symlink = Bos.OS.Path.symlink;
 let readlink = Bos.OS.Path.symlink_target;

--- a/esy-build-package/Run.re
+++ b/esy-build-package/Run.re
@@ -101,9 +101,9 @@ let copyAllTo = (~from, ~ignore=[], dest) => {
 
   let traverse = `Sat(p => Ok(! Path.Set.mem(p, excludePaths)));
 
-  let rebasePath = (prevRoot, nextRoot, path) =>
-    switch (Fpath.relativize(~root=prevRoot, path)) {
-    | Some(p) => Path.(nextRoot /\/ p)
+  let rebasePath = path =>
+    switch (Fpath.relativize(~root=from, path)) {
+    | Some(p) => Path.(dest /\/ p)
     | None => path
     };
 
@@ -114,7 +114,7 @@ let copyAllTo = (~from, ~ignore=[], dest) => {
         Ok();
       } else {
         let%bind stats = Bos.OS.Path.symlink_stat(path);
-        let nextPath = rebasePath(from, dest, path);
+        let nextPath = rebasePath(path);
         switch (stats.Unix.st_kind) {
         | Unix.S_DIR =>
           let _ = Bos.OS.Dir.create(nextPath);
@@ -125,7 +125,7 @@ let copyAllTo = (~from, ~ignore=[], dest) => {
           Bos.OS.Path.Mode.set(nextPath, stats.Unix.st_perm);
         | Unix.S_LNK =>
           let%bind targetPath = Bos.OS.Path.symlink_target(path);
-          let nextTargetPath = rebasePath(from, dest, targetPath);
+          let nextTargetPath = rebasePath(targetPath);
           Bos.OS.Path.symlink(~target=nextTargetPath, nextPath);
         | _ => /* ignore everything else */ Ok()
         };

--- a/esy-build-package/Run.rei
+++ b/esy-build-package/Run.rei
@@ -12,6 +12,8 @@ type t('v, 'e) = result('v, err('e));
 let ok : t(unit, _);
 let return : 'v => t('v, _);
 
+let write : (~data:string, EsyLib.Path.t) => t(unit, _);
+let ls : EsyLib.Path.t => t(list(EsyLib.Path.t), _);
 let rm : EsyLib.Path.t => t(unit, _);
 let rmdir : EsyLib.Path.t => t(unit, _);
 let mv : (~force: bool=?, EsyLib.Path.t, EsyLib.Path.t) => t(unit, _);

--- a/esy-build-package/Run.rei
+++ b/esy-build-package/Run.rei
@@ -33,6 +33,9 @@ let traverse : (
     (EsyLib.Path.t, Unix.stats) => t(unit, 'e)
   ) => t(unit, 'e)
 
+let copyAllTo : (~from: Fpath.t, ~ignore: list(string)=?, Fpath.t) => t(unit, _);
+
 module Let_syntax: {
   let bind: (~f: 'v1 => t('v2, 'err), t('v1, 'err)) => t('v2, 'err);
 }
+

--- a/esy-build-package/Run.rei
+++ b/esy-build-package/Run.rei
@@ -7,37 +7,84 @@
 type err('b) =
   [> | `Msg(string) | `CommandError(Cmd.t, Bos.OS.Cmd.status)] as 'b;
 
+/** Computation which might succeed or fail. */
 type t('v, 'e) = result('v, err('e));
 
-let ok : t(unit, _);
+
+/* Convenience */
+
 let return : 'v => t('v, _);
-
-let write : (~data:string, EsyLib.Path.t) => t(unit, _);
-let ls : EsyLib.Path.t => t(list(EsyLib.Path.t), _);
-let rm : EsyLib.Path.t => t(unit, _);
-let rmdir : EsyLib.Path.t => t(unit, _);
-let mv : (~force: bool=?, EsyLib.Path.t, EsyLib.Path.t) => t(unit, _);
-let mkdir : EsyLib.Path.t => t(unit, _);
-let realpath : EsyLib.Path.t => t(EsyLib.Path.t, _);
-let exists : EsyLib.Path.t => t(bool, _);
-let withCwd : (EsyLib.Path.t, ~f: unit => t('a, 'e)) => t('a, 'e);
-let symlink : (~force: bool=?, ~target: EsyLib.Path.t, EsyLib.Path.t) => t(unit, _);
-let symlinkTarget : EsyLib.Path.t => t(EsyLib.Path.t, _);
-let putTempFile : string => result(EsyLib.Path.t, [> Rresult.R.msg ]);
-
+let error : string => t(_, _);
 let coerceFrmMsgOnly : result('a, [ `Msg(string) ]) => t('a, _);
 
-let v : string => EsyLib.Path.t;
-let (/) : EsyLib.Path.t => string => EsyLib.Path.t;
-
-let traverse : (
-    EsyLib.Path.t,
-    (EsyLib.Path.t, Unix.stats) => t(unit, 'e)
-  ) => t(unit, 'e)
-
-let copyAllTo : (~from: Fpath.t, ~ignore: list(string)=?, Fpath.t) => t(unit, _);
+let ok : t(unit, _);
 
 module Let_syntax: {
   let bind: (~f: 'v1 => t('v2, 'err), t('v1, 'err)) => t('v2, 'err);
 }
 
+
+/* Path operations */
+
+let v : string => EsyLib.Path.t;
+let (/) : EsyLib.Path.t => string => EsyLib.Path.t;
+
+
+/* Filesystem operations: common. */
+
+/** Check if path exists. */
+let exists : EsyLib.Path.t => t(bool, _);
+
+/** Remove path, if it's a dir then remove it recursively. */
+let rm : EsyLib.Path.t => t(unit, _);
+
+/** Move. */
+let mv : (~force: bool=?, EsyLib.Path.t, EsyLib.Path.t) => t(unit, _);
+
+/** Resolve path using realpath. */
+let realpath : EsyLib.Path.t => t(EsyLib.Path.t, _);
+
+/** Get path stats (including info on symlinks). */
+let lstat : EsyLib.Path.t => t(Unix.stats, _);
+
+/** Perform operation with a different working directory. */
+let withCwd : (EsyLib.Path.t, ~f: unit => t('a, 'e)) => t('a, 'e);
+
+/** Traverse path. */
+let traverse : (
+    EsyLib.Path.t,
+    (EsyLib.Path.t, Unix.stats) => t(unit, 'e)
+  ) => t(unit, 'e)
+
+
+/* Filesystem operations: files. */
+
+/** Read file into strinlg. */
+let read : (EsyLib.Path.t) => t(string, _);
+
+/** Write data into file */
+let write : (~data:string, EsyLib.Path.t) => t(unit, _);
+
+/** Create temporary file with data. */
+let createTmpFile : string => t(EsyLib.Path.t, _);
+
+
+/* Filesystem operations: directories. */
+
+/** List directory and return a list of relative paths. */
+let ls : EsyLib.Path.t => t(list(EsyLib.Path.t), _);
+
+/** Create a directory. */
+let mkdir : EsyLib.Path.t => t(unit, _);
+
+/** Copy contents of a directory to the destination directory. */
+let copyContents : (~from: Fpath.t, ~ignore: list(string)=?, Fpath.t) => t(unit, _);
+
+
+/* Filesystem operations: symlinks. */
+
+/** Create a symlink. */
+let symlink : (~force: bool=?, ~target: EsyLib.Path.t, EsyLib.Path.t) => t(unit, _);
+
+/** Read symlink's target. */
+let readlink : EsyLib.Path.t => t(EsyLib.Path.t, _);

--- a/esy-build-package/Sandbox.re
+++ b/esy-build-package/Sandbox.re
@@ -44,7 +44,7 @@ module Darwin = {
   let sandboxExec = config => {
     open Run;
     let configData = renderConfig(config);
-    let%bind configFilename = putTempFile(configData);
+    let%bind configFilename = createTmpFile(configData);
     let prepare = (~env, command) => {
       open Bos.OS.Cmd;
       let sandboxCommand =
@@ -81,7 +81,7 @@ module Windows = {
        * because we need the current PATH/env to pick up node and run the shell
        */
       let jsonString = convertEnvToJsonString(env);
-      let%bind environmentTempFile = putTempFile(jsonString);
+      let%bind environmentTempFile = createTmpFile(jsonString);
       let commandAsList = Cmd.to_list(command);
 
       /* Normalize slashes in the command we send to esy-bash */

--- a/esy-build-package/Task.re
+++ b/esy-build-package/Task.re
@@ -40,7 +40,7 @@ type t = {
 };
 
 let ofFile = (path: Path.t) => {
-  let%bind data = Bos.OS.File.read(path);
+  let%bind data = Run.read(path);
   let json = Yojson.Safe.from_string(data);
   switch (of_yojson(json)) {
   | Ok(task) => Ok(task)

--- a/esy-build-package/bin/esyBuildPackageCommand.re
+++ b/esy-build-package/bin/esyBuildPackageCommand.re
@@ -98,9 +98,11 @@ let shell = (copts: commonOpts) => {
   let runShell = build => {
     ppBanner(build);
     let%bind rcFilename =
-      putTempFile({|
+      createTmpFile(
+        {|
         export PS1="[build $cur__name] % ";
-        |});
+        |},
+      );
     let cmd =
       Cmd.of_list([
         "bash",

--- a/esy/Environment.ml
+++ b/esy/Environment.ml
@@ -119,7 +119,7 @@ let current =
   |> List.filter ~f:filterFunctions
 
 let ofSandboxEnv =
-  let toEnvVar (Manifest.SandboxEnv. {name; value}) = {
+  let toEnvVar (Manifest.Env. {name; value}) = {
     name;
     value = Value value;
     origin = None;

--- a/esy/Manifest.ml
+++ b/esy/Manifest.ml
@@ -104,7 +104,7 @@ end
 (**
  * Environment for the entire sandbox as specified in "esy.sandboxEnv".
  *)
-module SandboxEnv = struct
+module Env = struct
 
   type item = {
     name : string;
@@ -208,7 +208,8 @@ module EsyManifest = struct
     install: (CommandList.t [@default None]);
     buildsInSource: (BuildType.t [@default BuildType.OutOfSource]);
     exportedEnv: (ExportedEnv.t [@default []]);
-    sandboxEnv: (SandboxEnv.t [@default []]);
+    buildEnv: (Env.t [@default Env.empty]);
+    sandboxEnv: (Env.t [@default Env.empty]);
     release: (EsyReleaseConfig.t option [@default None]);
   } [@@deriving (show, of_yojson { strict = false })]
 
@@ -217,7 +218,8 @@ module EsyManifest = struct
     install = None;
     buildsInSource = BuildType.OutOfSource;
     exportedEnv = [];
-    sandboxEnv = [];
+    sandboxEnv = Env.empty;
+    buildEnv = Env.empty;
     release = None;
   }
 

--- a/esy/NpmRelease.ml
+++ b/esy/NpmRelease.ml
@@ -207,6 +207,7 @@ let make ~esyInstallRelease ~outputPath ~concurrency ~cfg ~sandbox =
           dependencies = [Package.Dependency pkg];
           sourceType = Manifest.SourceType.Transient;
           sandboxEnv = pkg.sandboxEnv;
+          buildEnv = Manifest.Env.empty;
           build = Package.EsyBuild {
               buildCommands = None;
               installCommands = None;

--- a/esy/Package.ml
+++ b/esy/Package.ml
@@ -29,7 +29,8 @@ type t = {
   dependencies : dependencies;
   sourcePath : Config.ConfigPath.t;
   sourceType : Manifest.SourceType.t;
-  sandboxEnv : Manifest.SandboxEnv.t;
+  sandboxEnv : Manifest.Env.t;
+  buildEnv : Manifest.Env.t;
   exportedEnv : Manifest.ExportedEnv.t;
   resolution : string option;
   build : build;

--- a/esy/Sandbox.ml
+++ b/esy/Sandbox.ml
@@ -167,7 +167,8 @@ let ofDir (cfg : Config.t) =
           version = Manifest.Opam.version manifest;
           dependencies;
           sourceType = Manifest.Opam.sourceType manifest;
-          sandboxEnv = Manifest.SandboxEnv.empty;
+          sandboxEnv = Manifest.Env.empty;
+          buildEnv = Manifest.Env.empty;
           exportedEnv = Manifest.Opam.exportedEnv manifest;
           build = Package.OpamBuild {
             name = Manifest.Opam.opamName manifest;
@@ -200,6 +201,7 @@ let ofDir (cfg : Config.t) =
             dependencies;
             sourceType;
             sandboxEnv = esyManifest.sandboxEnv;
+            buildEnv = esyManifest.buildEnv;
             exportedEnv = esyManifest.exportedEnv;
             build = Package.EsyBuild {
               buildCommands = esyManifest.Manifest.EsyManifest.build;

--- a/esy/Task.ml
+++ b/esy/Task.ml
@@ -699,7 +699,13 @@ let ofPackage
           origin = Some pkg;
         }
       in
-      Result.List.map ~f pkg.buildEnv
+
+      let bindings =
+        {Manifest.Env. name = "DUNE_BUILD_DIR"; value = "#{self.target_dir}";}
+        :: pkg.buildEnv
+      in
+
+      Result.List.map ~f bindings
     in
 
     let buildEnv =

--- a/test/Task.ml
+++ b/test/Task.ml
@@ -45,6 +45,7 @@ module TestCommandExpr = struct
       }
     ];
     sandboxEnv = [];
+    buildEnv = [];
     sourcePath = Config.ConfigPath.ofPath cfg (Path.v "/path");
     resolution = Some "ok";
   }
@@ -64,6 +65,7 @@ module TestCommandExpr = struct
     };
     sourceType = Manifest.SourceType.Immutable;
     exportedEnv = [];
+    buildEnv = [];
     sandboxEnv = [];
     sourcePath = Config.ConfigPath.ofPath cfg (Path.v "/path");
     resolution = Some "ok";
@@ -81,8 +83,8 @@ module TestCommandExpr = struct
     check pkg (fun task ->
       Task.CommandList.equal
         task.buildCommands
-        [["cp"; "./hello"; "%store%/s/pkg-1.0.0-85fdaa3f/bin"];
-         ["cp"; "./hello2"; "%store%/s/pkg-1.0.0-85fdaa3f/bin"]]
+        [["cp"; "./hello"; "%store%/s/pkg-1.0.0-75f4d362/bin"];
+         ["cp"; "./hello2"; "%store%/s/pkg-1.0.0-75f4d362/bin"]]
     )
 
   let%test "#{...} inside esy.build / esy.install (depends on os)" =
@@ -122,7 +124,7 @@ module TestCommandExpr = struct
     check pkg (fun task ->
       Task.CommandList.equal
         task.installCommands
-        [["cp"; "./man"; "%store%/s/pkg-1.0.0-85fdaa3f/man"]]
+        [["cp"; "./man"; "%store%/s/pkg-1.0.0-75f4d362/man"]]
     )
 
   let%test "#{...} inside esy.exportedEnv" =
@@ -130,9 +132,9 @@ module TestCommandExpr = struct
       let bindings = Environment.Closed.bindings task.env in
       let f = function
         | {Environment. name = "OK"; value = Value value; _} ->
-          Some (value = "%store%/i/dep-1.0.0-ccbb761e/ok")
+          Some (value = "%store%/i/dep-1.0.0-ba8890c3/ok")
         | {Environment. name = "OK_BY_NAME"; value = Value value; _} ->
-          Some (value = "%store%/i/dep-1.0.0-ccbb761e/ok-by-name")
+          Some (value = "%store%/i/dep-1.0.0-ba8890c3/ok-by-name")
         | _ ->
           None
       in


### PR DESCRIPTION
This pull requests attempts to improve support for out-of-source builds and tailor some features specifically to support `dune` build system.

If this PR is merged then the following esy configuration is enough to enable fast out of source builds which are compatible with esy link workflow:
```json
"esy": {
  "build": "dune build",
  "install": "dune install --prefix=#{self.install}"
}
```

Note that `"install"` is required to use `dune install` as `opam-installer` (and subsequently `esy-installer` which uses the former) is buggy with `*.install` files generated by `dune` when `--build-dir` is present.

If/when `dune` starts support configuring installation prefix via environment variable (see ocaml/dune#946) then we can remove `--prefix=#{self.install}` part as well.

What this PR does:

- [x] Tweaks sandboxing rules to allow `*.install` in the source root. 
- [x] Adds `"esy.buildEnv"` (see below)
- [x] Automatically adds `DUNE_BUILD_DIR=#{self.target_dir}` to build env
- [x] For out-of-source root builds creates a symlink from `<sourceRoot>/_build` to `self.target_dir`
- [x] Refactors `EsyBuildpackage.Build` into a set of lifecycles (unsafe, relocate-source, out-of-source and jbuilder), this helps consolidating rules specific to different types of builds.

## `"esy.buildEnv"`

(copy from 44fcc61 message)

This adds `"esy.buildEnv"` configuration field to `package.json` manifests.

`"esy.buildEnv"` sets the additional variables to the build environment of the currently building package.

The main motivation is to enable true out-of-source builds with `dune`. `dune` can be configured to use an out-of-source location for build dir either via `--build-dir` flag or via `DUNE_BUILD_DIR` env variable.

While it is possiblle to set `"esy.build"` command to use `--build-dir` it only works for `esy build` invocation. For invocations like `esy b dune ...` it won't work unless you pass `--build-dir` manually each invocation.

With `"esy.buildEnv"` one could say in a `package.json`:

```
{
  "esy": {
    "build": "dune build",
    "install": "dune install",
    "buildEnv": {"DUNE_BUILD_DIR": "#{self.target_dir}"}
  }
  ...
}
```

and make all invocations of `dune` inside esy-constructed build env to use `#{self.target-dir}` as build dir.

I suspect `buildEnv` will be useful for other cases too.