### PR TITLE
Fixes to esyi

### DIFF
--- a/esy-lib/Fs.ml
+++ b/esy-lib/Fs.ml
@@ -15,12 +15,12 @@ let readFile (path : Path.t) =
     Lwt_io.with_file ~mode:Lwt_io.Input path f
   )
 
-let writeFile ~data (path : Path.t) =
+let writeFile ?perm ~data (path : Path.t) =
   let path = Path.to_string path in
   let desc = Printf.sprintf "Unable to write file %s" path in
   toRunAsync ~desc (fun () ->
     let f oc = Lwt_io.write oc data in
-    Lwt_io.with_file ~mode:Lwt_io.Output path f
+    Lwt_io.with_file ?perm ~mode:Lwt_io.Output path f
   )
 
 let openFile ~mode ~perm path =

--- a/esy-lib/Fs.mli
+++ b/esy-lib/Fs.mli
@@ -4,7 +4,7 @@
 
 val readFile : Path.t -> string RunAsync.t
 
-val writeFile : data:string -> Path.t -> unit RunAsync.t
+val writeFile : ?perm:int -> data:string -> Path.t -> unit RunAsync.t
 
 val readJsonFile : Path.t -> Yojson.Safe.json RunAsync.t
 

--- a/esyi/Config.re
+++ b/esyi/Config.re
@@ -37,7 +37,7 @@ let make =
       ~cacheTarballsPath=?,
       ~opamRepository=?,
       ~esyOpamOverride=?,
-      ~solveTimeout=8.0,
+      ~solveTimeout=60.0,
       ~esySolveCmd,
       ~createProgressReporter,
       ~skipRepositoryUpdate,

--- a/esyi/FetchStorage.ml
+++ b/esyi/FetchStorage.ml
@@ -132,7 +132,7 @@ let fetch ~(cfg : Config.t) (record : Solution.Record.t) =
     in
 
     let%bind () =
-      let f {Package.File. name; content} =
+      let f {Package.File. name; content; perm} =
         let name = Path.append path name in
         let dirname = Path.parent name in
         let%bind () = Fs.createDir dirname in
@@ -142,7 +142,7 @@ let fetch ~(cfg : Config.t) (record : Solution.Record.t) =
           then content
           else content ^ "\n"
         in
-        let%bind () = Fs.writeFile ~data:contents name in
+        let%bind () = Fs.writeFile ~perm ~data:contents name in
         return()
       in
       List.map ~f record.files |> RunAsync.List.waitAll

