### PR TITLE
Fix build break: merge conflict with envSep -> System.Environment.sep

### DIFF
--- a/esy-lib/ChildProcess.ml
+++ b/esy-lib/ChildProcess.ml
@@ -39,7 +39,7 @@ let resolveCmdInEnv ~env prg =
       | Some v  -> v
       | None -> ""
     in
-    String.split_on_char System.envSep.[0] v
+    String.split_on_char System.Environment.sep.[0] v
   in Run.ofBosError (Cmd.resolveCmd path prg)
 
 let withProcess ?(env=`CurrentEnv) ?(resolveProgramInEnv=false) ?stdin ?stdout ?stderr cmd f =


### PR DESCRIPTION
__Issue:__ After merging #270 , the builds went red.

__Defect:__ There was a silent merge conflict that wasn't picked up - part of the code using `System.envSep` but this had been refactored to `System.Environment.sep`. I should've brought in the latest `master` prior to merging, as the branch was a few days out-of-date.

__Fix:__ Change `System.envSep` -> `System.Environment.sep`.