### PR TITLE
tests: pin release test to ocaml@4.6.x

### DIFF
--- a/test-e2e/common/fixtures/release/package.json
+++ b/test-e2e/common/fixtures/release/package.json
@@ -4,29 +4,16 @@
   "license": "MIT",
   "dependencies": {
     "release-dep": "link:./dependencies/release-dep",
-    "ocaml": "^4.6.1"
+    "ocaml": "~4.6.1"
   },
   "esy": {
     "build": [
-      [
-        "cp",
-        "#{self.name '.exe'}",
-        "#{self.bin / self.name '.exe'}"
-      ],
-      [
-        "chmod",
-        "+x",
-        "#{self.bin / self.name '.exe'}"
-      ]
+      ["cp", "#{self.name '.exe'}", "#{self.bin / self.name '.exe'}"],
+      ["chmod", "+x", "#{self.bin / self.name '.exe'}"]
     ],
     "release": {
-      "releasedBinaries": [
-        "release.exe",
-        "release-dep.exe"
-      ],
-      "deleteFromBinaryRelease": [
-        "ocaml-*"
-      ]
+      "releasedBinaries": ["release.exe", "release-dep.exe"],
+      "deleteFromBinaryRelease": ["ocaml-*"]
     }
   }
 }


### PR DESCRIPTION
This just pulls @andreypopp 's fix for the tests (https://github.com/esy/esy/commit/a2a62b0f03420b21aeea997085d962ea2f1cc2ab) out to a separate change, to get the builds green 👍 