### PR TITLE
Windows - Fix #242: Failure building menhir

### DIFF
--- a/esy-build-package/Build.re
+++ b/esy-build-package/Build.re
@@ -335,7 +335,7 @@ let commitBuildToStore = (config: Config.t, build: build) => {
         let%bind () = rewritePrefixInFile(~origPrefix=origPrefixString, ~destPrefix=destPrefixString, path);
         let normalizedOrigPrefix = Path.normalizePathSlashes(origPrefixString);
         let normalizedDestPrefix = Path.normalizePathSlashes(destPrefixString);
-        let%bind () = rewritePrefixInFile(~origPrefix=normalizedOrigPrefixPath, ~destPrefix=normalizedDestPrefixPath, path);
+        let%bind () = rewritePrefixInFile(~origPrefix=normalizedOrigPrefix, ~destPrefix=normalizedDestPrefix, path);
         ok;
     | _ =>
         rewritePrefixInFile(~origPrefix=origPrefixString, ~destPrefix=destPrefixString, path);

--- a/esy-build-package/Build.re
+++ b/esy-build-package/Build.re
@@ -320,25 +320,25 @@ let commitBuildToStore = (config: Config.t, build: build) => {
         empty
         % config.fastreplacestringCmd
         % p(path)
-        % p(origPrefix)
-        % p(destPrefix)
+        % origPrefix
+        % destPrefix
       );
     Bos.OS.Cmd.run(cmd);
   };
   let rewritePrefixesInFile = (~origPrefix, ~destPrefix, path) => {
+    let origPrefixString = Path.to_string(origPrefix);
+    let destPrefixString = Path.to_string(destPrefix);
     switch (System.Platform.host) {
     | Windows =>
         /* On Windows, the slashes could be either `/` or windows-style `\` */
         /* We'll replace both styles */
-        let%bind () = rewritePrefixInFile(~origPrefix, ~destPrefix, path);
-        let normalizedOrigPrefix = Path.normalizePathSlashes(Path.to_string(origPrefix));
-        let normalizedDestPrefix = Path.normalizePathSlashes(Path.to_string(destPrefix));
-        let normalizedOrigPrefixPath = Fpath.v(normalizedOrigPrefix);
-        let normalizedDestPrefixPath = Fpath.v(normalizedDestPrefix);
+        let%bind () = rewritePrefixInFile(~origPrefix=origPrefixString, ~destPrefix=destPrefixString, path);
+        let normalizedOrigPrefix = Path.normalizePathSlashes(origPrefixString);
+        let normalizedDestPrefix = Path.normalizePathSlashes(destPrefixString);
         let%bind () = rewritePrefixInFile(~origPrefix=normalizedOrigPrefixPath, ~destPrefix=normalizedDestPrefixPath, path);
         ok;
     | _ =>
-        rewritePrefixInFile(~origPrefix, ~destPrefix, path);
+        rewritePrefixInFile(~origPrefix=origPrefixString, ~destPrefix=destPrefixString, path);
     }
   };
   let rewriteTargetInSymlink = (~origPrefix, ~destPrefix, path) => {


### PR DESCRIPTION
__Issue:__ The `fastreplacestring` replacement of prefix paths from install -> store wasn't happening reliably. This would manifest as obscure errors, like: `Failure: Cannot find "ocamlbuild.cmo" in ocamlbuild -where'

__Defect:__ Some of the binaries would have paths in posix-style paths, like `C:/users/bryphe/.esy/3/_/s/...`. However, with the Path library we use in sending arguments to `fastreplacestring`, we'd always send windows-style paths, like `C:\users\bryphe\.esy\3_\s\`. This meant that the paths would not actually get replaced.

__Fix:__ On Windows, do two passes of replacement - the first with windows-style paths, and the second with 'normalized' paths (meaning posix style paths).

After this fix, `menhir` builds for `esy-reason-project`, and it gets significantly farther, however it still doesn't build completely quite yet. 