### PR TITLE
[WIP] Start running the e2e tests on Windows / AppVeyor

### DIFF
--- a/scripts/bootstrap/Test.ps1
+++ b/scripts/bootstrap/Test.ps1
@@ -20,14 +20,15 @@ ls
 mkdir C:/esy-home
 $env:HOME="C:/esy-home"
 
-# "Integration Test" for now
-# This requires retries on all platforms at the moment:
+
+# Install esy's dependencies so that we can run the jest tests
+
+cd C:/projects/esy
+
 C:/projects/esy/_release/_build/default/esy/bin/esyCommand.exe legacy-install
 C:/projects/esy/_release/_build/default/esy/bin/esyCommand.exe legacy-install
 C:/projects/esy/_release/_build/default/esy/bin/esyCommand.exe legacy-install
 
-exitIfFailed
+ exitIfFailed
 
-# TODO: Bring this back when we have a project that can build successfully!
-# C:/projects/esy/_release/_build/default/esy/bin/esyCommand.exe build
-# exitIfFailed
+ npm run test-e2e


### PR DESCRIPTION
This change leverages the awesome work @ulrikstrid did, and gets the `e2e` tests running on our Windows AppVeyor builds.

Currently, all the tests fail, but there should be a subset that pass on Windows. I'd like to get an initial set green, and then skip the rest for now - we can incrementally get more and more tests green to build out our windows 'safety net'. 

This also gives us the platform to add additional `e2e` tests as we fix Windows bugs - would be great to have e2e tests that exercise things like #294 