### PR TITLE
Windows Support - esyi: Fix filenames for temporary download tarballs

### DIFF
--- a/esy-lib/Path.re
+++ b/esy-lib/Path.re
@@ -47,3 +47,32 @@ let of_yojson = (json: Yojson.Safe.json) =>
   };
 
 let to_yojson = (path: t) => `String(to_string(path));
+
+let safeName = {
+  let replaceAt = Str.regexp("@");
+  let replaceUnderscore = Str.regexp("_+");
+  let replaceSlash = Str.regexp("\\/");
+  let replaceDot = Str.regexp("\\.");
+  let replaceDash = Str.regexp("\\-");
+  let replaceColon = Str.regexp(":");
+  let make = (name: string) =>
+    name
+    |> String.lowercase_ascii
+    |> Str.global_replace(replaceAt, "")
+    |> Str.global_replace(replaceUnderscore, "__")
+    |> Str.global_replace(replaceSlash, "__slash__")
+    |> Str.global_replace(replaceDot, "__dot__")
+    |> Str.global_replace(replaceColon, "__colon__")
+    |> Str.global_replace(replaceDash, "_");
+  make;
+};
+
+let safePath = {
+  let replaceSlash = Str.regexp("\\/");
+  let replaceColon = Str.regexp(":");
+  let make = name =>
+    name
+    |> Str.global_replace(replaceSlash, "__slash__")
+    |> Str.global_replace(replaceColon, "__colon__");
+  make;
+};

--- a/esy/Task.ml
+++ b/esy/Task.ml
@@ -160,33 +160,6 @@ let taskOf (dep : dependency) =
   | DevDependency task -> task
   | BuildTimeDependency task -> task
 
-let safeName =
-  let replaceAt = Str.regexp "@" in
-  let replaceUnderscore = Str.regexp "_+" in
-  let replaceSlash = Str.regexp "\\/" in
-  let replaceDot = Str.regexp "\\." in
-  let replaceDash = Str.regexp "\\-" in
-  let replaceColon = Str.regexp ":" in
-  let make (name : string) =
-    name
-    |> String.lowercase_ascii
-    |> Str.global_replace replaceAt ""
-    |> Str.global_replace replaceUnderscore "__"
-    |> Str.global_replace replaceSlash "__slash__"
-    |> Str.global_replace replaceDot "__dot__"
-    |> Str.global_replace replaceColon "__colon__"
-    |> Str.global_replace replaceDash "_"
-  in make
-
-let safePath =
-  let replaceSlash = Str.regexp "\\/" in
-  let replaceColon = Str.regexp ":" in
-  let make name =
-    name
-    |> Str.global_replace replaceSlash "__slash__"
-    |> Str.global_replace replaceColon "__colon__"
-  in make
-
 let buildId
   (rootPkg : Package.t)
   (pkg : Package.t)
@@ -273,7 +246,7 @@ let buildId
   let id = List.fold_left ~f:updateWithDepId ~init:id dependencies in
   let hash = Digest.to_hex id in
   let hash = String.sub hash 0 8 in
-  (safeName pkg.name ^ "-" ^ safePath pkg.version ^ "-" ^ hash)
+  (EsyLib.Path.safeName pkg.name ^ "-" ^ EsyLib.Path.safePath pkg.version ^ "-" ^ hash)
 
 let getenv name =
   try Some (Sys.getenv name)

--- a/esyi/FetchStorage.ml
+++ b/esyi/FetchStorage.ml
@@ -171,8 +171,11 @@ let fetch ~(cfg : Config.t) (record : Solution.Record.t) =
   in
 
   let doFetchIfNeeded source =
-    let key = cacheId source record in
+    let unsafeKey = cacheId source record in
+    let key = EsyLib.Path.safePath unsafeKey in
     let tarballPath = Path.(cfg.cacheTarballsPath // v key |> addExt "tgz") in
+
+    print_endline("doFetchIfNeeded: " ^ (Path.to_string tarballPath));
 
     let dist = {
       Dist.

--- a/esyi/FetchStorage.ml
+++ b/esyi/FetchStorage.ml
@@ -175,8 +175,6 @@ let fetch ~(cfg : Config.t) (record : Solution.Record.t) =
     let key = EsyLib.Path.safePath unsafeKey in
     let tarballPath = Path.(cfg.cacheTarballsPath // v key |> addExt "tgz") in
 
-    print_endline("doFetchIfNeeded: " ^ (Path.to_string tarballPath));
-
     let dist = {
       Dist.
       tarballPath = Some tarballPath;


### PR DESCRIPTION
__Issue:__ This is the second blocker for getting `esyi` to run on Windows, after #311 

__Defect:__ Windows can't handle colons `:` in the file path. Some of our package names look like this:
```
@opam\conf-m4__opam:1__cc0c9b34.tgz
```
And when we try and use that as a path, it won't work - having the `:` makes Windows think its a drive.

__Fix:__ Use the `safePath` utility we have to fix up this case. After this fix, we get correctly appended paths, like:
```
C:\Users\bryph\.esy\esyi\tarballs\@opam__slash__conf-m4__opam__colon__1__cc0c9b34.tgz
```

As part of this change, I factored the `safePath` and `safeName` utilities from` esy` -> `esy-lib`.