### PR TITLE
Implement esy-installer

### DIFF
--- a/esy-build-package/Build.re
+++ b/esy-build-package/Build.re
@@ -309,6 +309,7 @@ module Installer =
       let stat = Run.lstat;
       let readdir = Run.ls;
       let mkdir = Run.mkdir;
+      let link = Run.link(~force=false);
     };
   });
 

--- a/esy-build-package/Run.re
+++ b/esy-build-package/Run.re
@@ -35,6 +35,7 @@ let ls = path => Bos.OS.Dir.contents(~dotfiles=true, ~rel=true, path);
 let rm = path => Bos.OS.Path.delete(~must_exist=false, ~recurse=true, path);
 let stat = Bos.OS.Path.stat;
 let lstat = Bos.OS.Path.symlink_stat;
+let link = Bos.OS.Path.link;
 let symlink = Bos.OS.Path.symlink;
 let readlink = Bos.OS.Path.symlink_target;
 

--- a/esy-build-package/Run.re
+++ b/esy-build-package/Run.re
@@ -6,7 +6,11 @@ type err('b) =
 
 type t('v, 'e) = result('v, err('e));
 
-let coerceFrmMsgOnly = x => (x: result(_, [ | `Msg(string)]) :> t(_, _));
+let coerceFromMsgOnly = x => (x: result(_, [ | `Msg(string)]) :> t(_, _));
+let coerceFromClosed = x => (
+  x: result(_, [ | `Msg(string) | `CommandError(Cmd.t, Bos.OS.Cmd.status)]) :>
+    t(_, _)
+);
 
 let ok = Result.ok;
 let return = v => Ok(v);

--- a/esy-build-package/Run.re
+++ b/esy-build-package/Run.re
@@ -29,15 +29,18 @@ let mkdir = path =>
 let ls = path => Bos.OS.Dir.contents(~dotfiles=true, ~rel=true, path);
 
 let rm = path => Bos.OS.Path.delete(~must_exist=false, ~recurse=true, path);
+let stat = Bos.OS.Path.stat;
 let lstat = Bos.OS.Path.symlink_stat;
 let symlink = Bos.OS.Path.symlink;
 let readlink = Bos.OS.Path.symlink_target;
 
-let write = (~data, path) => Bos.OS.File.write(path, data);
+let write = (~perm=?, ~data, path) =>
+  Bos.OS.File.write(~mode=?perm, path, data);
 let read = path => Bos.OS.File.read(path);
 
 let mv = Bos.OS.Path.move;
 
+let bind = Result.Syntax.Let_syntax.bind;
 module Let_syntax = Result.Syntax.Let_syntax;
 
 let rec realpath = (p: Fpath.t) => {

--- a/esy-build-package/Run.rei
+++ b/esy-build-package/Run.rei
@@ -86,7 +86,10 @@ let mkdir : EsyLib.Path.t => t(unit, _);
 let copyContents : (~from: Fpath.t, ~ignore: list(string)=?, Fpath.t) => t(unit, _);
 
 
-/* Filesystem operations: symlinks. */
+/* Filesystem operations: links. */
+
+/** Create a  hard link. */
+let link : (~force: bool=?, ~target: EsyLib.Path.t, EsyLib.Path.t) => t(unit, _);
 
 /** Create a symlink. */
 let symlink : (~force: bool=?, ~target: EsyLib.Path.t, EsyLib.Path.t) => t(unit, _);

--- a/esy-build-package/Run.rei
+++ b/esy-build-package/Run.rei
@@ -16,7 +16,8 @@ type t('v, 'e) = result('v, err('e));
 let return : 'v => t('v, _);
 let error : string => t(_, _);
 let bind : (~f: 'a => result('b, 'c), result('a, 'c)) => result('b, 'c)
-let coerceFrmMsgOnly : result('a, [ `Msg(string) ]) => t('a, _);
+let coerceFromMsgOnly : result('a, [ `Msg(string) ]) => t('a, _);
+let coerceFromClosed : result('a, [ `Msg(string) | `CommandError(Cmd.t, Bos.OS.Cmd.status) ]) => t('a, _);
 
 let ok : t(unit, _);
 

--- a/esy-build-package/Run.rei
+++ b/esy-build-package/Run.rei
@@ -15,6 +15,7 @@ type t('v, 'e) = result('v, err('e));
 
 let return : 'v => t('v, _);
 let error : string => t(_, _);
