### PR TITLE
Windows: Upgrade to 'esy-bash@0.1.21'

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,13 +12,11 @@ install:
 # once we have an `esy` build published for Windows that supports a minimal set of primitives
 # to support our current build system.
     - git submodule update --init --recursive
-    - npm install esy-bash
-    - npm install esy-ocaml/FastReplaceString.git#9450b6
+    - powershell scripts/bootstrap/install-npm-dependencies.ps1
     - node scripts/bootstrap/copy-fastreplacestring.js
     - appveyor-retry yarn run bootstrap:esy-install
     - npm run bootstrap:install-opam
     - npm run bootstrap:install-dependencies
-    - powershell scripts/bootstrap/install-npm-dependencies.ps1
 
 build_script:
 # Reset %PATH% to avoid cygwin DLL conflicts with cause

--- a/scripts/bootstrap/install-npm-dependencies.ps1
+++ b/scripts/bootstrap/install-npm-dependencies.ps1
@@ -10,6 +10,9 @@ function exitIfFailed() {
     }
 }
 
+npm install esy-bash@0.1.19
+npm install esy-ocaml/FastReplaceString.git#9450b6
+
 npm install babel-preset-env
 npm install babel-preset-flow
 npm install del

--- a/scripts/bootstrap/install-npm-dependencies.ps1
+++ b/scripts/bootstrap/install-npm-dependencies.ps1
@@ -10,9 +10,6 @@ function exitIfFailed() {
     }
 }
 
-npm install esy-bash@0.1.19
-npm install esy-ocaml/FastReplaceString.git#9450b6
-
 npm install babel-preset-env
 npm install babel-preset-flow
 npm install del
@@ -29,5 +26,11 @@ npm install tar-fs
 npm install tmp
 npm install outdent
 npm install rimraf
+
+# If updating the version for this,
+# make sure to also update it in `scripts/release-postinstall.js`, too!
+npm install esy-bash@0.1.21
+
+npm install esy-ocaml/FastReplaceString.git#9450b6
 
 exitIfFailed

--- a/scripts/release-postinstall.js
+++ b/scripts/release-postinstall.js
@@ -60,7 +60,7 @@ switch (platform) {
     copyPlatformBinaries('windows-x64');
 
     console.log('Installing cygwin sandbox...');
-    cp.execSync('npm install esy-bash');
+    cp.execSync('npm install esy-bash@0.1.19');
     console.log('Cygwin installed successfully.');
     break;
   case 'linux':

--- a/scripts/release-postinstall.js
+++ b/scripts/release-postinstall.js
@@ -60,7 +60,7 @@ switch (platform) {
     copyPlatformBinaries('windows-x64');
 
     console.log('Installing cygwin sandbox...');
-    cp.execSync('npm install esy-bash@0.1.19');
+    cp.execSync('npm install esy-bash@0.1.21');
     console.log('Cygwin installed successfully.');
     break;
   case 'linux':


### PR DESCRIPTION
- Use a specific version of `esy-bash` (to ensure that the version download on `postinstall` is what we expect)
- Move `esy-bash`/`fastreplacestring` from `appveyor.yml` -> `install-npm-dependencies.ps1

This picks up a small bug fix in `esy-bash` to unblock #321