### PR TITLE
esy: do not inject DUNE_BUILD_DIR

### DIFF
--- a/esy/Task.ml
+++ b/esy/Task.ml
@@ -700,12 +700,7 @@ let ofPackage
         }
       in
 
-      let bindings =
-        {Manifest.Env. name = "DUNE_BUILD_DIR"; value = "#{self.target_dir}";}
-        :: pkg.buildEnv
-      in
-
-      Result.List.map ~f bindings
+      Result.List.map ~f pkg.buildEnv
     in
 
     let buildEnv =


### PR DESCRIPTION
It's breaking builds now as as *.install files genearted with the
presence of such var break `esy-installer`. We will re-introduce this
change later after we implement own installer.