--- a/esyi/OpamOverrides.re
+++ b/esyi/OpamOverrides.re
@@ -92,8 +92,9 @@ let load = baseDir => {
       let f = (files, path, _stat) =>
         switch (Path.relativize(~root=filesPath, path)) {
         | Some(name) =>
-          let%bind content = Fs.readFile(path);
-          let file = {Package.File.name, content};
+          let%bind content = Fs.readFile(path)
+          and stat = Fs.stat(path);
+          let file = {Package.File.name, content, perm: stat.Unix.st_perm};
           return([file, ...files]);
         | None =>
           /* This case isn't really possible but... */

--- a/esyi/OpamRegistry.ml
+++ b/esyi/OpamRegistry.ml
@@ -173,8 +173,9 @@ let readOpamFiles (path : Path.t) () =
     let collect files filePath _fileStats =
       match Path.relativize ~root:filesPath filePath with
       | Some name ->
-        let%bind content = Fs.readFile filePath in
-        return ({Package.File. name; content}::files)
+        let%bind content = Fs.readFile filePath
+        and stats = Fs.stat filePath in
+        return ({Package.File. name; content; perm = stats.Unix.st_perm}::files)
       | None -> return files
     in
     Fs.fold ~init:[] ~f:collect filesPath

--- a/esyi/Package.ml
+++ b/esyi/Package.ml
@@ -774,7 +774,9 @@ module File = struct
   [@@@ocaml.warning "-32"]
   type t = {
     name : Path.t;
-    content : string
+    content : string;
+    (* file, permissions add 0o644 default for backward compat. *)
+    perm : (int [@default 0o644]);
   } [@@deriving (yojson, show, eq)]
 end
 

--- a/esyi/Package.ml
+++ b/esyi/Package.ml
@@ -370,6 +370,7 @@ module Req = struct
       str "https:";
       str "http:";
       str "git:";
+      str "npm:";
       str "link:";
       str "git+";
     ] in
@@ -383,23 +384,43 @@ module Req = struct
       Some (proto, body)
     | None -> None
 
-  let tryParseSourceSpec v =
+  let tryParseProto v =
     let open Result.Syntax in
     match parseProto v with
-    | Some ("link:", v) -> return (Some (SourceSpec.LocalPathLink (Path.v v)))
-    | Some ("file:", v) -> return (Some (SourceSpec.LocalPath (Path.v v)))
+    | Some ("link:", v) ->
+      let spec = SourceSpec.LocalPathLink (Path.v v) in
+      return (Some (VersionSpec.Source spec))
+    | Some ("file:", v) ->
+      let spec = SourceSpec.LocalPath (Path.v v) in
+      return (Some (VersionSpec.Source spec))
     | Some ("https:", _)
     | Some ("http:", _) ->
       let%bind url, checksum = parseChecksum v in
-      return (Some (SourceSpec.Archive {url; checksum}))
+      let spec = SourceSpec.Archive {url; checksum} in
+      return (Some (VersionSpec.Source spec))
     | Some ("git+", v) ->
       let remote, ref = parseRef v in
-      return (Some (SourceSpec.Git {remote;ref;}))
+      let spec = SourceSpec.Git {remote;ref;} in
+      return (Some (VersionSpec.Source spec))
     | Some ("git:", _) ->
       let remote, ref = parseRef v in
-      return (Some (SourceSpec.Git {remote;ref;}))
+      let spec = SourceSpec.Git {remote;ref;} in
+      return (Some (VersionSpec.Source spec))
+    | Some ("npm:", v) ->
+      begin match String.cut ~rev:true ~sep:"@" v with
+      | None ->
+        let%bind v = SemverVersion.Formula.parse v in
+        return (Some (VersionSpec.Npm v))
+      | Some (_, v) ->
+        let%bind v = SemverVersion.Formula.parse v in
+        return (Some (VersionSpec.Npm v))
+      end
     | Some _
-    | None -> return (tryParseGitHubSpec v)
+    | None ->
+      begin match tryParseGitHubSpec v with
+      | Some spec -> return (Some (VersionSpec.Source spec))
+      | None -> return None
+      end
 
   let make ~name ~spec =
     let open Result.Syntax in
@@ -411,20 +432,20 @@ module Req = struct
       let%bind spec =
         match String.cut ~sep:"/" name with
         | Some ("@opam", _opamName) -> begin
-          match%bind tryParseSourceSpec spec with
-          | Some spec -> Ok (VersionSpec.Source spec)
+          match%bind tryParseProto spec with
+          | Some v -> Ok v
           | None -> Ok (VersionSpec.Opam (OpamVersion.Formula.parse spec))
           end
         | Some _
         | None -> begin
-          match%bind tryParseSourceSpec spec with
-          | Some spec -> Ok (VersionSpec.Source spec)
+          match%bind tryParseProto spec with
+          | Some v -> Ok v
           | None ->
             begin match SemverVersion.Formula.parse spec with
               | Ok v -> Ok (VersionSpec.Npm v)
-              | Error err ->
-                let msg = Printf.sprintf "error parsing semver formula: %s" err in
-                Error msg
+              | Error _ ->
+                Logs.warn (fun m -> m "error parsing version: %s" spec);
+                Ok (VersionSpec.Npm [[SemverVersion.Constraint.ANY]])
             end
           end
       in
@@ -485,6 +506,18 @@ module Req = struct
           remote = "https://github.com/eslint/eslint.git";
           ref = Some "9d6223040316456557e0a2383afd96be90d28c5a"
         });
+
+      (* npm *)
+      make ~name:"pkg" ~spec:"4.1.0",
+      VersionSpec.Npm (SemverVersion.Formula.parseExn "4.1.0");
+      make ~name:"pkg" ~spec:"~4.1.0",
+      VersionSpec.Npm (SemverVersion.Formula.parseExn "~4.1.0");
+      make ~name:"pkg" ~spec:"^4.1.0",
+      VersionSpec.Npm (SemverVersion.Formula.parseExn "^4.1.0");
+      make ~name:"pkg" ~spec:"npm:>4.1.0",
+      VersionSpec.Npm (SemverVersion.Formula.parseExn ">4.1.0");
+      make ~name:"pkg" ~spec:"npm:name@>4.1.0",
+      VersionSpec.Npm (SemverVersion.Formula.parseExn ">4.1.0");
     ]
 
     let expectParsesTo req e =

