### PR TITLE
e2e tests for opam sandboxes

### DIFF
--- a/test-e2e/build/augment-path.test.js
+++ b/test-e2e/build/augment-path.test.js
@@ -3,7 +3,7 @@
 const path = require('path');
 
 const {
-  genFixture,
+  createTestSandbox,
   packageJson,
   dir,
   file,
@@ -57,7 +57,7 @@ describe('Build - augment path', () => {
   it('package "dep" should be visible in all envs', async () => {
     expect.assertions(3);
 
-    const p = await genFixture(...fixture);
+    const p = await createTestSandbox(...fixture);
     await p.esy('build');
 
     const expecting = expect.stringMatching('__DEP__');

--- a/test-e2e/build/creates-symlinks.test.js
+++ b/test-e2e/build/creates-symlinks.test.js
@@ -3,7 +3,7 @@
 const path = require('path');
 
 const {
-  genFixture,
+  createTestSandbox,
   packageJson,
   dir,
   file,
@@ -55,7 +55,7 @@ const fixture = [
 
 it('Build - creates symlinks', async () => {
   expect.assertions(4);
-  const p = await genFixture(...fixture);
+  const p = await createTestSandbox(...fixture);
 
   await p.esy('build');
 

--- a/test-e2e/build/custom-prefix.test.js
+++ b/test-e2e/build/custom-prefix.test.js
@@ -5,7 +5,7 @@ const path = require('path');
 
 const outdent = require('outdent');
 const {
-  genFixture,
+  createTestSandbox,
   ocamlPackage,
   dir,
   packageJson,
@@ -42,7 +42,7 @@ const fixture = [
 ];
 
 it('Build - custom prefix', async () => {
-  const p = await genFixture(...fixture);
+  const p = await createTestSandbox(...fixture);
 
   await p.esy('build', {noEsyPrefix: true});
 

--- a/test-e2e/build/errorneous-build.test.js
+++ b/test-e2e/build/errorneous-build.test.js
@@ -1,7 +1,7 @@
 // @flow
 const path = require('path');
 
-const {genFixture, packageJson, dir} = require('../test/helpers');
+const {createTestSandbox, packageJson, dir} = require('../test/helpers');
 
 const fixture = [
   packageJson({
@@ -15,7 +15,7 @@ const fixture = [
 ];
 
 it('Build - errorneous build', async () => {
-  const p = await genFixture(...fixture);
+  const p = await createTestSandbox(...fixture);
   try {
     await p.esy('build');
   } catch (err) {

--- a/test-e2e/build/has-build-time-deps.test.js
+++ b/test-e2e/build/has-build-time-deps.test.js
@@ -5,7 +5,7 @@ const path = require('path');
 
 const outdent = require('outdent');
 const {
-  genFixture,
+  createTestSandbox,
   packageJson,
   dir,
   file,
@@ -112,7 +112,7 @@ const fixture = [
 
 describe('Build - has build time deps', () => {
   it('builds', async () => {
-    const p = await genFixture(...fixture);
+    const p = await createTestSandbox(...fixture);
     await p.esy('build');
 
     {

--- a/test-e2e/build/no-deps-_build.test.js
+++ b/test-e2e/build/no-deps-_build.test.js
@@ -4,7 +4,7 @@ const os = require('os');
 const path = require('path');
 const outdent = require('outdent');
 const {
-  genFixture,
+  createTestSandbox,
   ocamlPackage,
   dir,
   file,
@@ -40,7 +40,7 @@ const fixture = [
 ];
 
 it('Build - no deps _build', async () => {
-  const p = await genFixture(...fixture);
+  const p = await createTestSandbox(...fixture);
 
   await p.esy('build');
 

--- a/test-e2e/build/no-deps-backslash.test.js
+++ b/test-e2e/build/no-deps-backslash.test.js
@@ -3,7 +3,7 @@
 const path = require('path');
 const outdent = require('outdent');
 const {
-  genFixture,
+  createTestSandbox,
   ocamlPackage,
   dir,
   file,
@@ -45,7 +45,7 @@ const fixture = [
 ];
 
 it('Build - no deps backslash', async () => {
-  const p = await genFixture(...fixture);
+  const p = await createTestSandbox(...fixture);
 
   await p.esy('build');
 

--- a/test-e2e/build/no-deps-in-source.test.js
+++ b/test-e2e/build/no-deps-in-source.test.js
@@ -3,7 +3,7 @@
 const path = require('path');
 const outdent = require('outdent');
 const {
-  genFixture,
+  createTestSandbox,
   ocamlPackage,
   dir,
   file,
@@ -35,7 +35,7 @@ const fixture = [
 ];
 
 it('Build - no deps in source', async () => {
-  const p = await genFixture(...fixture);
+  const p = await createTestSandbox(...fixture);
   await p.esy('build');
 
   const {stdout} = await p.esy('x no-deps-in-source');

--- a/test-e2e/build/no-deps.test.js
+++ b/test-e2e/build/no-deps.test.js
@@ -4,7 +4,7 @@ const os = require('os');
 const path = require('path');
 const outdent = require('outdent');
 const {
-  genFixture,
+  createTestSandbox,
   ocamlPackage,
   dir,
   file,
@@ -46,7 +46,7 @@ const fixture = [
 ];
 
 it('Build - no deps', async () => {
-  const p = await genFixture(...fixture);
+  const p = await createTestSandbox(...fixture);
   await p.esy('build');
 
   const {stdout} = await p.esy('x no-deps');

--- a/test-e2e/build/not-enough-deps.test.js
+++ b/test-e2e/build/not-enough-deps.test.js
@@ -1,7 +1,7 @@
 // @flow
 
 const path = require('path');
-const {genFixture, packageJson} = require('../test/helpers');
+const {createTestSandbox, packageJson} = require('../test/helpers');
 
 const fixture = [
   packageJson({
@@ -19,7 +19,7 @@ const fixture = [
 
 describe('Build - not enough deps', () => {
   it("should fail as there's not enough deps and output relevant info", async () => {
-    const p = await genFixture(...fixture);
+    const p = await createTestSandbox(...fixture);
 
     await p.esy('build').catch(e => {
       expect(e.stderr).toEqual(

--- a/test-e2e/build/opam-sandbox.test.js
+++ b/test-e2e/build/opam-sandbox.test.js
@@ -4,7 +4,7 @@ const {
   file,
   dir,
   packageJson,
-  genFixture,
+  createTestSandbox,
   promiseExec,
   ocamlPackage,
   skipSuiteOnWindows,
@@ -14,7 +14,7 @@ skipSuiteOnWindows();
 
 describe('build opam sandbox', () => {
   it('builds an opam sandbox with a single opam file', async () => {
-    const p = await genFixture(
+    const p = await createTestSandbox(
       file(
         'opam',
         `
@@ -46,7 +46,7 @@ describe('build opam sandbox', () => {
   });
 
   it('builds an opam sandbox with multiple opam files', async () => {
-    const p = await genFixture(
+    const p = await createTestSandbox(
       file(
         'one.opam',
         `

--- a/test-e2e/build/sandbox-stress-_build.test.js
+++ b/test-e2e/build/sandbox-stress-_build.test.js
@@ -1,7 +1,7 @@
 // @flow
 
 const path = require('path');
-const {genFixture, packageJson, skipSuiteOnWindows} = require('../test/helpers');
+const {createTestSandbox, packageJson, skipSuiteOnWindows} = require('../test/helpers');
 
 skipSuiteOnWindows();
 
@@ -34,7 +34,7 @@ const fixture = [
 
 it('Build - sandbox stress _build', async () => {
   expect.assertions(1);
-  const p = await genFixture(...fixture);
+  const p = await createTestSandbox(...fixture);
   await p.esy('build');
 
   const {stdout} = await p.esy('x echo ok');

--- a/test-e2e/build/sandbox-stress-in-source.test.js
+++ b/test-e2e/build/sandbox-stress-in-source.test.js
@@ -1,7 +1,7 @@
 // @flow
 
 const path = require('path');
-const {genFixture, packageJson} = require('../test/helpers');
+const {createTestSandbox, packageJson} = require('../test/helpers');
 
 const fixture = [
   packageJson({
@@ -25,7 +25,7 @@ const fixture = [
 
 it('Build - sandbox stress in source', async () => {
   expect.assertions(1);
-  const p = await genFixture(...fixture);
+  const p = await createTestSandbox(...fixture);
   await p.esy('build');
   const {stdout} = await p.esy('x echo ok');
   expect(stdout).toEqual(expect.stringMatching('ok'));

--- a/test-e2e/build/sandbox-stress.test.js
+++ b/test-e2e/build/sandbox-stress.test.js
@@ -1,7 +1,7 @@
 // @flow
 
 const path = require('path');
-const {genFixture, packageJson, skipSuiteOnWindows} = require('../test/helpers');
+const {createTestSandbox, packageJson, skipSuiteOnWindows} = require('../test/helpers');
 
 skipSuiteOnWindows();
 
@@ -24,7 +24,7 @@ const fixture = [
 
 it('Build - sandbox stress', async () => {
   expect.assertions(1);
-  const p = await genFixture(...fixture);
+  const p = await createTestSandbox(...fixture);
   await p.esy('build');
   const {stdout} = await p.esy('x echo ok');
   expect(stdout).toEqual(expect.stringMatching('ok'));

--- a/test-e2e/build/with-dep-_build.test.js
+++ b/test-e2e/build/with-dep-_build.test.js
@@ -2,7 +2,7 @@
 
 const path = require('path');
 const {
-  genFixture,
+  createTestSandbox,
   packageJson,
   dir,
   file,
@@ -53,7 +53,7 @@ const fixture = [
 
 describe('Build - with dep _build', () => {
   it('package "dep" should be visible in all envs', async () => {
-    const p = await genFixture(...fixture);
+    const p = await createTestSandbox(...fixture);
     await p.esy('build');
 
     const expecting = expect.stringMatching('__dep__');

--- a/test-e2e/build/with-dep-in-source.test.js
+++ b/test-e2e/build/with-dep-in-source.test.js
@@ -3,7 +3,7 @@
 const path = require('path');
 
 const {
-  genFixture,
+  createTestSandbox,
   packageJson,
   dir,
   file,
@@ -50,7 +50,7 @@ const fixture = [
 
 describe('Build - with dep in source', () => {
   it('package "dep" should be visible in all envs', async () => {
-    const p = await genFixture(...fixture);
+    const p = await createTestSandbox(...fixture);
     await p.esy('build');
 
     const expecting = expect.stringMatching('__dep__');

--- a/test-e2e/build/with-dep.test.js
+++ b/test-e2e/build/with-dep.test.js
@@ -2,7 +2,7 @@
 
 const path = require('path');
 const {
-  genFixture,
+  createTestSandbox,
   packageJson,
   dir,
   file,
@@ -50,7 +50,7 @@ const fixture = [
 
 describe('Build - with dep', () => {
   it('package "dep" should be visible in all envs', async () => {
-    const p = await genFixture(...fixture);
+    const p = await createTestSandbox(...fixture);
     await p.esy('build');
 
     const expecting = expect.stringMatching('__dep__');

--- a/test-e2e/build/with-dev-dep.test.js
+++ b/test-e2e/build/with-dev-dep.test.js
@@ -2,7 +2,7 @@
 
 const path = require('path');
 const {
-  genFixture,
+  createTestSandbox,
   packageJson,
   dir,
   file,
@@ -72,7 +72,7 @@ describe('Build - with dev dep', () => {
   let p;
 
   beforeEach(async () => {
-    p = await genFixture(...fixture);
+    p = await createTestSandbox(...fixture);
     await p.esy('build');
   });
 

--- a/test-e2e/build/with-linked-dep-_build.test.js
+++ b/test-e2e/build/with-linked-dep-_build.test.js
@@ -4,7 +4,7 @@ const path = require('path');
 const fs = require('fs');
 
 const {
-  genFixture,
+  createTestSandbox,
   packageJson,
   file,
   dir,
@@ -60,7 +60,7 @@ const fixture = [
 
 describe('Build - with linked dep _build', () => {
   it('package "dep" should be visible in all envs', async () => {
-    const p = await genFixture(...fixture);
+    const p = await createTestSandbox(...fixture);
     await p.esy('build');
 
     const expecting = expect.stringMatching('dep');

--- a/test-e2e/build/with-linked-dep-in-source.test.js
+++ b/test-e2e/build/with-linked-dep-in-source.test.js
@@ -4,7 +4,7 @@ const path = require('path');
 const fs = require('fs');
 
 const {
-  genFixture,
+  createTestSandbox,
   packageJson,
   file,
   dir,
@@ -55,7 +55,7 @@ const fixture = [
 
 describe('Build - with linked dep _build', () => {
   it('package "dep" should be visible in all envs', async () => {
-    const p = await genFixture(...fixture);
+    const p = await createTestSandbox(...fixture);
 
     const expecting = expect.stringMatching('__dep__');
 

--- a/test-e2e/build/with-linked-dep-sandbox-env.test.js
+++ b/test-e2e/build/with-linked-dep-sandbox-env.test.js
@@ -5,7 +5,7 @@ const fs = require('fs');
 
 const outdent = require('outdent');
 const {
-  genFixture,
+  createTestSandbox,
   ocamlPackage,
   packageJson,
   symlink,
@@ -137,7 +137,7 @@ describe('Build - with linked dep _build', () => {
   let p;
 
   beforeEach(async () => {
-    p = await genFixture(...fixture);
+    p = await createTestSandbox(...fixture);
     await p.esy('build');
   });
 

--- a/test-e2e/build/with-linked-dep.test.js
+++ b/test-e2e/build/with-linked-dep.test.js
@@ -7,7 +7,7 @@ const open = promisify(fs.open);
 const close = promisify(fs.close);
 
 const {
-  genFixture,
+  createTestSandbox,
   packageJson,
   dir,
   file,
@@ -65,7 +65,7 @@ describe('Build - with linked dep', () => {
   let p;
 
   beforeAll(async () => {
-    p = await genFixture(...fixture);
+    p = await createTestSandbox(...fixture);
     await p.esy('build');
   });
 

--- a/test-e2e/common/anycmd.test.js
+++ b/test-e2e/common/anycmd.test.js
@@ -5,7 +5,7 @@ const fs = require('fs-extra');
 const os = require('os');
 
 const {
-  genFixture,
+  createTestSandbox,
   promiseExec,
   ESYCOMMAND,
   skipSuiteOnWindows,
@@ -19,7 +19,7 @@ describe('Common - anycmd', () => {
   let prevEnv = {...process.env};
 
   beforeEach(async () => {
-    p = await genFixture(...fixture.simpleProject);
+    p = await createTestSandbox(...fixture.simpleProject);
     await p.esy('build');
   });
 

--- a/test-e2e/common/build-anycmd.test.js
+++ b/test-e2e/common/build-anycmd.test.js
@@ -3,13 +3,13 @@
 const os = require('os');
 const path = require('path');
 
-const {genFixture, skipSuiteOnWindows} = require('../test/helpers');
+const {createTestSandbox, skipSuiteOnWindows} = require('../test/helpers');
 const fixture = require('./fixture.js');
 
 skipSuiteOnWindows();
 
 it('Common - build anycmd', async () => {
-  const p = await genFixture(...fixture.simpleProject);
+  const p = await createTestSandbox(...fixture.simpleProject);
 
   await p.esy('build');
 

--- a/test-e2e/common/build-env.test.js
+++ b/test-e2e/common/build-env.test.js
@@ -3,14 +3,14 @@
 const path = require('path');
 const fs = require('fs-extra');
 
-const {genFixture, promiseExec, skipSuiteOnWindows} = require('../test/helpers');
+const {createTestSandbox, promiseExec, skipSuiteOnWindows} = require('../test/helpers');
 const fixture = require('./fixture.js');
 
 skipSuiteOnWindows('#301');
 
 describe('Common - build-env', () => {
   it('generates an environment with deps in $PATH', async () => {
-    const p = await genFixture(...fixture.simpleProject);
+    const p = await createTestSandbox(...fixture.simpleProject);
 
     await p.esy('build');
 

--- a/test-e2e/common/command-env.test.js
+++ b/test-e2e/common/command-env.test.js
@@ -3,14 +3,14 @@
 const path = require('path');
 const fs = require('fs-extra');
 
-const {genFixture, promiseExec, skipSuiteOnWindows} = require('../test/helpers');
+const {createTestSandbox, promiseExec, skipSuiteOnWindows} = require('../test/helpers');
 const fixture = require('./fixture.js');
 
 skipSuiteOnWindows('#301');
 
 describe('Common - command-env', () => {
   it('generates valid environmenmt with deps and devdeps in $PATH', async () => {
-    const p = await genFixture(...fixture.simpleProject);
+    const p = await createTestSandbox(...fixture.simpleProject);
     await p.esy('build');
 
     const commandEnv = (await p.esy('command-env')).stdout;

--- a/test-e2e/common/default-command.test.js
+++ b/test-e2e/common/default-command.test.js
@@ -1,7 +1,7 @@
 // @flow
 
 const {
-  genFixture,
+  createTestSandbox,
   packageJson,
   skipSuiteOnWindows,
   dir,
@@ -45,7 +45,7 @@ const fixture = [
 ];
 
 it('Build - default command', async () => {
-  let p = await genFixture(...fixture);
+  let p = await createTestSandbox(...fixture);
   await p.esy();
 
   const dep = await p.esy('dep');

--- a/test-e2e/common/ejected-command-env.test.js
+++ b/test-e2e/common/ejected-command-env.test.js
@@ -3,14 +3,14 @@
 const path = require('path');
 const fs = require('fs-extra');
 
-const {genFixture, promiseExec, skipSuiteOnWindows} = require('../test/helpers');
+const {createTestSandbox, promiseExec, skipSuiteOnWindows} = require('../test/helpers');
 const fixture = require('./fixture.js');
 
 skipSuiteOnWindows('#301');
 
 describe('Common - ejected command env', () => {
   it('Check that `esy build` ejects a command-env which contains deps and devDeps in $PATH', async () => {
-    const p = await genFixture(...fixture.simpleProject);
+    const p = await createTestSandbox(...fixture.simpleProject);
     await p.esy('build');
 
     await expect(

--- a/test-e2e/common/esy-prefix-via-esyrc.test.js
+++ b/test-e2e/common/esy-prefix-via-esyrc.test.js
@@ -5,7 +5,7 @@ const path = require('path');
 const del = require('del');
 const fs = require('fs-extra');
 
-const {genFixture, skipSuiteOnWindows} = require('../test/helpers');
+const {createTestSandbox, skipSuiteOnWindows} = require('../test/helpers');
 const fixture = require('./fixture.js');
 
 skipSuiteOnWindows();
@@ -15,7 +15,7 @@ it('Common - esy prefix via esyrc', async () => {
   const tmpPath = await fs.mkdtemp(path.join(tmp, 'XXXX'));
   const customEsyPrefix = path.join(tmpPath, 'prefix');
 
-  const p = await genFixture(...fixture.simpleProject);
+  const p = await createTestSandbox(...fixture.simpleProject);
 
   await fs.writeFile(
     path.join(p.projectPath, '.esyrc'),

--- a/test-e2e/common/release.test.js
+++ b/test-e2e/common/release.test.js
@@ -4,7 +4,7 @@ const path = require('path');
 
 const outdent = require('outdent');
 const {
-  genFixture,
+  createTestSandbox,
   file,
   dir,
   packageJson,
@@ -73,7 +73,7 @@ const fixture = [
 it('Common - release', async () => {
   jest.setTimeout(300000);
 
-  const p = await genFixture(...fixture);
+  const p = await createTestSandbox(...fixture);
 
   await expect(p.esy('release')).resolves.not.toThrow();
 

--- a/test-e2e/common/release.test.js
+++ b/test-e2e/common/release.test.js
@@ -71,8 +71,6 @@ const fixture = [
 ];
 
 it('Common - release', async () => {
-  jest.setTimeout(300000);
-
   const p = await createTestSandbox(...fixture);
 
   await expect(p.esy('release')).resolves.not.toThrow();

--- a/test-e2e/common/scripts.test.js
+++ b/test-e2e/common/scripts.test.js
@@ -7,7 +7,7 @@ const {skipSuiteOnWindows} = require('../test/helpers');
 
 skipSuiteOnWindows('#272');
 
-const {packageJson, file, genFixture} = require('../test/helpers');
+const {packageJson, file, createTestSandbox} = require('../test/helpers');
 
 const fixture = [
   packageJson({
@@ -41,7 +41,7 @@ const fixture = [
 ];
 
 it('Common - scripts', async () => {
-  const p = await genFixture(...fixture);
+  const p = await createTestSandbox(...fixture);
   await p.esy('build');
 
   await expect(p.esy('cmd1')).resolves.toEqual(

--- a/test-e2e/common/symlink-workflow.test.js
+++ b/test-e2e/common/symlink-workflow.test.js
@@ -4,7 +4,7 @@ const path = require('path');
 const outdent = require('outdent');
 const fs = require('fs-extra');
 const {
-  genFixture,
+  createTestSandbox,
   file,
   dir,
   packageJson,
@@ -115,7 +115,7 @@ describe('Common - symlink workflow', () => {
   let appEsy;
 
   beforeEach(async () => {
-    p = await genFixture(...fixture);
+    p = await createTestSandbox(...fixture);
 
     appEsy = args =>
       promiseExec(`${ESYCOMMAND} ${args}`, {

--- a/test-e2e/common/x-anycmd.test.js
+++ b/test-e2e/common/x-anycmd.test.js
@@ -4,7 +4,7 @@ const path = require('path');
 const fs = require('fs-extra');
 
 const {
-  genFixture,
+  createTestSandbox,
   promiseExec,
   ESYCOMMAND,
   skipSuiteOnWindows,
@@ -18,7 +18,7 @@ describe('Common - x anycmd', () => {
   let prevEnv = {...process.env};
 
   beforeEach(async () => {
-    p = await genFixture(...fixture.simpleProject);
+    p = await createTestSandbox(...fixture.simpleProject);
     await p.esy('build');
   });
 

--- a/test-e2e/complete/esy-sandbox.test.js
+++ b/test-e2e/complete/esy-sandbox.test.js
@@ -1,0 +1,180 @@
+// @flow
+
+const outdent = require('outdent');
+const helpers = require('../test/helpers.js');
+
+const {file, packageJson} = helpers;
+
+helpers.skipSuiteOnWindows();
+
+describe('complete workflow for esy sandboxes', () => {
+  async function createTestSandbox(...fixture) {
+    const p = await helpers.createTestSandbox(...fixture);
+
+    // add ocaml package, required by opam sandboxes implicitly
+    await p.defineNpmPackageOfFixture(helpers.ocamlPackage().items);
+
+    // add @esy-ocaml/substs package, required by opam sandboxes implicitly
+    await p.defineNpmPackage({
+      name: '@esy-ocaml/substs',
+      version: '1.0.0',
+      esy: {},
+    });
+
+    return p;
+  }
+
+  it('no dependencies', async () => {
+    const fixture = [
+      packageJson({
+        name: 'root',
+        version: '1.0.0',
+        esy: {
+          build: ['true'],
+        },
+      }),
+    ];
+    const p = await createTestSandbox(...fixture);
+    await p.esy('install');
+    await p.esy('build');
+  });
+
+  it('no dependencies, only ocaml devDep', async () => {
+    const fixture = [
+      packageJson({
+        name: 'root',
+        version: '1.0.0',
+        esy: {
+          build: [
+            'cp root.ml #{self.target_dir/}root.ml',
+            'ocamlopt -o #{self.target_dir/}root.exe #{self.target_dir/}root.ml',
+          ],
+          install: ['cp #{self.target_dir/}root.exe #{self.bin/}root.exe'],
+        },
+        dependencies: {
+          ocaml: '*',
+        },
+        devDependencies: {
+          ocaml: '*',
+        },
+      }),
+      file('root.ml', 'print_endline "__root__"'),
+    ];
+    const p = await createTestSandbox(...fixture);
+    await p.esy('install');
+    await p.esy('build');
+    const {stdout} = await p.esy('x root.exe');
+    expect(stdout.trim()).toEqual('__root__');
+  });
+
+  it('npm dependencies, only ocaml devDep', async () => {
+    const fixture = [
+      packageJson({
+        name: 'root',
+        version: '1.0.0',
+        esy: {},
+        dependencies: {
+          ocaml: '*',
+          dep: '*',
+        },
+        devDependencies: {
+          ocaml: '*',
+        },
+      }),
+    ];
+    const p = await createTestSandbox(...fixture);
+
+    await p.defineNpmPackageOfFixture([
+      packageJson({
+        name: 'dep',
+        version: '1.0.0',
+        esy: {
+          build: [
+            'cp dep.ml #{self.target_dir/}dep.ml',
+            'ocamlopt -o #{self.target_dir/}dep.exe #{self.target_dir/}dep.ml',
+          ],
+          install: ['cp #{self.target_dir/}dep.exe #{self.bin/}dep.exe'],
+        },
+        dependencies: {
+          ocaml: '*',
+        },
+      }),
+      file('dep.ml', 'print_endline "__dep__"'),
+    ]);
+
+    await p.esy('install');
+    await p.esy('build');
+
+    {
+      const {stdout} = await p.esy('dep.exe');
+      expect(stdout.trim()).toEqual('__dep__');
+    }
+    {
+      const {stdout} = await p.esy('b dep.exe');
+      expect(stdout.trim()).toEqual('__dep__');
+    }
+    {
+      const {stdout} = await p.esy('x dep.exe');
+      expect(stdout.trim()).toEqual('__dep__');
+    }
+  });
+
+  it('opam dependencies, only ocaml devDep', async () => {
+    const fixture = [
+      packageJson({
+        name: 'root',
+        version: '1.0.0',
+        esy: {},
+        dependencies: {
+          ocaml: '*',
+          '@opam/dep': '*',
+        },
+        devDependencies: {
+          ocaml: '*',
+        },
+      }),
+    ];
+    const p = await createTestSandbox(...fixture);
+
+    await p.defineOpamPackageOfFixture(
+      {
+        name: 'dep',
+        version: '1',
+        opam: outdent`
+          opam-version: "1.2"
+          build: [
+            ["ocamlopt" "-o" "dep.exe" "dep.ml"]
+          ]
+          install: [
+            ["cp" "dep.exe" "%{bin}%/dep.exe"]
+          ]
+        `,
+        url: null,
+      },
+      [
+        helpers.file(
+          'dep.ml',
+          outdent`
+            let () = print_endline "__dep__"
+          `,
+        ),
+      ],
+    );
+
+    await p.esy('install');
+    await p.esy('build');
+
+    {
+      const {stdout} = await p.esy('dep.exe');
+      expect(stdout.trim()).toEqual('__dep__');
+    }
+    {
+      const {stdout} = await p.esy('b dep.exe');
+      expect(stdout.trim()).toEqual('__dep__');
+    }
+    {
+      const {stdout} = await p.esy('x dep.exe');
+      expect(stdout.trim()).toEqual('__dep__');
+    }
+  });
+});

--- a/test-e2e/complete/opam-sandbox.test.js
+++ b/test-e2e/complete/opam-sandbox.test.js
@@ -1,0 +1,175 @@
+// @flow
+
+const outdent = require('outdent');
+const helpers = require('../test/helpers.js');
+
+helpers.skipSuiteOnWindows();
+
+describe('installing dependencies for opam sandbox', () => {
+  async function createTestSandbox(...fixture) {
+    const p = await helpers.createTestSandbox(...fixture);
+
+    // add ocaml package, required by opam sandboxes implicitly
+    await p.defineNpmPackageOfFixture(helpers.ocamlPackage().items);
+
+    // add @esy-ocaml/substs package, required by opam sandboxes implicitly
+    await p.defineNpmPackage({
+      name: '@esy-ocaml/substs',
+      version: '1.0.0',
+      esy: {},
+    });
+
+    return p;
+  }
+
+  it('single opam file, no dependencies', async () => {
+    const fixture = [
+      helpers.file(
+        'opam',
+        outdent`
+          opam-version: "1.2"
+          build: [
+            ["ocamlopt" "-o" "hello.exe" "hello.ml"]
+          ]
+          install: [
+            ["cp" "hello.exe" "%{bin}%/hello.exe"]
+          ]
+        `,
+      ),
+      helpers.file(
+        'hello.ml',
+        outdent`
+          let () = print_endline "__opam__"
+        `,
+      ),
+    ];
+
+    const p = await createTestSandbox(...fixture);
+    await p.esy('install');
+
+    // build should execute build commands from pkg.opam file
+    await p.esy('build');
+    const {stdout} = await p.esy('x hello.exe');
+    expect(stdout.trim()).toEqual('__opam__');
+  });
+
+  it('single opam file, has dependencies', async () => {
+    const fixture = [
+      helpers.file(
+        'opam',
+        outdent`
+          opam-version: "1.2"
+          depends: [
+            "dep1"
+            "dep2"
+          ]
+        `,
+      ),
+    ];
+
+    const p = await createTestSandbox(...fixture);
+
+    await p.defineOpamPackage({
+      name: 'dep1',
+      version: '1',
+      opam: outdent`
+        opam-version: "1.2"
+        build: [
+          ["true"]
+        ]
+      `,
+      url: null,
+    });
+
+    await p.defineOpamPackage({
+      name: 'dep2',
+      version: '2',
+      opam: outdent`
+        opam-version: "1.2"
+        build: [
+          ["true"]
+        ]
+      `,
+      url: null,
+    });
+
+    await p.esy('install');
+    await p.esy('build');
+  });
+
+  it('single <pkg>.opam file', async () => {
+    const fixture = [
+      helpers.file(
+        'pkg.opam',
+        outdent`
+          opam-version: "1.2"
+          build: [
+            ["ocamlopt" "-o" "hello.exe" "hello.ml"]
+          ]
+          install: [
+            ["cp" "hello.exe" "%{bin}%/hello.exe"]
+          ]
+        `,
+      ),
+      helpers.file(
+        'hello.ml',
+        outdent`
+          let () = print_endline "__opam__"
+        `,
+      ),
+    ];
+
+    const p = await createTestSandbox(...fixture);
+
+    await p.esy('install');
+
+    // build should execute build commands from pkg.opam file
+    await p.esy('build');
+    const {stdout} = await p.esy('x hello.exe');
+    expect(stdout.trim()).toEqual('__opam__');
+  });
+
+  it('multiple <pkg>.opam files', async () => {
+    const fixture = [
+      // this define "false" as build command to make sure esy doesn't execute
+      // it
+      helpers.file(
+        'one.opam',
+        outdent`
+          opam-version: "1.2"
+          build: [
+            ["false"]
+          ]
+        `,
+      ),
+      // this define "false" as build command to make sure esy doesn't execute
+      // it
+      helpers.file(
+        'another.opam',
+        outdent`
+          opam-version: "1.2"
+          build: [
+            ["false"]
+          ]
+        `,
+      ),
+      helpers.file(
+        'hello.ml',
+        outdent`
+          let () = print_endline "__opam__"
+        `,
+      ),
+    ];
+
+    const p = await createTestSandbox(...fixture);
+    await p.esy('install');
+
+    // build shouldn't execute build commands from *.opam files
+    await p.esy('build');
+
+    // we should be able to use ocaml and build stuff
+    await p.esy('build ocamlopt -o hello.exe ./hello.ml');
+    const {stdout} = await p.esy('./hello.exe');
+    expect(stdout.trim()).toEqual('__opam__');
+  });
+});

--- a/test-e2e/complete/opam-sandbox.test.js
+++ b/test-e2e/complete/opam-sandbox.test.js
@@ -5,7 +5,7 @@ const helpers = require('../test/helpers.js');
 
 helpers.skipSuiteOnWindows();
 
-describe('installing dependencies for opam sandbox', () => {
+describe('complete flow for opam sandboxes', () => {
   async function createTestSandbox(...fixture) {
     const p = await helpers.createTestSandbox(...fixture);
 

--- a/test-e2e/export-import-build/from-list.test.js
+++ b/test-e2e/export-import-build/from-list.test.js
@@ -5,7 +5,7 @@ const del = require('del');
 const fs = require('fs-extra');
 
 const {
-  genFixture,
+  createTestSandbox,
   file,
   dir,
   packageJson,
@@ -70,7 +70,7 @@ const fixture = [
 ];
 
 it('export import build - from list', async () => {
-  const p = await genFixture(...fixture);
+  const p = await createTestSandbox(...fixture);
   await p.esy('build');
 
   await p.esy('export-dependencies');

--- a/test-e2e/export-import-build/symlinks-into-dep.test.js
+++ b/test-e2e/export-import-build/symlinks-into-dep.test.js
@@ -6,7 +6,7 @@ const tar = require('tar');
 const del = require('del');
 
 const {
-  genFixture,
+  createTestSandbox,
   file,
   dir,
   packageJson,
@@ -74,7 +74,7 @@ describe('export import build - import symlinks into dep', () => {
   let p;
 
   beforeEach(async () => {
-    p = await genFixture(...fixture);
+    p = await createTestSandbox(...fixture);
     await p.esy('build');
   });
 

--- a/test-e2e/install/basic-esy.test.js
+++ b/test-e2e/install/basic-esy.test.js
@@ -5,116 +5,119 @@ const helpers = require('../test/helpers.js');
 helpers.skipSuiteOnWindows('Needs investigation');
 
 describe(`Basic tests`, () => {
-  test(
-    `it should correctly install a single dependency that contains no sub-dependencies`,
-    helpers.makeTemporaryEnv(
-      {
+  test(`it should correctly install a single dependency that contains no sub-dependencies`, async () => {
+    const fixture = [
+      helpers.packageJson({
         name: 'root',
         version: '1.0.0',
         esy: {},
         dependencies: {[`no-deps`]: `1.0.0`},
-      },
-      async ({path, run, source}) => {
-        await run(`install`);
+      }),
+    ];
+    const p = await helpers.createTestSandbox(...fixture);
 
-        await expect(source(`require('no-deps')`)).resolves.toMatchObject({
-          name: `no-deps`,
-          version: `1.0.0`,
-        });
-      },
-    ),
-  );
+    await p.esy(`install`);
 
-  test(
-    `it should correctly install a dependency that itself contains a fixed dependency`,
-    helpers.makeTemporaryEnv(
-      {
+    await expect(
+      p.runJavaScriptInNodeAndReturnJson(`require('no-deps')`),
+    ).resolves.toMatchObject({
+      name: `no-deps`,
+      version: `1.0.0`,
+    });
+  });
+
+  test(`it should correctly install a dependency that itself contains a fixed dependency`, async () => {
+    const fixture = [
+      helpers.packageJson({
         name: 'root',
         version: '1.0.0',
         esy: {},
         dependencies: {[`one-fixed-dep`]: `1.0.0`},
-      },
-      async ({path, run, source}) => {
-        await run(`install`);
+      }),
+    ];
+    const p = await helpers.createTestSandbox(...fixture);
+    await p.esy(`install`);
 
-        await expect(source(`require('one-fixed-dep')`)).resolves.toMatchObject({
-          name: `one-fixed-dep`,
+    await expect(
+      p.runJavaScriptInNodeAndReturnJson(`require('one-fixed-dep')`),
+    ).resolves.toMatchObject({
+      name: `one-fixed-dep`,
+      version: `1.0.0`,
+      dependencies: {
+        [`no-deps`]: {
+          name: `no-deps`,
           version: `1.0.0`,
-          dependencies: {
-            [`no-deps`]: {
-              name: `no-deps`,
-              version: `1.0.0`,
-            },
-          },
-        });
+        },
       },
-    ),
-  );
+    });
+  });
 
-  test(
-    `it should correctly install a dependency that itself contains a range dependency`,
-    helpers.makeTemporaryEnv(
-      {
+  test(`it should correctly install a dependency that itself contains a range dependency`, async () => {
+    const fixture = [
+      helpers.packageJson({
         name: 'root',
         version: '1.0.0',
         esy: {},
         dependencies: {[`one-range-dep`]: `1.0.0`},
-      },
-      async ({path, run, source}) => {
-        await run(`install`);
+      }),
+    ];
 
-        await expect(source(`require('one-range-dep')`)).resolves.toMatchObject({
-          name: `one-range-dep`,
-          version: `1.0.0`,
-          dependencies: {
-            [`no-deps`]: {
-              name: `no-deps`,
-              version: `1.1.0`,
-            },
-          },
-        });
-      },
-    ),
-  );
+    const p = await helpers.createTestSandbox(...fixture);
+    await p.esy(`install`);
 
-  test(
-    `it should prefer esy._dependenciesForNewEsyInstaller`,
-    helpers.makeTemporaryEnv(
-      {
+    await expect(
+      p.runJavaScriptInNodeAndReturnJson(`require('one-range-dep')`),
+    ).resolves.toMatchObject({
+      name: `one-range-dep`,
+      version: `1.0.0`,
+      dependencies: {
+        [`no-deps`]: {
+          name: `no-deps`,
+          version: `1.1.0`,
+        },
+      },
+    });
+  });
+
+  test(`it should prefer esy._dependenciesForNewEsyInstaller`, async () => {
+    const fixture = [
+      helpers.packageJson({
         name: 'root',
         version: '1.0.0',
         dependencies: {apkg: `1.0.0`},
         esy: {},
-      },
-      async ({path, run, source}) => {
-        await helpers.definePackage({
-          name: 'apkg',
-          version: '1.0.0',
-          esy: {
-            _dependenciesForNewEsyInstaller: {
-              'apkg-dep': `2.0.0`,
-            },
-          },
-          dependencies: {'apkg-dep': `1.0.0`},
-        });
-        await helpers.definePackage({
-          name: 'apkg-dep',
-          esy: {},
-          version: '1.0.0',
-        });
-        await helpers.definePackage({
-          name: 'apkg-dep',
-          esy: {},
-          version: '2.0.0',
-        });
+      }),
+    ];
 
-        await run(`install`);
-
-        await expect(source(`require('apkg-dep/package.json')`)).resolves.toMatchObject({
-          name: 'apkg-dep',
-          version: `2.0.0`,
-        });
+    const p = await helpers.createTestSandbox(...fixture);
+    await p.defineNpmPackage({
+      name: 'apkg',
+      version: '1.0.0',
+      esy: {
+        _dependenciesForNewEsyInstaller: {
+          'apkg-dep': `2.0.0`,
+        },
       },
-    ),
-  );
+      dependencies: {'apkg-dep': `1.0.0`},
+    });
+    await p.defineNpmPackage({
+      name: 'apkg-dep',
+      esy: {},
+      version: '1.0.0',
+    });
+    await p.defineNpmPackage({
+      name: 'apkg-dep',
+      esy: {},
+      version: '2.0.0',
+    });
+
+    await p.esy(`install`);
+
+    await expect(
+      p.runJavaScriptInNodeAndReturnJson(`require('apkg-dep/package.json')`),
+    ).resolves.toMatchObject({
+      name: 'apkg-dep',
+      version: `2.0.0`,
+    });
+  });
 });

--- a/test-e2e/install/basic-npm.test.js
+++ b/test-e2e/install/basic-npm.test.js
@@ -1,337 +1,343 @@
 /* @flow */
 
-const {join} = require('path');
+const path = require('path');
 const helpers = require('../test/helpers.js');
 
 helpers.skipSuiteOnWindows();
 
 describe(`Basic tests for npm packages`, () => {
-  test(
-    `it should correctly install a single dependency that contains no sub-dependencies`,
-    helpers.makeTemporaryEnv(
-      {
+  test(`it should correctly install a single dependency that contains no sub-dependencies`, async () => {
+    const fixture = [
+      helpers.packageJson({
         name: 'root',
         version: '1.0.0',
         dependencies: {[`no-deps`]: `1.0.0`},
-      },
-      async ({path, run, source}) => {
-        await run(`install`);
+      }),
+    ];
 
-        await expect(source(`require('no-deps')`)).resolves.toMatchObject({
-          name: `no-deps`,
-          version: `1.0.0`,
-        });
-      },
-    ),
-  );
+    const p = await helpers.createTestSandbox(...fixture);
+    await p.esy('install');
 
-  test(
-    `it should correctly install a dependency that itself contains a fixed dependency`,
-    helpers.makeTemporaryEnv(
-      {
+    await expect(
+      p.runJavaScriptInNodeAndReturnJson(`require('no-deps')`),
+    ).resolves.toMatchObject({
+      name: `no-deps`,
+      version: `1.0.0`,
+    });
+  });
+
+  test(`it should correctly install a dependency that itself contains a fixed dependency`, async () => {
+    const fixture = [
+      helpers.packageJson({
         name: 'root',
         version: '1.0.0',
         dependencies: {[`one-fixed-dep`]: `1.0.0`},
-      },
-      async ({path, run, source}) => {
-        await run(`install`);
+      }),
+    ];
 
-        await expect(source(`require('one-fixed-dep')`)).resolves.toMatchObject({
-          name: `one-fixed-dep`,
+    const p = await helpers.createTestSandbox(...fixture);
+    await p.esy('install');
+
+    await expect(
+      p.runJavaScriptInNodeAndReturnJson(`require('one-fixed-dep')`),
+    ).resolves.toMatchObject({
+      name: `one-fixed-dep`,
+      version: `1.0.0`,
+      dependencies: {
+        [`no-deps`]: {
+          name: `no-deps`,
           version: `1.0.0`,
-          dependencies: {
-            [`no-deps`]: {
-              name: `no-deps`,
-              version: `1.0.0`,
-            },
-          },
-        });
+        },
       },
-    ),
-  );
+    });
+  });
 
-  test(
-    `it should correctly install a dependency that itself contains a range dependency`,
-    helpers.makeTemporaryEnv(
-      {
+  test(`it should correctly install a dependency that itself contains a range dependency`, async () => {
+    const fixture = [
+      helpers.packageJson({
         name: 'root',
         version: '1.0.0',
         dependencies: {[`one-range-dep`]: `1.0.0`},
-      },
-      async ({path, run, source}) => {
-        await run(`install`);
+      }),
+    ];
 
-        await expect(source(`require('one-range-dep')`)).resolves.toMatchObject({
-          name: `one-range-dep`,
-          version: `1.0.0`,
-          dependencies: {
-            [`no-deps`]: {
-              name: `no-deps`,
-              version: `1.1.0`,
-            },
-          },
-        });
-      },
-    ),
-  );
+    const p = await helpers.createTestSandbox(...fixture);
+    await p.esy('install');
 
-  test(
-    `it should correctly install bin wrappers into node_modules/.bin (single bin)`,
-    helpers.makeTemporaryEnv(
-      {
+    await expect(
+      p.runJavaScriptInNodeAndReturnJson(`require('one-range-dep')`),
+    ).resolves.toMatchObject({
+      name: `one-range-dep`,
+      version: `1.0.0`,
+      dependencies: {
+        [`no-deps`]: {
+          name: `no-deps`,
+          version: `1.1.0`,
+        },
+      },
+    });
+  });
+
+  test(`it should correctly install bin wrappers into node_modules/.bin (single bin)`, async () => {
+    const fixture = [
+      helpers.packageJson({
         name: 'root',
         version: '1.0.0',
         dependencies: {[`dep`]: `1.0.0`},
-      },
-      async ({path, run, source}) => {
-        await helpers.definePackage({
-          name: 'depDep',
-          version: '1.0.0',
-          dependencies: {depDep: `1.0.0`},
-          bin: './depDep.exe',
-        });
-        const depPath = await helpers.definePackage({
-          name: 'dep',
-          version: '1.0.0',
-          dependencies: {depDep: `1.0.0`},
-          bin: './dep.exe',
-        });
+      }),
+    ];
 
-        await helpers.makeFakeBinary(join(depPath, 'dep.exe'), {
-          exitCode: 0,
-          output: 'HELLO',
-        });
+    const p = await helpers.createTestSandbox(...fixture);
 
-        await run(`install`);
+    await p.defineNpmPackage({
+      name: 'depDep',
+      version: '1.0.0',
+      dependencies: {depDep: `1.0.0`},
+      bin: './depDep.exe',
+    });
 
-        {
-          const binPath = join(path, 'node_modules', '.bin', 'dep');
-          expect(await helpers.exists(binPath)).toBeTruthy();
+    const depPath = await p.defineNpmPackage({
+      name: 'dep',
+      version: '1.0.0',
+      dependencies: {depDep: `1.0.0`},
+      bin: './dep.exe',
+    });
 
-          const p = await helpers.execFile(binPath, [], {});
-          expect(p.stdout.toString().trim()).toBe('HELLO');
-        }
+    await helpers.makeFakeBinary(path.join(depPath, 'dep.exe'), {
+      exitCode: 0,
+      output: 'HELLO',
+    });
 
-        // only root deps has their bin installed
-        expect(await helpers.exists(join(path, 'node_modules', '.bin', 'depDep'))).toBeFalsy();
-      },
-    ),
-  );
+    await p.esy('install');
 
-  test(
-    `it should correctly install bin wrappers into node_modules/.bin (multiple bins)`,
-    helpers.makeTemporaryEnv(
-      {
+    const binPath = path.join(p.projectPath, 'node_modules', '.bin', 'dep');
+    expect(await helpers.exists(binPath)).toBeTruthy();
+
+    const proc = await helpers.execFile(binPath, [], {});
+    expect(proc.stdout.toString().trim()).toBe('HELLO');
+
+    // only root deps has their bin installed
+    expect(
+      await helpers.exists(path.join(p.projectPath, 'node_modules', '.bin', 'depDep')),
+    ).toBeFalsy();
+  });
+
+  test(`it should correctly install bin wrappers into node_modules/.bin (multiple bins)`, async () => {
+    const fixture = [
+      helpers.packageJson({
         name: 'root',
         version: '1.0.0',
         dependencies: {[`dep`]: `1.0.0`},
+      }),
+    ];
+    const p = await helpers.createTestSandbox(...fixture);
+    await p.defineNpmPackage({
+      name: 'depDep',
+      version: '1.0.0',
+      dependencies: {depDep: `1.0.0`},
+      bin: './depDep.exe',
+    });
+    const depPath = await p.defineNpmPackage({
+      name: 'dep',
+      version: '1.0.0',
+      dependencies: {depDep: `1.0.0`},
+      bin: {
+        dep: './dep.exe',
+        dep2: './dep2.exe',
       },
-      async ({path, run, source}) => {
-        await helpers.definePackage({
-          name: 'depDep',
-          version: '1.0.0',
-          dependencies: {depDep: `1.0.0`},
-          bin: './depDep.exe',
-        });
-        const depPath = await helpers.definePackage({
-          name: 'dep',
-          version: '1.0.0',
-          dependencies: {depDep: `1.0.0`},
-          bin: {
-            dep: './dep.exe',
-            dep2: './dep2.exe',
-          },
-        });
+    });
 
-        await helpers.makeFakeBinary(join(depPath, 'dep.exe'), {
-          exitCode: 0,
-          output: 'HELLO',
-        });
-        await helpers.makeFakeBinary(join(depPath, 'dep2.exe'), {
-          exitCode: 0,
-          output: 'HELLO2',
-        });
+    await helpers.makeFakeBinary(path.join(depPath, 'dep.exe'), {
+      exitCode: 0,
+      output: 'HELLO',
+    });
+    await helpers.makeFakeBinary(path.join(depPath, 'dep2.exe'), {
+      exitCode: 0,
+      output: 'HELLO2',
+    });
 
-        await run(`install`);
+    await p.esy(`install`);
 
-        {
-          const binPath = join(path, 'node_modules', '.bin', 'dep');
-          expect(await helpers.exists(binPath)).toBeTruthy();
+    {
+      const binPath = path.join(p.projectPath, 'node_modules', '.bin', 'dep');
+      expect(await helpers.exists(binPath)).toBeTruthy();
 
-          const p = await helpers.execFile(binPath, [], {});
-          expect(p.stdout.toString().trim()).toBe('HELLO');
-        }
+      const proc = await helpers.execFile(binPath, [], {});
+      expect(proc.stdout.toString().trim()).toBe('HELLO');
+    }
 
-        {
-          const binPath = join(path, 'node_modules', '.bin', 'dep2');
-          expect(await helpers.exists(binPath)).toBeTruthy();
+    {
+      const binPath = path.join(p.projectPath, 'node_modules', '.bin', 'dep2');
+      expect(await helpers.exists(binPath)).toBeTruthy();
 
-          const p = await helpers.execFile(binPath, [], {});
-          expect(p.stdout.toString().trim()).toBe('HELLO2');
-        }
+      const proc = await helpers.execFile(binPath, [], {});
+      expect(proc.stdout.toString().trim()).toBe('HELLO2');
+    }
 
-        // only root deps has their bin installed
-        expect(await helpers.exists(join(path, 'node_modules', '.bin', 'depDep'))).toBeFalsy();
-      },
-    ),
-  );
+    // only root deps has their bin installed
+    expect(
+      await helpers.exists(path.join(p.projectPath, 'node_modules', '.bin', 'depDep')),
+    ).toBeFalsy();
+  });
 
-  test.skip(
-    `it should correctly install an inter-dependency loop`,
-    helpers.makeTemporaryEnv(
-      {
-        name: 'root',
-        version: '1.0.0',
-        dependencies: {[`dep-loop-entry`]: `1.0.0`},
-      },
-      async ({path, run, source}) => {
-        await run(`install`);
+  // test.skip(
+  //   `it should correctly install an inter-dependency loop`,
+  //   helpers.makeTemporaryEnv(
+  //     {
+  //       name: 'root',
+  //       version: '1.0.0',
+  //       dependencies: {[`dep-loop-entry`]: `1.0.0`},
+  //     },
+  //     async ({path, run, source}) => {
+  //       await run(`install`);
 
-        await expect(
-          source(
-            // eslint-disable-next-line
-            `require('dep-loop-entry') === require('dep-loop-entry').dependencies['dep-loop-exit'].dependencies['dep-loop-entry']`,
-          ),
-        );
-      },
-    ),
-  );
+  //       await expect(
+  //         source(
+  //           // eslint-disable-next-line
+  //           `require('dep-loop-entry') === require('dep-loop-entry').dependencies['dep-loop-exit'].dependencies['dep-loop-entry']`,
+  //         ),
+  //       );
+  //     },
+  //   ),
+  // );
 
-  test.skip(
-    `it should install from archives on the filesystem`,
-    helpers.makeTemporaryEnv(
-      {
-        name: 'root',
-        version: '1.0.0',
-        dependencies: {[`no-deps`]: helpers.getPackageArchivePath(`no-deps`, `1.0.0`)},
-      },
-      async ({path, run, source}) => {
-        await run(`install`);
+  // test.skip(
+  //   `it should install from archives on the filesystem`,
+  //   helpers.makeTemporaryEnv(
+  //     {
+  //       name: 'root',
+  //       version: '1.0.0',
+  //       dependencies: {[`no-deps`]: helpers.getPackageArchivePath(`no-deps`, `1.0.0`)},
+  //     },
+  //     async ({path, run, source}) => {
+  //       await run(`install`);
 
-        await expect(source(`require('no-deps')`)).resolves.toMatchObject({
-          name: `no-deps`,
-          version: `1.0.0`,
-        });
-      },
-    ),
-  );
+  //       await expect(source(`require('no-deps')`)).resolves.toMatchObject({
+  //         name: `no-deps`,
+  //         version: `1.0.0`,
+  //       });
+  //     },
+  //   ),
+  // );
 
-  test.skip(
-    `it should install the dependencies of any dependency fetched from the filesystem`,
-    helpers.makeTemporaryEnv(
-      {
-        name: 'root',
-        version: '1.0.0',
-        dependencies: {
-          [`one-fixed-dep`]: helpers.getPackageArchivePath(`one-fixed-dep`, `1.0.0`),
-        },
-      },
-      async ({path, run, source}) => {
-        await run(`install`);
+  // test.skip(
+  //   `it should install the dependencies of any dependency fetched from the filesystem`,
+  //   helpers.makeTemporaryEnv(
+  //     {
+  //       name: 'root',
+  //       version: '1.0.0',
+  //       dependencies: {
+  //         [`one-fixed-dep`]: helpers.getPackageArchivePath(`one-fixed-dep`, `1.0.0`),
+  //       },
+  //     },
+  //     async ({path, run, source}) => {
+  //       await run(`install`);
 
-        await expect(source(`require('one-fixed-dep')`)).resolves.toMatchObject({
-          name: `one-fixed-dep`,
-          version: `1.0.0`,
-          dependencies: {
-            [`no-deps`]: {
-              name: `no-deps`,
-              version: `1.0.0`,
-            },
-          },
-        });
-      },
-    ),
-  );
+  //       await expect(source(`require('one-fixed-dep')`)).resolves.toMatchObject({
+  //         name: `one-fixed-dep`,
+  //         version: `1.0.0`,
+  //         dependencies: {
+  //           [`no-deps`]: {
+  //             name: `no-deps`,
+  //             version: `1.0.0`,
+  //           },
+  //         },
+  //       });
+  //     },
+  //   ),
+  // );
 
-  test.skip(
-    `it should install from files on the internet`,
-    helpers.makeTemporaryEnv(
-      {
-        name: 'root',
-        version: '1.0.0',
-        dependencies: {[`no-deps`]: helpers.getPackageHttpArchivePath(`no-deps`, `1.0.0`)},
-      },
-      async ({path, run, source}) => {
-        await run(`install`);
+  // test.skip(
+  //   `it should install from files on the internet`,
+  //   helpers.makeTemporaryEnv(
+  //     {
+  //       name: 'root',
+  //       version: '1.0.0',
+  //       dependencies: {
+  //         [`no-deps`]: helpers.getPackageHttpArchivePath(`no-deps`, `1.0.0`),
+  //       },
+  //     },
+  //     async ({path, run, source}) => {
+  //       await run(`install`);
 
-        await expect(source(`require('no-deps')`)).resolves.toMatchObject({
-          name: `no-deps`,
-          version: `1.0.0`,
-        });
-      },
-    ),
-  );
+  //       await expect(source(`require('no-deps')`)).resolves.toMatchObject({
+  //         name: `no-deps`,
+  //         version: `1.0.0`,
+  //       });
+  //     },
+  //   ),
+  // );
 
-  test.skip(
-    `it should install the dependencies of any dependency fetched from the internet`,
-    helpers.makeTemporaryEnv(
-      {
-        name: 'root',
-        version: '1.0.0',
-        dependencies: {
-          [`one-fixed-dep`]: helpers.getPackageHttpArchivePath(`one-fixed-dep`, `1.0.0`),
-        },
-      },
-      async ({path, run, source}) => {
-        await run(`install`);
+  // test.skip(
+  //   `it should install the dependencies of any dependency fetched from the internet`,
+  //   helpers.makeTemporaryEnv(
+  //     {
+  //       name: 'root',
+  //       version: '1.0.0',
+  //       dependencies: {
+  //         [`one-fixed-dep`]: helpers.getPackageHttpArchivePath(`one-fixed-dep`, `1.0.0`),
+  //       },
+  //     },
+  //     async ({path, run, source}) => {
+  //       await run(`install`);
 
-        await expect(source(`require('one-fixed-dep')`)).resolves.toMatchObject({
-          name: `one-fixed-dep`,
-          version: `1.0.0`,
-          dependencies: {
-            [`no-deps`]: {
-              name: `no-deps`,
-              version: `1.0.0`,
-            },
-          },
-        });
-      },
-    ),
-  );
+  //       await expect(source(`require('one-fixed-dep')`)).resolves.toMatchObject({
+  //         name: `one-fixed-dep`,
+  //         version: `1.0.0`,
+  //         dependencies: {
+  //           [`no-deps`]: {
+  //             name: `no-deps`,
+  //             version: `1.0.0`,
+  //           },
+  //         },
+  //       });
+  //     },
+  //   ),
+  // );
 
-  test.skip(
-    `it should install from local directories`,
-    helpers.makeTemporaryEnv(
-      {
-        name: 'root',
-        version: '1.0.0',
-        dependencies: {[`no-deps`]: helpers.getPackageDirectoryPath(`no-deps`, `1.0.0`)},
-      },
-      async ({path, run, source}) => {
-        await run(`install`);
+  // test.skip(
+  //   `it should install from local directories`,
+  //   helpers.makeTemporaryEnv(
+  //     {
+  //       name: 'root',
+  //       version: '1.0.0',
+  //       dependencies: {[`no-deps`]: helpers.getPackageDirectoryPath(`no-deps`, `1.0.0`)},
+  //     },
+  //     async ({path, run, source}) => {
+  //       await run(`install`);
 
-        await expect(source(`require('no-deps')`)).resolves.toMatchObject({
-          name: `no-deps`,
-          version: `1.0.0`,
-        });
-      },
-    ),
-  );
+  //       await expect(source(`require('no-deps')`)).resolves.toMatchObject({
+  //         name: `no-deps`,
+  //         version: `1.0.0`,
+  //       });
+  //     },
+  //   ),
+  // );
 
-  test.skip(
-    `it should install the dependencies of any dependency fetched from a local directory`,
-    helpers.makeTemporaryEnv(
-      {
-        name: 'root',
-        version: '1.0.0',
-        dependencies: {
-          [`one-fixed-dep`]: helpers.getPackageDirectoryPath(`one-fixed-dep`, `1.0.0`),
-        },
-      },
-      async ({path, run, source}) => {
-        await run(`install`);
+  // test.skip(
+  //   `it should install the dependencies of any dependency fetched from a local directory`,
+  //   helpers.makeTemporaryEnv(
+  //     {
+  //       name: 'root',
+  //       version: '1.0.0',
+  //       dependencies: {
+  //         [`one-fixed-dep`]: helpers.getPackageDirectoryPath(`one-fixed-dep`, `1.0.0`),
+  //       },
+  //     },
+  //     async ({path, run, source}) => {
+  //       await run(`install`);
 
-        await expect(source(`require('one-fixed-dep')`)).resolves.toMatchObject({
-          name: `one-fixed-dep`,
-          version: `1.0.0`,
-          dependencies: {
-            [`no-deps`]: {
-              name: `no-deps`,
-              version: `1.0.0`,
-            },
-          },
-        });
-      },
-    ),
-  );
+  //       await expect(source(`require('one-fixed-dep')`)).resolves.toMatchObject({
+  //         name: `one-fixed-dep`,
+  //         version: `1.0.0`,
+  //         dependencies: {
+  //           [`no-deps`]: {
+  //             name: `no-deps`,
+  //             version: `1.0.0`,
+  //           },
+  //         },
+  //       });
+  //     },
+  //   ),
+  // );
 });

--- a/test-e2e/install/devDependencies.test.js
+++ b/test-e2e/install/devDependencies.test.js
@@ -5,183 +5,177 @@ const helpers = require('../test/helpers.js');
 helpers.skipSuiteOnWindows();
 
 describe('Installing devDependencies', function() {
-  test(
-    `it should install devDependencies`,
-    helpers.makeTemporaryEnv(
-      {
+  test(`it should install devDependencies`, async () => {
+    const fixture = [
+      helpers.packageJson({
         name: 'root',
         version: '1.0.0',
         esy: {},
         devDependencies: {devDep: `1.0.0`},
-      },
-      async ({path, run, source}) => {
-        await helpers.definePackage({
+      }),
+    ];
+    const p = await helpers.createTestSandbox(...fixture);
+    await p.defineNpmPackage({
+      name: 'devDep',
+      version: '1.0.0',
+      esy: {},
+      dependencies: {},
+    });
+
+    await p.esy(`install`);
+
+    await expect(helpers.crawlLayout(p.projectPath)).resolves.toMatchObject({
+      dependencies: {
+        devDep: {
           name: 'devDep',
-          version: '1.0.0',
-          esy: {},
-          dependencies: {},
-        });
-
-        await run(`install`);
-
-        await expect(helpers.crawlLayout(path)).resolves.toMatchObject({
-          dependencies: {
-            devDep: {
-              name: 'devDep',
-            },
-          },
-        });
+        },
       },
-    ),
-  );
+    });
+  });
 
-  test(
-    `it should install devDependencies along with its deps`,
-    helpers.makeTemporaryEnv(
-      {
+  test(`it should install devDependencies along with its deps`, async () => {
+    const fixture = [
+      helpers.packageJson({
         name: 'root',
         version: '1.0.0',
         esy: {},
         devDependencies: {devDep: `1.0.0`},
+      }),
+    ];
+    const p = await helpers.createTestSandbox(...fixture);
+    await p.defineNpmPackage({
+      name: 'devDep',
+      version: '1.0.0',
+      esy: {},
+      dependencies: {
+        ok: '1.0.0',
       },
-      async ({path, run, source}) => {
-        await helpers.definePackage({
-          name: 'devDep',
-          version: '1.0.0',
-          esy: {},
-          dependencies: {
-            ok: '1.0.0',
-          },
-        });
-        await helpers.definePackage({
+    });
+    await p.defineNpmPackage({
+      name: 'ok',
+      version: '1.0.0',
+      esy: {},
+      dependencies: {},
+    });
+
+    await p.esy(`install`);
+
+    await expect(helpers.crawlLayout(p.projectPath)).resolves.toMatchObject({
+      dependencies: {
+        ok: {
           name: 'ok',
           version: '1.0.0',
-          esy: {},
+        },
+        devDep: {
+          name: 'devDep',
           dependencies: {},
-        });
-
-        await run(`install`);
-
-        await expect(helpers.crawlLayout(path)).resolves.toMatchObject({
-          dependencies: {
-            ok: {
-              name: 'ok',
-              version: '1.0.0',
-            },
-            devDep: {
-              name: 'devDep',
-              dependencies: {},
-            },
-          },
-        });
+        },
       },
-    ),
-  );
+    });
+  });
 
-  test(
-    `it should prefer an already installed version when solving devDeps deps`,
-    helpers.makeTemporaryEnv(
-      {
+  test(`it should prefer an already installed version when solving devDeps deps`, async () => {
+    const fixture = [
+      helpers.packageJson({
         name: 'root',
         version: '1.0.0',
         dependencies: {ok: `1.0.0`},
         esy: {},
         devDependencies: {devDep: `1.0.0`},
+      }),
+    ];
+    const p = await helpers.createTestSandbox(...fixture);
+
+    await p.defineNpmPackage({
+      name: 'devDep',
+      version: '1.0.0',
+      esy: {},
+      dependencies: {
+        ok: '*',
       },
-      async ({path, run, source}) => {
-        await helpers.definePackage({
+    });
+    await p.defineNpmPackage({
+      name: 'ok',
+      version: '1.0.0',
+      esy: {},
+      dependencies: {},
+    });
+    await p.defineNpmPackage({
+      name: 'ok',
+      version: '2.0.0',
+      esy: {},
+      dependencies: {},
+    });
+
+    await p.esy(`install`);
+
+    const layout = await helpers.crawlLayout(p.projectPath);
+    await expect(layout).toMatchObject({
+      dependencies: {
+        ok: {
+          name: 'ok',
+          version: '1.0.0',
+        },
+        devDep: {
           name: 'devDep',
-          version: '1.0.0',
-          esy: {},
-          dependencies: {
-            ok: '*',
-          },
-        });
-        await helpers.definePackage({
-          name: 'ok',
-          version: '1.0.0',
-          esy: {},
           dependencies: {},
-        });
-        await helpers.definePackage({
-          name: 'ok',
-          version: '2.0.0',
-          esy: {},
-          dependencies: {},
-        });
-
-        await run(`install`);
-
-        const layout = await helpers.crawlLayout(path);
-        await expect(layout).toMatchObject({
-          dependencies: {
-            ok: {
-              name: 'ok',
-              version: '1.0.0',
-            },
-            devDep: {
-              name: 'devDep',
-              dependencies: {},
-            },
-          },
-        });
-        expect(layout).not.toHaveProperty('dependencies.devDep.dependencies.ok');
+        },
       },
-    ),
-  );
+    });
+    expect(layout).not.toHaveProperty('dependencies.devDep.dependencies.ok');
+  });
 
-  test(
-    `it should handle two devDeps sharing a dep`,
-    helpers.makeTemporaryEnv(
-      {
+  test(`it should handle two devDeps sharing a dep`, async () => {
+    const fixture = [
+      helpers.packageJson({
         name: 'root',
         version: '1.0.0',
         esy: {},
         devDependencies: {devDep: `1.0.0`, devDep2: '1.0.0'},
+      }),
+    ];
+    const p = await helpers.createTestSandbox(...fixture);
+
+    await p.defineNpmPackage({
+      name: 'devDep',
+      version: '1.0.0',
+      esy: {},
+      dependencies: {
+        ok: '*',
       },
-      async ({path, run, source}) => {
-        await helpers.definePackage({
-          name: 'devDep',
-          version: '1.0.0',
-          esy: {},
-          dependencies: {
-            ok: '*',
-          },
-        });
-        await helpers.definePackage({
-          name: 'devDep2',
-          version: '1.0.0',
-          esy: {},
-          dependencies: {
-            ok: '*',
-          },
-        });
-        await helpers.definePackage({
+    });
+    await p.defineNpmPackage({
+      name: 'devDep2',
+      version: '1.0.0',
+      esy: {},
+      dependencies: {
+        ok: '*',
+      },
+    });
+    await p.defineNpmPackage({
+      name: 'ok',
+      version: '1.0.0',
+      esy: {},
+      dependencies: {},
+    });
+
+    await p.esy(`install`);
+
+    const layout = await helpers.crawlLayout(p.projectPath);
+    await expect(layout).toMatchObject({
+      dependencies: {
+        ok: {
           name: 'ok',
-          version: '1.0.0',
-          esy: {},
+        },
+        devDep: {
+          name: 'devDep',
           dependencies: {},
-        });
-
-        await run(`install`);
-
-        const layout = await helpers.crawlLayout(path);
-        await expect(layout).toMatchObject({
-          dependencies: {
-            ok: {
-              name: 'ok',
-            },
-            devDep: {
-              name: 'devDep',
-              dependencies: {},
-            },
-            devDep2: {
-              name: 'devDep2',
-              dependencies: {},
-            },
-          },
-        });
+        },
+        devDep2: {
+          name: 'devDep2',
+          dependencies: {},
+        },
       },
-    ),
-  );
+    });
+  });
 });

--- a/test-e2e/install/dragon.test.js
+++ b/test-e2e/install/dragon.test.js
@@ -13,50 +13,49 @@ helpers.skipSuiteOnWindows();
 // names being sorted in a certain way).
 
 describe(`Dragon tests`, () => {
-  test(
-    `it should pass the dragon test 1`,
-    helpers.makeTemporaryEnv(
-      {
+  test(`it should pass the dragon test 1`, async () => {
+    // This test assumes the following:
+    //
+    // . -> D@1.0.0 -> C@1.0.0 -> B@1.0.0 -> A@1.0.0
+    //   -> E@1.0.0 -> B@2.0.0
+    //              -> C@1.0.0 -> B@1.0.0 -> A@1.0.0
+    //
+    // This setup has the following properties:
+    //
+    //   - we have a package that can be hoisted (dragon-test-1-a, aka A)
+    //   - its parent can NOT be hoisted (dragon-test-1-b, aka B)
+    //   - its grandparent can be hoisted (dragon-test-1-c, aka C)
+    //   - the D package prevents E>C from being pruned from the tree at resolution
+    //
+    // In this case, the package that can be hoisted will be hoisted to the
+    // top-level while we traverse the D branch, then B as well, then C as
+    // well. We then crawl the E branch: A is merged with the top-level A
+    // (so we merge their hoistedFrom fields), then B cannot be hoisted
+    // because its version conflict with the direct dependency of E (so
+    // its hoistedFrom field stays where it is), then C will be merged
+    // with the top-level C we already had, and its whole dependency branch
+    // will be removed from the tree (including the B direct dependency that
+    // has not been hoisted).
+    //
+    // Because of this, we end up having a hoistedFrom entry in A that
+    // references E>C>B>A. When we try to link this to its parent (E>C>B), we
+    // might then have a problem, because E>C>B doesn't exist anymore in the
+    // tree (we removed it when we hoisted C).
+    //
+    // This test simply makes sure that this edge case doesn't crash the install.
+
+    const fixture = [
+      helpers.packageJson({
         name: 'root',
         version: '1.0.0',
         dependencies: {
           [`dragon-test-1-d`]: `1.0.0`,
           [`dragon-test-1-e`]: `1.0.0`,
         },
-      },
-      async ({path, run}) => {
-        // This test assumes the following:
-        //
-        // . -> D@1.0.0 -> C@1.0.0 -> B@1.0.0 -> A@1.0.0
-        //   -> E@1.0.0 -> B@2.0.0
-        //              -> C@1.0.0 -> B@1.0.0 -> A@1.0.0
-        //
-        // This setup has the following properties:
-        //
-        //   - we have a package that can be hoisted (dragon-test-1-a, aka A)
-        //   - its parent can NOT be hoisted (dragon-test-1-b, aka B)
-        //   - its grandparent can be hoisted (dragon-test-1-c, aka C)
-        //   - the D package prevents E>C from being pruned from the tree at resolution
-        //
-        // In this case, the package that can be hoisted will be hoisted to the
-        // top-level while we traverse the D branch, then B as well, then C as
-        // well. We then crawl the E branch: A is merged with the top-level A
-        // (so we merge their hoistedFrom fields), then B cannot be hoisted
-        // because its version conflict with the direct dependency of E (so
-        // its hoistedFrom field stays where it is), then C will be merged
-        // with the top-level C we already had, and its whole dependency branch
-        // will be removed from the tree (including the B direct dependency that
-        // has not been hoisted).
-        //
-        // Because of this, we end up having a hoistedFrom entry in A that
-        // references E>C>B>A. When we try to link this to its parent (E>C>B), we
-        // might then have a problem, because E>C>B doesn't exist anymore in the
-        // tree (we removed it when we hoisted C).
-        //
-        // This test simply makes sure that this edge case doesn't crash the install.
+      }),
+    ];
+    const p = await helpers.createTestSandbox(...fixture);
 
-        await run(`install`);
-      },
-    ),
-  );
+    await p.esy(`install`);
+  });
 });

--- a/test-e2e/install/link.test.js
+++ b/test-e2e/install/link.test.js
@@ -1,52 +1,51 @@
 /* @flow */
 
-const {join} = require('path');
+const path = require('path');
 const helpers = require('../test/helpers');
 
 helpers.skipSuiteOnWindows();
 
 describe(`installing linked packages`, () => {
-  test(
-    'it should install linked packages',
-    helpers.makeTemporaryEnv(
-      {
+  test('it should install linked packages', async () => {
+    const fixture = [
+      helpers.packageJson({
         name: 'root',
         version: '1.0.0',
         esy: {},
         dependencies: {dep: `link:./dep`},
+      }),
+    ];
+    const p = await helpers.createTestSandbox(...fixture);
+
+    await p.defineNpmPackage({
+      name: 'depdep',
+      version: '1.0.0',
+      esy: {},
+    });
+    await p.defineNpmLocalPackage(path.join(p.projectPath, 'dep'), {
+      name: 'dep',
+      version: '1.0.0',
+      esy: {},
+      dependencies: {
+        depdep: '*',
       },
-      async ({path, run, source}) => {
-        await helpers.definePackage({
+    });
+
+    await p.esy(`install`);
+
+    const layout = await helpers.crawlLayout(p.projectPath);
+    expect(layout).toMatchObject({
+      name: 'root',
+      dependencies: {
+        depdep: {
           name: 'depdep',
           version: '1.0.0',
-          esy: {},
-        });
-        await helpers.defineLocalPackage(join(path, 'dep'), {
+        },
+        dep: {
           name: 'dep',
           version: '1.0.0',
-          esy: {},
-          dependencies: {
-            depdep: '*',
-          },
-        });
-
-        await run(`install`);
-
-        const layout = await helpers.crawlLayout(path);
-        expect(layout).toMatchObject({
-          name: 'root',
-          dependencies: {
-            depdep: {
-              name: 'depdep',
-              version: '1.0.0',
-            },
-            dep: {
-              name: 'dep',
-              version: '1.0.0',
-            },
-          },
-        });
+        },
       },
-    ),
-  );
+    });
+  });
 });

--- a/test-e2e/install/pkg-integrity.test.js
+++ b/test-e2e/install/pkg-integrity.test.js
@@ -5,32 +5,30 @@ const helpers = require('../test/helpers.js');
 helpers.skipSuiteOnWindows('Needs investigation.');
 
 describe('Testing integrity of downloaded packages', function() {
-  test(
-    `it should fail on corrupted tarballs`,
-    helpers.makeTemporaryEnv(
-      {
+  test(`it should fail on corrupted tarballs`, async () => {
+    const fixture = [
+      helpers.packageJson({
         name: 'root',
         version: '1.0.0',
         esy: {},
         dependencies: {dep: `1.0.0`},
+      }),
+    ];
+    const p = await helpers.createTestSandbox(...fixture);
+    await p.defineNpmPackage(
+      {
+        name: 'dep',
+        version: '1.0.0',
+        esy: {},
+        dependencies: {},
       },
-      async ({path, run, source}) => {
-        await helpers.definePackage(
-          {
-            name: 'dep',
-            version: '1.0.0',
-            esy: {},
-            dependencies: {},
-          },
-          {shasum: 'dummy-invalid-shasum'},
-        );
+      {shasum: 'dummy-invalid-shasum'},
+    );
 
-        try {
-          await run(`install`);
-        } catch (err) {
-          expect(/sha1 checksum mismatch/.exec(err)).toBeTruthy();
-        }
-      },
-    ),
-  );
+    try {
+      await p.esy(`install`);
+    } catch (err) {
+      expect(/sha1 checksum mismatch/.exec(err)).toBeTruthy();
+    }
+  });
 });

--- a/test-e2e/install/resolutions.test.js
+++ b/test-e2e/install/resolutions.test.js
@@ -5,89 +5,85 @@ const helpers = require('../test/helpers.js');
 helpers.skipSuiteOnWindows();
 
 describe(`Installing with resolutions`, () => {
-  test(
-    `it should prefer resolution over dependencies for the root`,
-    helpers.makeTemporaryEnv(
-      {
+  test(`it should prefer resolution over dependencies for the root`, async () => {
+    const fixture = [
+      helpers.packageJson({
         name: 'root',
         version: '1.0.0',
         esy: {},
         dependencies: {dep: `1.0.0`},
         resolutions: {dep: `2.0.0`},
-      },
-      async ({path, run, source}) => {
-        await helpers.definePackage({
-          name: 'dep',
-          version: '1.0.0',
-          esy: {},
-        });
-        await helpers.definePackage({
+      }),
+    ];
+    const p = await helpers.createTestSandbox(...fixture);
+    await p.defineNpmPackage({
+      name: 'dep',
+      version: '1.0.0',
+      esy: {},
+    });
+    await p.defineNpmPackage({
+      name: 'dep',
+      version: '2.0.0',
+      esy: {},
+    });
+
+    await p.esy(`install`);
+
+    const layout = await helpers.crawlLayout(p.projectPath);
+    expect(layout).toMatchObject({
+      name: 'root',
+      dependencies: {
+        dep: {
           name: 'dep',
           version: '2.0.0',
-          esy: {},
-        });
-
-        await run(`install`);
-
-        const layout = await helpers.crawlLayout(path);
-        expect(layout).toMatchObject({
-          name: 'root',
-          dependencies: {
-            dep: {
-              name: 'dep',
-              version: '2.0.0',
-            },
-          },
-        });
+        },
       },
-    ),
-  );
+    });
+  });
 
-  test(
-    `it should prefer resolution over dependencies for the dependency`,
-    helpers.makeTemporaryEnv(
-      {
+  test(`it should prefer resolution over dependencies for the dependency`, async () => {
+    const fixture = [
+      helpers.packageJson({
         name: 'root',
         version: '1.0.0',
         esy: {},
         dependencies: {dep: `1.0.0`},
         resolutions: {depDep: `2.0.0`},
-      },
-      async ({path, run, source}) => {
-        await helpers.definePackage({
+      }),
+    ];
+    const p = await helpers.createTestSandbox(...fixture);
+    await p.defineNpmPackage({
+      name: 'dep',
+      version: '1.0.0',
+      esy: {},
+      dependencies: {depDep: `1.0.0`},
+    });
+    await p.defineNpmPackage({
+      name: 'depDep',
+      esy: {},
+      version: '1.0.0',
+    });
+    await p.defineNpmPackage({
+      name: 'depDep',
+      esy: {},
+      version: '2.0.0',
+    });
+
+    await p.esy(`install`);
+
+    const layout = await helpers.crawlLayout(p.projectPath);
+    expect(layout).toMatchObject({
+      name: 'root',
+      dependencies: {
+        dep: {
           name: 'dep',
           version: '1.0.0',
-          esy: {},
-          dependencies: {depDep: `1.0.0`},
-        });
-        await helpers.definePackage({
+        },
+        depDep: {
           name: 'depDep',
-          esy: {},
-          version: '1.0.0',
-        });
-        await helpers.definePackage({
-          name: 'depDep',
-          esy: {},
           version: '2.0.0',
-        });
-
-        await run(`install`);
-
-        const layout = await helpers.crawlLayout(path);
-        expect(layout).toMatchObject({
-          name: 'root',
-          dependencies: {
-            dep: {
-              name: 'dep',
-              version: '1.0.0',
-            },
-            depDep: {
-              name: 'depDep',
-              version: '2.0.0',
-            },
-          },
-        });
+        },
       },
-    ),
-  );
+    });
+  });
 });

--- a/test-e2e/install/sources.test.js
+++ b/test-e2e/install/sources.test.js
@@ -6,13 +6,6 @@ helpers.skipSuiteOnWindows();
 
 describe(`Tests for installations from custom sources`, () => {
   describe('Installation from github', () => {
-    beforeEach(async () => {
-      await helpers.definePackage({
-        name: 'lodash',
-        version: '4.24.0',
-      });
-    });
-
     async function assertLayoutCorrect(path) {
       await expect(helpers.crawlLayout(path)).resolves.toMatchObject({
         dependencies: {
@@ -28,94 +21,97 @@ describe(`Tests for installations from custom sources`, () => {
       });
     }
 
-    test(
-      'it should install without ref',
-      helpers.makeTemporaryEnv(
-        {
+    test('it should install without ref', async () => {
+      const fixture = [
+        helpers.packageJson({
           name: 'root',
           version: '1.0.0',
           dependencies: {'example-yarn-package': `yarnpkg/example-yarn-package`},
-        },
-        async ({path, run, source}) => {
-          await run('install');
-          await assertLayoutCorrect(path);
-        },
-      ),
-    );
+        }),
+      ];
+      const p = await helpers.createTestSandbox(...fixture);
+      await p.defineNpmPackage({
+        name: 'lodash',
+        version: '4.24.0',
+      });
+      await p.esy('install');
+      await assertLayoutCorrect(p.projectPath);
+    });
 
-    test(
-      'it should install with branch as ref',
-      helpers.makeTemporaryEnv(
-        {
+    test('it should install with branch as ref', async () => {
+      const fixture = [
+        helpers.packageJson({
           name: 'root',
           version: '1.0.0',
           dependencies: {'example-yarn-package': `yarnpkg/example-yarn-package#master`},
-        },
-        async ({path, run, source}) => {
-          await run('install');
-          await assertLayoutCorrect(path);
-        },
-      ),
-    );
+        }),
+      ];
+      const p = await helpers.createTestSandbox(...fixture);
+      await p.defineNpmPackage({
+        name: 'lodash',
+        version: '4.24.0',
+      });
+      await p.esy('install');
+      await assertLayoutCorrect(p.projectPath);
+    });
 
-    test(
-      'it should install with 6 char commit sha as ref',
-      helpers.makeTemporaryEnv(
-        {
+    test('it should install with 6 char commit sha as ref', async () => {
+      const fixture = [
+        helpers.packageJson({
           name: 'root',
           version: '1.0.0',
           dependencies: {'example-yarn-package': `yarnpkg/example-yarn-package#0b8f43`},
-        },
-        async ({path, run, source}) => {
-          await run('install');
-          await assertLayoutCorrect(path);
-        },
-      ),
-    );
+        }),
+      ];
+      const p = await helpers.createTestSandbox(...fixture);
+      await p.defineNpmPackage({
+        name: 'lodash',
+        version: '4.24.0',
+      });
+      await p.esy('install');
+      await assertLayoutCorrect(p.projectPath);
+    });
 
-    test(
-      'it should install with 9 char commit sha as ref',
-      helpers.makeTemporaryEnv(
-        {
+    test('it should install with 9 char commit sha as ref', async () => {
+      const fixture = [
+        helpers.packageJson({
           name: 'root',
           version: '1.0.0',
           dependencies: {
             'example-yarn-package': `yarnpkg/example-yarn-package#0b8f43f77`,
           },
-        },
-        async ({path, run, source}) => {
-          await run('install');
-          await assertLayoutCorrect(path);
-        },
-      ),
-    );
+        }),
+      ];
+      const p = await helpers.createTestSandbox(...fixture);
+      await p.defineNpmPackage({
+        name: 'lodash',
+        version: '4.24.0',
+      });
+      await p.esy('install');
+      await assertLayoutCorrect(p.projectPath);
+    });
 
-    test(
-      'it should install with 40 char commit sha as ref',
-      helpers.makeTemporaryEnv(
-        {
+    test('it should install with 40 char commit sha as ref', async () => {
+      const fixture = [
+        helpers.packageJson({
           name: 'root',
           version: '1.0.0',
           dependencies: {
             'example-yarn-package': `yarnpkg/example-yarn-package#0b8f43f77361ff7739bcb42de7787b09208bcece`,
           },
-        },
-        async ({path, run, source}) => {
-          await run('install');
-          await assertLayoutCorrect(path);
-        },
-      ),
-    );
-  });
-
-  describe('Installation from git', () => {
-    beforeEach(async () => {
-      await helpers.definePackage({
+        }),
+      ];
+      const p = await helpers.createTestSandbox(...fixture);
+      await p.defineNpmPackage({
         name: 'lodash',
         version: '4.24.0',
       });
+      await p.esy('install');
+      await assertLayoutCorrect(p.projectPath);
     });
+  });
 
+  describe('Installation from git', () => {
     async function assertLayoutCorrect(path) {
       await expect(helpers.crawlLayout(path)).resolves.toMatchObject({
         dependencies: {
@@ -131,106 +127,118 @@ describe(`Tests for installations from custom sources`, () => {
       });
     }
 
-    test(
-      'install from git+https:// with no ref',
-      helpers.makeTemporaryEnv(
-        {
+    test('install from git+https:// with no ref', async () => {
+      const fixture = [
+        helpers.packageJson({
           name: 'root',
           version: '1.0.0',
           dependencies: {
             'example-yarn-package': `git+https://github.com/yarnpkg/example-yarn-package.git`,
           },
-        },
-        async ({path, run, source}) => {
-          await run('install');
-          await assertLayoutCorrect(path);
-        },
-      ),
-    );
+        }),
+      ];
+      const p = await helpers.createTestSandbox(...fixture);
+      await p.defineNpmPackage({
+        name: 'lodash',
+        version: '4.24.0',
+      });
+      await p.esy('install');
+      await assertLayoutCorrect(p.projectPath);
+    });
 
-    test(
-      'install from git+https:// with branch as ref',
-      helpers.makeTemporaryEnv(
-        {
+    test('install from git+https:// with branch as ref', async () => {
+      const fixture = [
+        helpers.packageJson({
           name: 'root',
           version: '1.0.0',
           dependencies: {
             'example-yarn-package': `git+https://github.com/yarnpkg/example-yarn-package.git#master`,
           },
-        },
-        async ({path, run, source}) => {
-          await run('install');
-          await assertLayoutCorrect(path);
-        },
-      ),
-    );
+        }),
+      ];
+      const p = await helpers.createTestSandbox(...fixture);
+      await p.defineNpmPackage({
+        name: 'lodash',
+        version: '4.24.0',
+      });
+      await p.esy('install');
+      await assertLayoutCorrect(p.projectPath);
+    });
 
-    test(
-      'install from git+https:// with commit sha as ref',
-      helpers.makeTemporaryEnv(
-        {
+    test('install from git+https:// with commit sha as ref', async () => {
+      const fixture = [
+        helpers.packageJson({
           name: 'root',
           version: '1.0.0',
           dependencies: {
             'example-yarn-package': `git+https://github.com/yarnpkg/example-yarn-package.git#0b8f43`,
           },
-        },
-        async ({path, run, source}) => {
-          await run('install');
-          await assertLayoutCorrect(path);
-        },
-      ),
-    );
+        }),
+      ];
+      const p = await helpers.createTestSandbox(...fixture);
+      await p.defineNpmPackage({
+        name: 'lodash',
+        version: '4.24.0',
+      });
+      await p.esy('install');
+      await assertLayoutCorrect(p.projectPath);
+    });
 
-    test(
-      'install from git:// with no ref',
-      helpers.makeTemporaryEnv(
-        {
+    test('install from git:// with no ref', async () => {
+      const fixture = [
+        helpers.packageJson({
           name: 'root',
           version: '1.0.0',
           dependencies: {
             'example-yarn-package': `git://github.com/yarnpkg/example-yarn-package.git`,
           },
-        },
-        async ({path, run, source}) => {
-          await run('install');
-          await assertLayoutCorrect(path);
-        },
-      ),
-    );
+        }),
+      ];
+      const p = await helpers.createTestSandbox(...fixture);
+      await p.defineNpmPackage({
+        name: 'lodash',
+        version: '4.24.0',
+      });
+      await p.esy('install');
+      await assertLayoutCorrect(p.projectPath);
+    });
 
-    test(
-      'install from git:// with branch as ref',
-      helpers.makeTemporaryEnv(
-        {
+    test('install from git:// with branch as ref', async () => {
+      const fixture = [
+        helpers.packageJson({
           name: 'root',
           version: '1.0.0',
           dependencies: {
             'example-yarn-package': `git://github.com/yarnpkg/example-yarn-package.git#master`,
           },
-        },
-        async ({path, run, source}) => {
-          await run('install');
-          await assertLayoutCorrect(path);
-        },
-      ),
-    );
+        }),
+      ];
+      const p = await helpers.createTestSandbox(...fixture);
+      await p.defineNpmPackage({
+        name: 'lodash',
+        version: '4.24.0',
+      });
+      await p.esy('install');
+      await assertLayoutCorrect(p.projectPath);
+    });
 
-    test(
-      'install from git:// with commit as ref',
-      helpers.makeTemporaryEnv(
-        {
+    test('install from git:// with commit as ref', async () => {
+      const fixture = [
+        helpers.packageJson({
           name: 'root',
           version: '1.0.0',
           dependencies: {
             'example-yarn-package': `git://github.com/yarnpkg/example-yarn-package.git#0b8f43`,
           },
-        },
-        async ({path, run, source}) => {
-          await run('install');
-          await assertLayoutCorrect(path);
-        },
-      ),
-    );
+        }),
+      ];
+      const p = await helpers.createTestSandbox(...fixture);
+      await p.defineNpmPackage({
+        name: 'lodash',
+        version: '4.24.0',
+      });
+      await p.esy('install');
+      await assertLayoutCorrect(p.projectPath);
+    });
   });
 });

--- a/test-e2e/test/FixtureUtils.js
+++ b/test-e2e/test/FixtureUtils.js
@@ -46,7 +46,7 @@ function packageJson(json: Object) {
   return file('package.json', JSON.stringify(json, null, 2));
 }
 
-async function initialize(p: string, fixture: FixtureItem) {
+async function layout(p: string, fixture: FixtureItem) {
   if (fixture.type === 'file') {
     await fs.writeFile(path.join(p, fixture.name), fixture.data);
   } else if (fixture.type === 'file-copy') {
@@ -56,10 +56,14 @@ async function initialize(p: string, fixture: FixtureItem) {
   } else if (fixture.type === 'dir') {
     const nextp = path.join(p, fixture.name);
     await fs.mkdir(nextp);
-    await Promise.all(fixture.items.map(item => initialize(nextp, item)));
+    await Promise.all(fixture.items.map(item => layout(nextp, item)));
   } else {
     throw new Error('unknown fixture ' + JSON.stringify(fixture));
   }
+}
+
+function initialize(p: string, fixture: Fixture) {
+  return Promise.all(fixture.map(item => layout(p, item)));
 }
 
 module.exports = {

--- a/test-e2e/test/OpamRegistryMock.js
+++ b/test-e2e/test/OpamRegistryMock.js
@@ -8,14 +8,16 @@ const path = require('path');
 const fs = require('fs-extra');
 const {createTemporaryFolder} = require('./fs.js');
 
-export opaque type OpamRegistry = {
+export type OpamRegistry = {
   registryPath: string,
   overridePath: string,
 };
 
 async function initialize(): Promise<OpamRegistry> {
   const registryPath = await createTemporaryFolder();
+  await fs.mkdirp(path.join(registryPath, 'packages'));
   const overridePath = await createTemporaryFolder();
+  await fs.mkdirp(path.join(overridePath, 'packages'));
   return {registryPath, overridePath};
 }
 
@@ -28,7 +30,7 @@ async function defineOpamPackage(
     url: ?string,
   },
 ) {
-  const packagePath = path.join(registry.registryPath, spec.name);
+  const packagePath = path.join(registry.registryPath, 'packages', spec.name);
   await fs.mkdirp(packagePath);
 
   const packageVersionPath = path.join(packagePath, `${spec.name}.${spec.version}`);
@@ -39,3 +41,8 @@ async function defineOpamPackage(
     await fs.writeFile(path.join(packageVersionPath, 'url'), spec.opam);
   }
 }
+
+module.exports = {
+  initialize,
+  defineOpamPackage,
+};

--- a/test-e2e/test/OpamRegistryMock.js
+++ b/test-e2e/test/OpamRegistryMock.js
@@ -1,0 +1,41 @@
+/**
+ * Utilities for mocking opam registry.
+ *
+ * @flow
+ */
+
+const path = require('path');
+const fs = require('fs-extra');
+const {createTemporaryFolder} = require('./fs.js');
+
+export opaque type OpamRegistry = {
+  registryPath: string,
+  overridePath: string,
+};
+
+async function initialize(): Promise<OpamRegistry> {
+  const registryPath = await createTemporaryFolder();
+  const overridePath = await createTemporaryFolder();
+  return {registryPath, overridePath};
+}
+
+async function defineOpamPackage(
+  registry: OpamRegistry,
+  spec: {
+    name: string,
+    version: string,
+    opam: string,
+    url: ?string,
+  },
+) {
+  const packagePath = path.join(registry.registryPath, spec.name);
+  await fs.mkdirp(packagePath);
+
+  const packageVersionPath = path.join(packagePath, `${spec.name}.${spec.version}`);
+  await fs.mkdirp(packageVersionPath);
+
+  await fs.writeFile(path.join(packageVersionPath, 'opam'), spec.opam);
+  if (spec.url != null) {
+    await fs.writeFile(path.join(packageVersionPath, 'url'), spec.opam);
+  }
+}

--- a/test-e2e/test/OpamRegistryMock.js
+++ b/test-e2e/test/OpamRegistryMock.js
@@ -4,13 +4,22 @@
  * @flow
  */
 
+import type {ServerResponse} from 'http';
+import type {Fixture} from './FixtureUtils.js';
+
+const outdent = require('outdent');
+const crypto = require('crypto');
+const http = require('http');
 const path = require('path');
 const fs = require('fs-extra');
-const {createTemporaryFolder} = require('./fs.js');
+const {createTemporaryFolder, packToFile} = require('./fs.js');
+const FixtureUtils = require('./FixtureUtils.js');
 
 export type OpamRegistry = {
   registryPath: string,
   overridePath: string,
+  serverUrl: string,
+  packageSourcesPath: string,
 };
 
 async function initialize(): Promise<OpamRegistry> {
@@ -18,7 +27,66 @@ async function initialize(): Promise<OpamRegistry> {
   await fs.mkdirp(path.join(registryPath, 'packages'));
   const overridePath = await createTemporaryFolder();
   await fs.mkdirp(path.join(overridePath, 'packages'));
-  return {registryPath, overridePath};
+
+  const packageSourcesPath = await createTemporaryFolder();
+
+  const serverUrl = await new Promise((resolve, reject) => {
+    function processError(
+      res: ServerResponse,
+      statusCode: number,
+      errorMessage: string,
+    ): boolean {
+      console.error(errorMessage);
+
+      res.writeHead(statusCode);
+      res.end(errorMessage);
+
+      return true;
+    }
+
+    async function processPackageTarball(
+      tarballName: string,
+      res: ServerResponse,
+    ): Promise<boolean> {
+      const tarballPath = path.join(packageSourcesPath, tarballName);
+      if (!(await fs.exists(tarballPath))) {
+        return processError(res, 404, `Tarball not found: ${tarballPath}`);
+      }
+
+      res.writeHead(200, {
+        ['Content-Type']: 'application/octet-stream',
+        ['Transfer-Encoding']: 'chunked',
+      });
+
+      const out = fs.createReadStream(tarballPath);
+      out.pipe(res);
+
+      return true;
+    }
+
+    const server = http.createServer(
+      (req, res) =>
+        void (async () => {
+          try {
+            const url = req.url;
+            if (await processPackageTarball(url, res)) {
+              return;
+            }
+
+            processError(res, 404, `Invalid route: ${url}`);
+          } catch (error) {
+            processError(res, 500, error.stack);
+          }
+        })(),
+    );
+    server.listen(() => {
+      server.unref();
+      const {port} = server.address();
+      resolve(`http://localhost:${port}`);
+    });
+  });
+
+  return {serverUrl, registryPath, overridePath, packageSourcesPath};
 }
 
 async function defineOpamPackage(
@@ -38,11 +106,51 @@ async function defineOpamPackage(
 
   await fs.writeFile(path.join(packageVersionPath, 'opam'), spec.opam);
   if (spec.url != null) {
-    await fs.writeFile(path.join(packageVersionPath, 'url'), spec.opam);
+    await fs.writeFile(path.join(packageVersionPath, 'url'), spec.url);
   }
+}
+
+async function defineOpamPackageOfFixture(
+  registry: OpamRegistry,
+  spec: {
+    name: string,
+    version: string,
+    opam: string,
+  },
+  fixture: Fixture,
+) {
+  const packagePath = path.join(registry.registryPath, 'packages', spec.name);
+  await fs.mkdirp(packagePath);
+
+  const packageVersionPath = path.join(packagePath, `${spec.name}.${spec.version}`);
+  await fs.mkdirp(packageVersionPath);
+
+  const tarballFilename = `${spec.name}@${spec.version}.tgz`;
+  await fs.writeFile(path.join(packageVersionPath, 'opam'), spec.opam);
+  const packageSourcePath = await createTemporaryFolder();
+  await FixtureUtils.initialize(packageSourcePath, fixture);
+
+  const tarballPath = path.join(registry.packageSourcesPath, tarballFilename);
+  await packToFile(tarballPath, packageSourcePath, {
+    virtualPath: `/${spec.name}-${spec.version}`,
+  });
+
+  const data = await fs.readFile(tarballPath);
+  const hasher = crypto.createHash('md5');
+  hasher.update(data);
+  const checksum = hasher.digest('hex');
+
+  await fs.writeFile(
+    path.join(packageVersionPath, 'url'),
+    outdent`
+      archive: "${registry.serverUrl}/${tarballFilename}"
+      checksum: "${checksum}"
+    `,
+  );
 }
 
 module.exports = {
   initialize,
   defineOpamPackage,
+  defineOpamPackageOfFixture,
 };

--- a/test-e2e/test/PackageGraph.js
+++ b/test-e2e/test/PackageGraph.js
@@ -1,0 +1,57 @@
+/**
+ * Represent node_modules directory in memory and make assertions against it.
+ *
+ * @flow
+ */
+
+const path = require('path');
+const fsUtils = require('./fs');
+
+export type Package = {
+  name: string,
+  version: string,
+  path: string,
+  dependencies: {[name: string]: Package},
+};
+
+async function crawl(directory: string): Promise<?Package> {
+  const esyLinkPath = path.join(directory, '_esylink');
+  const nodeModulesPath = path.join(directory, 'node_modules');
+
+  let packageJsonPath;
+  if (await fsUtils.exists(esyLinkPath)) {
+    let sourcePath = await fsUtils.readFile(esyLinkPath, 'utf8');
+    sourcePath = sourcePath.trim();
+    packageJsonPath = path.join(sourcePath, 'package.json');
+  } else {
+    packageJsonPath = path.join(directory, 'package.json');
+  }
+
+  if (!(await fsUtils.exists(packageJsonPath))) {
+    return null;
+  }
+  const packageJson = await fsUtils.readJson(packageJsonPath);
+  const dependencies = {};
+
+  if (await fsUtils.exists(nodeModulesPath)) {
+    const items = await fsUtils.readdir(nodeModulesPath);
+    await Promise.all(
+      items.map(async name => {
+        const depDirectory = path.join(directory, 'node_modules', name);
+        const dep = await crawl(depDirectory);
+        if (dep != null) {
+          dependencies[dep.name] = dep;
+        }
+      }),
+    );
+  }
+
+  return {
+    name: packageJson.name,
+    version: packageJson.version,
+    path: directory,
+    dependencies,
+  };
+}
+
+module.exports = {crawl};

--- a/test-e2e/test/helpers.js
+++ b/test-e2e/test/helpers.js
@@ -1,6 +1,6 @@
 // @flow
 
-jest.setTimeout(20000);
+jest.setTimeout(120000);
 
 import type {Fixture} from './FixtureUtils.js';
 const path = require('path');

--- a/test-e2e/test/helpers.js
+++ b/test-e2e/test/helpers.js
@@ -77,6 +77,15 @@ export type TestSandbox = {
     opam: string,
     url: ?string,
   }) => Promise<void>,
+  defineOpamPackageOfFixture: (
+    spec: {
+      name: string,
+      version: string,
+      opam: string,
+      url: ?string,
+    },
+    fixture: Fixture,
+  ) => Promise<void>,
 };
 
 async function createTestSandbox(...fixture: Fixture): Promise<TestSandbox> {
@@ -150,7 +159,9 @@ async function createTestSandbox(...fixture: Fixture): Promise<TestSandbox> {
       NpmRegistryMock.definePackageOfFixture(npmRegistry, fixture),
     defineNpmLocalPackage: (path, pkg) =>
       NpmRegistryMock.defineLocalPackage(npmRegistry, path, pkg),
-    defineOpamPackage: opam => OpamRegistryMock.defineOpamPackage(opamRegistry, opam),
+    defineOpamPackage: spec => OpamRegistryMock.defineOpamPackage(opamRegistry, spec),
+    defineOpamPackageOfFixture: (spec, fixture: Fixture) =>
+      OpamRegistryMock.defineOpamPackageOfFixture(opamRegistry, spec, fixture),
   };
 }
 

--- a/test-e2e/test/helpers.js
+++ b/test-e2e/test/helpers.js
@@ -176,6 +176,5 @@ module.exports = {
   exists: fs.exists,
   readdir: fs.readdir,
   execFile: exec.execFile,
-  genFixture: createTestSandbox,
   createTestSandbox,
 };

--- a/test-e2e/test/helpers.js
+++ b/test-e2e/test/helpers.js
@@ -119,6 +119,7 @@ async function createTestSandbox(...fixture: Fixture): Promise<TestSandbox> {
       env = {
         ...process.env,
         ESY__PREFIX: esyPrefixPath,
+        ESYI__CACHE: path.join(esyPrefixPath, 'esyi'),
         ESYI__OPAM_REPOSITORY: `:${opamRegistry.registryPath}`,
         ESYI__OPAM_OVERRIDE: `:${opamRegistry.overridePath}`,
         NPM_CONFIG_REGISTRY: npmRegistry.serverUrl,

--- a/test-e2e/test/helpers.js
+++ b/test-e2e/test/helpers.js
@@ -28,25 +28,18 @@ function getTempDir() {
 
 const exeExtension = isWindows ? '.exe' : '';
 
-let ocamlPackageCached = null;
-
 function ocamlPackage() {
-  if (ocamlPackageCached == null) {
-    let packageJson = {
-      type: 'file-copy',
-      name: 'package.json',
-      path: path.join(ocamlPackagePath, 'package.json'),
-    };
-    let ocamlopt = {
-      type: 'file-copy',
-      name: ocamloptName,
-      path: path.join(ocamlPackagePath, ocamloptName),
-    };
-    ocamlPackageCached = FixtureUtils.dir('ocaml', ocamlopt, packageJson);
-    return ocamlPackageCached;
-  } else {
-    return ocamlPackageCached;
-  }
+  let packageJson = {
+    type: 'file-copy',
+    name: 'package.json',
+    path: path.join(ocamlPackagePath, 'package.json'),
+  };
+  let ocamlopt = {
+    type: 'file-copy',
+    name: ocamloptName,
+    path: path.join(ocamlPackagePath, ocamloptName),
+  };
+  return FixtureUtils.dir('ocaml', ocamlopt, packageJson);
 }
 
 export type TestSandbox = {
@@ -75,8 +68,6 @@ export type TestSandbox = {
   ) => Promise<void>,
 };
 
-import {type PackageRegistry} from './NpmRegistryMock.js';
-
 async function createTestSandbox(...fixture: Fixture): Promise<TestSandbox> {
   // use /tmp on unix b/c sometimes it's too long to host the esy store
   const tmp = isWindows ? os.tmpdir() : '/tmp';
@@ -92,7 +83,7 @@ async function createTestSandbox(...fixture: Fixture): Promise<TestSandbox> {
   await fs.symlink(ESYCOMMAND, path.join(binPath, 'esy'));
 
   await Promise.all(fixture.map(item => FixtureUtils.initialize(projectPath, item)));
-  const npmRegistry: PackageRegistry = await NpmRegistryMock.initialize();
+  const npmRegistry = await NpmRegistryMock.initialize();
 
   async function runJavaScriptInNodeAndReturnJson(script) {
     const command = `node -p "JSON.stringify(${script.replace(/"/g, '\\"')})"`;


### PR DESCRIPTION
More improvements to tests:
- Same setup for install tests and other tests
- Test-local npm and opam registries:
   ```
   let p = await createTestSanbdox(fixture)
   // define simple npm package, just package.json
   await p.defineNpmPackage(...)
   // define npm package with contents specified by a fixture
   await p.defineNpmPackageOfFixture(...)
   // define simple opam package with just metadata, no sources
   await p.defineOpamPackage(...)
   // define opam package with contents specified by a fixture
   await p.defineOpamPackageOfFixture(...)
   ... 
   ```
- Add complete e2e tests for opam sandboxes (install and build, with deps).