### PR TITLE
Windows Support - esyi: Ignore solver temporarily

### DIFF
--- a/esyi/bin/esyi.re
+++ b/esyi/bin/esyi.re
@@ -222,8 +222,14 @@ module CommandLineInterface = {
         };
         (progress, finish);
       };
-      let%bind esySolveCmd =
-        resolve("esy-solve-cudf/esySolveCudfCommand.exe");
+
+      let%bind esySolveCmd = switch (System.Platform.host) {
+        /* Temporary workaround for #302, that we can leverage esyi on Windows without the solver -
+         * In other words, we can use esyi on Windows when an 'esy.lock.json' is present */
+        | Windows => return(Cmd.v("esy-solve-cudf/esySolveCudfCommand.exe"));
+        | _ => resolve("esy-solve-cudf/esySolveCudfCommand.exe");
+      };
+
       let%bind cfg =
         Config.make(
           ~esySolveCmd,


### PR DESCRIPTION
Per discussion with @andreypopp , we decided to pivot and get `esyi` working on Windows, even though #302 blocks the actual solver from working on Windows. We decided to start by handling the case where there is a lockfile already present, which can be generated on Mac/Linux and checked-in.

This addresses the first of several blockers to getting `esyi` running on Windows in pursuit of the lockfile-install strategy. 

This PR simply doesn't try to look for `esy-solve-cudf` when started on Windows.

Once we have a fix for #302 and `esy-solve-cudf` is building on Windows - we should revert this and bring back the solver