### PR TITLE
Windows - Build: Clear AppVeyor OPAM cache whenever dune files change

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ platform:
     - x64
 
 cache:
-    - C:\Users\appveyor\.opam
+    - C:\Users\appveyor\.opam -> **\dune
 
 install:
     - where git


### PR DESCRIPTION
This clears the OPAM cache whenever a `dune` file changes (which usually indicates we need a new library). I'm not sure if this is the perfect criteria for it (we may also need it to change when the bootstrap scripts change), but it's better than never clearing it out. 

This should address the build issue with #291 