### PR TITLE
Fix #286: Don't use chown on Windows

### DIFF
--- a/esy-lib/Fs.ml
+++ b/esy-lib/Fs.ml
@@ -166,14 +166,19 @@ let traverse ?skipTraverse ~f path =
   let f _ path stat = f path stat in
   fold ?skipTraverse ~f ~init:() path
 
+let chownLwt path uid gid =
+    match System.Platform.host with
+    | Windows -> Lwt.return () (* chown is not available in Windows *)
+    | _ ->
+        try%lwt Lwt_unix.chown path uid gid
+        with Unix.Unix_error (Unix.EPERM, _, _) -> Lwt.return ()
+
 let copyStatLwt ~stat path =
   let path = Path.to_string path in
   let%lwt () = Lwt_unix.utimes path stat.Unix.st_atime stat.Unix.st_mtime in
   let%lwt () = Lwt_unix.chmod path stat.Unix.st_perm in
-  let%lwt () =
-    try%lwt Lwt_unix.chown path stat.Unix.st_uid stat.Unix.st_gid
-    with Unix.Unix_error (Unix.EPERM, _, _) -> Lwt.return ()
-  in Lwt.return ()
+  let%lwt () = chownLwt path stat.Unix.st_uid stat.Unix.st_gid in
+  Lwt.return ()
 
 let copyFileLwt ~src ~dst =
 

--- a/esy-lib/Fs.ml
+++ b/esy-lib/Fs.ml
@@ -166,7 +166,7 @@ let traverse ?skipTraverse ~f path =
   let f _ path stat = f path stat in
   fold ?skipTraverse ~f ~init:() path
 
-let chownLwt path uid gid =
+let chownOrIgnoreLwt path uid gid =
     match System.Platform.host with
     | Windows -> Lwt.return () (* chown is not available in Windows *)
     | _ ->
@@ -177,7 +177,7 @@ let copyStatLwt ~stat path =
   let path = Path.to_string path in
   let%lwt () = Lwt_unix.utimes path stat.Unix.st_atime stat.Unix.st_mtime in
   let%lwt () = Lwt_unix.chmod path stat.Unix.st_perm in
-  let%lwt () = chownLwt path stat.Unix.st_uid stat.Unix.st_gid in
+  let%lwt () = chownOrIgnoreLwt path stat.Unix.st_uid stat.Unix.st_gid in
   Lwt.return ()
 
 let copyFileLwt ~src ~dst =


### PR DESCRIPTION
__Issue:__ When running `esy export-build` on Windows, get this error message:
```
esy: internal error, uncaught exception:
     (Invalid_argument "Unix.chown not implemented")
     Raised at file "pervasives.ml", line 33, characters 20-45
```

__Defect:__ `Unix.chown` is not implemented for Windows

__Fix:__ Don't call on WIndows. Fixes #286 