--- a/esyi/Package.mli
+++ b/esyi/Package.mli
@@ -167,7 +167,8 @@ end
 module File : sig
   type t = {
     name : Path.t;
-    content : string
+    content : string;
+    perm : int;
   }
 
   val equal : t -> t -> bool

--- a/esyi/Package.mli
+++ b/esyi/Package.mli
@@ -191,9 +191,15 @@ module OpamOverride : sig
     val empty : t
   end
 
+  module Command : sig
+    type t =
+      | Args of string list
+      | Line of string
+  end
+
   type t = {
-    build : string list list option;
-    install : string list list option;
+    build : Command.t list option;
+    install : Command.t list option;
     dependencies : NpmDependencies.t;
     peerDependencies : NpmDependencies.t;
     exportedEnv : ExportedEnv.t;

--- a/esyi/Solver.ml
+++ b/esyi/Solver.ml
@@ -547,9 +547,14 @@ let solveDependenciesNaively
       match dependencies with
       | Dependencies.NpmFormula reqs -> reqs
       | Dependencies.OpamFormula _ ->
-        (* TODO: cause opam formulas should be solved by the proper dependency
-        * solver we skip solving them, but we need some sanity check here *)
-        Dependencies.toApproximateRequests dependencies
+        (* only use already installed dependencies here
+         * TODO: refactor solution * construction so we don't need to do that *)
+        let reqs = Dependencies.toApproximateRequests dependencies in
+        let reqs =
+          let f req = Hashtbl.mem installed req.Req.name in
+          List.filter ~f reqs
+        in
+        reqs
     in
 
     let%bind pkgs =

--- a/esyi/Solver.ml
+++ b/esyi/Solver.ml
@@ -554,7 +554,12 @@ let solveDependenciesNaively
 
     let%bind pkgs =
       let f req =
-        let%bind pkg = resolve req in
+        let%bind pkg =
+          let context = Format.asprintf "resolving request %a" Req.pp req in
+          RunAsync.withContext
+            context
+            (resolve req)
+        in
         addToInstalled pkg;
         return pkg
       in
@@ -572,7 +577,12 @@ let solveDependenciesNaively
         loop seen rest
       | false ->
         let seen = Package.Set.add pkg seen in
-        let%bind dependencies = solveDependencies pkg.dependencies in
+        let%bind dependencies =
+          let context = Format.asprintf "solving dependencies of %a" Package.pp pkg in
+          RunAsync.withContext
+            context
+            (solveDependencies pkg.dependencies)
+        in
         addDependencies pkg dependencies;
         loop seen (rest @ dependencies)
       end

--- a/test-e2e/build-top-100-opam.slowtest.js
+++ b/test-e2e/build-top-100-opam.slowtest.js
@@ -108,6 +108,8 @@ const cases = [
   {name: "async", toolchains: ["~4.6.0"]},
   {name: "cudf", toolchains: ["~4.6.0"]},
   {name: "dose3", toolchains: ["~4.6.0"]},
+  {name: "ssl", toolchains: ["~4.6.0"]},
+  {name: "tls", toolchains: ["~4.6.0"]},
 ];
 
 const esyPrefixPath = fs.mkdtempSync('/tmp/esy-prefix');

--- a/test-e2e/install-npm.slowtest.js
+++ b/test-e2e/install-npm.slowtest.js
@@ -45,6 +45,12 @@ const cases = [
       require('babel-core');
     `
   },
+  {
+    name: "react-scripts",
+    test: `
+      require('react-scripts/bin/react-scripts.js');
+    `
+  },
 ];
 
 let p;


### PR DESCRIPTION
This PR brings assorted fixes to `esy install` command:

- [x] Makes `react-scripts` installable by not failing on invalid versions (yeah they are occurring in npm registry sometimes) and adding support for `npm:name@x.x.x` version specs (though `name` part isn't handled at the moment, going to look later into it).
- [x] Correctness fixes to dedupe algo — see 3875152 message for more info.
- [x] Correctly calculate sandbox checksum so that lockfile is invalidated on `devDependencies` changes.
- [x] Copy permissions from `files` of opam repo and opam override to installation location.
- [x] Fix `build` and `install` overrides to accept the same format for commands as `esy` accepts.
- [x] Fix handling disjunction of dependency requests both in `esyi` (previously it was trying to solve all packages mentioned in a disjunction using naive solver) and `esy` (same as in esy — it was trying to find all packages mentioned in `node_modules`)