+let bind : (~f: 'a => result('b, 'c), result('a, 'c)) => result('b, 'c)
 let coerceFrmMsgOnly : result('a, [ `Msg(string) ]) => t('a, _);
 
 let ok : t(unit, _);
@@ -44,6 +45,9 @@ let mv : (~force: bool=?, EsyLib.Path.t, EsyLib.Path.t) => t(unit, _);
 /** Resolve path using realpath. */
 let realpath : EsyLib.Path.t => t(EsyLib.Path.t, _);
 
+/** Get path stats. */
+let stat : EsyLib.Path.t => t(Unix.stats, _);
+
 /** Get path stats (including info on symlinks). */
 let lstat : EsyLib.Path.t => t(Unix.stats, _);
 
@@ -63,7 +67,7 @@ let traverse : (
 let read : (EsyLib.Path.t) => t(string, _);
 
 /** Write data into file */
-let write : (~data:string, EsyLib.Path.t) => t(unit, _);
+let write : (~perm: int=?, ~data: string, EsyLib.Path.t) => t(unit, _);
 
 /** Create temporary file with data. */
 let createTmpFile : string => t(EsyLib.Path.t, _);

--- a/esy-build-package/bin/esyBuildPackageCommand.re
+++ b/esy-build-package/bin/esyBuildPackageCommand.re
@@ -35,7 +35,7 @@ let createConfig = (copts: commonOpts) => {
         "../../../../bin/fastreplacestring",
         basedir,
       );
-    switch%bind (Run.coerceFrmMsgOnly(resolution)) {
+    switch%bind (Run.coerceFromMsgOnly(resolution)) {
     | Some(path) => Ok(Fpath.to_string(path))
     | None => Error(`Msg("cannot resolve fastreplacestring command"))
     };

--- a/esy-build-package/dune
+++ b/esy-build-package/dune
@@ -5,6 +5,7 @@
   (preprocess (pps ppx_let ppx_deriving_yojson ppx_deriving.std))
   (libraries
             EsyLib
+            EsyInstaller
             cmdliner
             yojson
             bos

--- a/esy-installer/Installer.ml
+++ b/esy-installer/Installer.ml
@@ -39,7 +39,9 @@ module Make (Io : IO) : INSTALLER with type 'v computation = 'v Io.computation =
   let allowLinkFiles =
     match Sys.os_type with
     | "Unix" -> true
-    | _ -> false
+    | "Win32" -> true
+    | "Cygwin" -> true
+    | _ -> false (* maybe not supported, not sure *)
 
   let installFile
     ?(executable=false)

--- a/esy-installer/Installer.ml
+++ b/esy-installer/Installer.ml
@@ -1,0 +1,224 @@
+module type IO = sig
+
+  type 'v computation
+  val return : 'v -> 'v computation
+  val error : string -> 'v computation
+  val bind : f:('v1 -> 'v2 computation) -> 'v1 computation -> 'v2 computation
+  val handle : 'v computation -> ('v, string) result computation
+
+  module Fs : sig
+    val mkdir : Fpath.t -> unit computation
+    val readdir : Fpath.t -> Fpath.t list computation
+    val read : Fpath.t -> string computation
+    val write : ?perm:int -> data:string -> Fpath.t -> unit computation
+    val stat : Fpath.t -> Unix.stats computation
+  end
+end
+
+module type INSTALLER = sig
+  type 'v computation
+  val run : root:Fpath.t -> prefix:Fpath.t -> string option -> unit computation
+end
+
+module Make (Io : IO) : INSTALLER with type 'v computation = 'v Io.computation = struct
+
+  open Io
+
+  type nonrec 'v computation = 'v computation
+
+  module Let_syntax = struct
+    let bind = bind
+  end
+
+  module F = OpamFile.Dot_install
+
+  let setExecutable perm = perm lor  0o111
+  let unsetExecutable perm = perm land (lnot 0o111)
+
+  let installFile
+    ?(executable=false)
+    ~root
+    ~prefix
+    ~(dstFilename : Fpath.t option)
+    (src : OpamTypes.basename OpamTypes.optional)
+    =
+    let srcPath =
+      let path = src.c |> OpamFilename.Base.to_string |> Fpath.v in
+      if Fpath.is_abs path
+      then path
+      else Fpath.(root // path)
+    in
+    let dstPath =
+      match dstFilename with
+      | None -> Fpath.(prefix / Fpath.basename srcPath)
+      | Some dstFilename -> Fpath.(prefix // dstFilename)
+    in
+    match%bind handle (Fs.stat srcPath) with
+    | Ok stats ->
+      let%bind data = Fs.read srcPath in
+      let%bind () = Fs.mkdir (Fpath.parent dstPath) in
+      let%bind () =
+        let perm =
+          if executable
+          then setExecutable stats.Unix.st_perm
+          else unsetExecutable stats.Unix.st_perm
+        in
+        Fs.write ~data ~perm dstPath
+      in
+      return ()
+    | Error msg ->
+      if src.optional
+      then return ()
+      else error msg
+
+    let installSection ?executable ?dstFilename ~root ~prefix files =
+      let rec aux = function
+        | [] -> return ()
+        | (src, dstFilenameSpec)::rest ->
+          let dstFilename =
+            match dstFilenameSpec, dstFilename with
+            | Some name, _ -> Some (Fpath.v (OpamFilename.Base.to_string name))
+            | None, Some dstFilename ->
+              let src = Fpath.v (OpamFilename.Base.to_string src.OpamTypes.c) in
+              Some (dstFilename src)
+            | None, None -> None
+          in
+          let%bind () = installFile ?executable ~root ~prefix ~dstFilename src in
+          aux rest
+      in
+      aux files
+
+  let run ~(root : Fpath.t) ~(prefix : Fpath.t) (filename : string option) =
+
+    let%bind (packageName, spec) =
+      let%bind filename =
+        match filename with
+        | Some name -> return Fpath.(root / name)
+        | None ->
+          let%bind items = Fs.readdir root in
+          let isInstallFile filename = Fpath.has_ext ".install" filename in
+          begin match List.filter isInstallFile items with
+          | [filename] -> return filename
+          | [] -> error "no *.install files found"
+          | _ -> error "multiple *.install files found"
+          end
+        in
+      let%bind data = Fs.read filename in
+      let packageName = Fpath.basename (Fpath.rem_ext filename) in
+      let spec =
+        let filename = OpamFile.make (OpamFilename.of_string (Fpath.to_string filename)) in
+        F.read_from_string ~filename data
+      in
+      return (packageName, spec)
+    in
+
+    (* See
+      *
+      *   https://opam.ocaml.org/doc/2.0/Manual.html#lt-pkgname-gt-install
+      *
+      * for explanations on each section.
+      *)
+
+    let%bind () =
+      installSection
+        ~root
+        ~prefix:Fpath.(prefix / "lib" / packageName)
+        (F.lib spec)
+    in
+
+    let%bind () =
+      installSection
+        ~root
+        ~prefix:Fpath.(prefix / "lib")
+        (F.lib_root spec)
+    in
+
+    let%bind () =
+      installSection
+        ~executable:true
+        ~root
+        ~prefix:Fpath.(prefix / "lib" / packageName)
+        (F.libexec spec)
+    in
+
+    let%bind () =
+      installSection
+        ~executable:true
+        ~root
+        ~prefix:Fpath.(prefix / "lib")
+        (F.libexec_root spec)
+    in
+
+    let%bind () =
+      installSection
+        ~executable:true
+        ~root
+        ~prefix:Fpath.(prefix / "bin")
+        (F.bin spec)
+    in
+
+    let%bind () =
+      installSection
+        ~executable:true
+        ~root
+        ~prefix:Fpath.(prefix / "sbin")
+        (F.sbin spec)
+    in
+
+    let%bind () =
+      installSection
+        ~root
+        ~prefix:Fpath.(prefix / "lib" / "toplevel")
+        (F.toplevel spec)
+    in
+
+    let%bind () =
+      installSection
+        ~root
+        ~prefix:Fpath.(prefix / "share" / packageName)
+        (F.share spec)
+    in
+
+    let%bind () =
+      installSection
+        ~root
+        ~prefix:Fpath.(prefix / "share")
+        (F.share_root spec)
+    in
+
+    let%bind () =
+      installSection
+        ~root
+        ~prefix:Fpath.(prefix / "etc" / packageName)
+        (F.etc spec)
+    in
+
+    let%bind () =
+      installSection
+        ~root
+        ~prefix:Fpath.(prefix / "doc" / packageName)
+        (F.doc spec)
+    in
+
+    let%bind () =
+      installSection
+        ~executable:true
+        ~root
+        ~prefix:Fpath.(prefix / "lib" / "stublibs")
+        (F.stublibs spec)
+    in
+
+    let%bind () =
+      let dstFilename src =
+        let num = Fpath.get_ext src in
+        Fpath.(v ("man" ^ num) / basename src)
+      in
+      installSection
+        ~dstFilename
+        ~root
+        ~prefix:Fpath.(prefix / "man")
+        (F.man spec)
+    in
+
+    return ()
+end

--- a/esy-installer/Installer.mli
+++ b/esy-installer/Installer.mli
@@ -11,6 +11,7 @@ module type IO = sig
     val readdir : Fpath.t -> Fpath.t list computation
     val read : Fpath.t -> string computation
     val write : ?perm:int -> data:string -> Fpath.t -> unit computation
+    val link : target:Fpath.t -> Fpath.t -> unit computation
     val stat : Fpath.t -> Unix.stats computation
   end
 end

--- a/esy-installer/Installer.mli
+++ b/esy-installer/Installer.mli
@@ -20,7 +20,7 @@ module type INSTALLER = sig
   type 'v computation
 
   (** Perform installation given the root and a prefix. *)
-  val run : root:Fpath.t -> prefix:Fpath.t -> string option -> unit computation
+  val run : rootPath:Fpath.t -> prefixPath:Fpath.t -> string option -> unit computation
 end
 
 module Make (Io : IO) : INSTALLER with type 'v computation = 'v Io.computation

--- a/esy-installer/Installer.mli
+++ b/esy-installer/Installer.mli
@@ -1,0 +1,26 @@
+module type IO = sig
+
+  type 'v computation
+  val return : 'v -> 'v computation
+  val error : string -> 'v computation
+  val bind : f : ('v1 -> 'v2 computation) -> 'v1 computation -> 'v2 computation
+  val handle : 'v computation -> ('v, string) result computation
+
+  module Fs : sig
+    val mkdir : Fpath.t -> unit computation
+    val readdir : Fpath.t -> Fpath.t list computation
+    val read : Fpath.t -> string computation
+    val write : ?perm:int -> data:string -> Fpath.t -> unit computation
+    val stat : Fpath.t -> Unix.stats computation
+  end
+end
+
+(** An installer which is parametrized over IO *)
+module type INSTALLER = sig
+  type 'v computation
+
+  (** Perform installation given the root and a prefix. *)
+  val run : root:Fpath.t -> prefix:Fpath.t -> string option -> unit computation
+end
+
+module Make (Io : IO) : INSTALLER with type 'v computation = 'v Io.computation

--- a/esy-installer/dune
+++ b/esy-installer/dune
@@ -1,0 +1,6 @@
+(library
+  (name EsyInstaller)
+  (public_name esy-installer)
+  (preprocess (pps ppx_let))
+  (libraries opam-format fpath)
+  )

--- a/esy/Manifest.ml
+++ b/esy/Manifest.ml
@@ -473,7 +473,6 @@ end = struct
       in
       let dependencies =
         "ocaml"
-        ::"@esy-ocaml/esy-installer"
         ::"@esy-ocaml/substs"
         ::dependencies
       in

--- a/esy/Task.ml
+++ b/esy/Task.ml
@@ -1012,13 +1012,13 @@ let ofPackage
             _
           } as build) ->
           let%bind installCommands = renderOpamCommands build installCommands in
-          return (installCommands @ [["sh"; "-c"; "(esy-installer || true)"]])
+          return installCommands
         | Package.OpamBuild ({
             installCommands = Manifest.Opam.OverridenCommands installCommands;
             _
           }) ->
           let%bind installCommands = renderEsyCommands installCommands in
-          return (installCommands @ [["sh"; "-c"; "(esy-installer || true)"]])
+          return installCommands
         end
     in
 

--- a/esyi/OpamRegistry.ml
+++ b/esyi/OpamRegistry.ml
@@ -349,11 +349,6 @@ module Manifest = struct
           @ [
               [{
                 Package.Dep.
-                name = "@esy-ocaml/esy-installer";
-                req = Npm SemverVersion.Constraint.ANY;
-              }];
-              [{
-                Package.Dep.
                 name = "@esy-ocaml/substs";
                 req = Npm SemverVersion.Constraint.ANY;
               }];

--- a/esyi/bin/dune
+++ b/esyi/bin/dune
@@ -4,5 +4,5 @@
   (public_name esyi)
   (flags (:standard "-open" "EsyLib"))
   (preprocess (pps lwt_ppx ppx_let ppxlib))
-  (libraries EsyInstaller cmdliner)
+  (libraries EsyInstall cmdliner)
   )

--- a/esyi/bin/esyi.re
+++ b/esyi/bin/esyi.re
@@ -1,4 +1,4 @@
-open EsyInstaller;
+open EsyInstall;
 module String = Astring.String;
 
 module Api = {

--- a/esyi/dune
+++ b/esyi/dune
@@ -1,5 +1,5 @@
 (library
-  (name EsyInstaller)
+  (name EsyInstall)
   (public_name esyi)
   (preprocess (pps
                   lwt_ppx ppx_let


### PR DESCRIPTION
This adds a new library `esy-installer` which implements installer following [spec in the opam manual](https://opam.ocaml.org/doc/2.0/Manual.html#lt-pkgname-gt-install).

The library itself is functorized over IO monad and a corresponding filesystem API and currently is being used in `esy-build-package` if there's no `install` commands defined and there's `*.install` file found in the root.

esy-ocaml/hello-ocaml builds ok, but I plan to confirm it is working on a wider set of packages and only merge after that.