### PR TITLE
Windows: Release package fixes

### DIFF
--- a/scripts/bootstrap/make-release-package.js
+++ b/scripts/bootstrap/make-release-package.js
@@ -30,13 +30,15 @@ const pack = async () => {
     // cygwin as port of a postinstall step (since `esy-bash` is called out as a dependency,
     // this should happen automatically).
     console.log("Deleting cygwin from release folder...")
-    await bashExec(`rm -rf ${packFolder}/node_modules/esy-bash`)
-
-    console.log("Creating folder...")
-    await bashExec(`mkdir ${destFolder}`)
 
     const cygwinDestFolder = await toCygwinPath(destFolder)
     const cygwinPackFolder = await toCygwinPath(packFolder)
+
+    console.log(`- Deleting: ${cygwinPackFolder}/node_modules/esy-bash`)
+    await bashExec(`rm -rf ${cygwinPackFolder}/node_modules/esy-bash`)
+
+    console.log(`Creating folder: ${cygwinDestFolder}`)
+    await bashExec(`mkdir ${cygwinDestFolder}`)
 
     console.log(`Creating archive from ${cygwinPackFolder} in ${cygwinDestFolder}.`)
     await bashExec(`tar -czvf ${cygwinDestFolder}/esy-v${version}-windows-${arch}.tgz -C ${cygwinPackFolder} .`)

--- a/scripts/bootstrap/make-release-package.js
+++ b/scripts/bootstrap/make-release-package.js
@@ -23,6 +23,14 @@ const getArch = () => {
 
 const arch = getArch();
 
+const bashExecAndThrow = async (command) => {
+    const code = await bashExec(command)
+
+    if (code !== 0) {
+        throw new Error(`Command: ${command} failed with exit code ${code}`)
+    }
+}
+
 const pack = async () => {
     // If we pack cygwin + all the installed dependencies, the archive by itself
     // is around 338 MB! If we pack that for both x86 + x64, we'll end up with almost 750 MB.
@@ -35,13 +43,13 @@ const pack = async () => {
     const cygwinPackFolder = await toCygwinPath(packFolder)
 
     console.log(`- Deleting: ${cygwinPackFolder}/node_modules/esy-bash`)
-    await bashExec(`rm -rf ${cygwinPackFolder}/node_modules/esy-bash`)
+    await bashExecAndThrow(`rm -rf ${cygwinPackFolder}/node_modules/esy-bash`)
 
     console.log(`Creating folder: ${cygwinDestFolder}`)
-    await bashExec(`mkdir ${cygwinDestFolder}`)
+    await bashExecAndThrow(`mkdir ${cygwinDestFolder}`)
 
     console.log(`Creating archive from ${cygwinPackFolder} in ${cygwinDestFolder}.`)
-    await bashExec(`tar -czvf ${cygwinDestFolder}/esy-v${version}-windows-${arch}.tgz -C ${cygwinPackFolder} .`)
+    await bashExecAndThrow(`tar -czvf ${cygwinDestFolder}/esy-v${version}-windows-${arch}.tgz -C ${cygwinPackFolder} .`)
 }
 
 pack()


### PR DESCRIPTION
Latest builds are showing errors putting together the windows release package:

```
npm run bootstrap:make-release-package
> esy@0.2.5 bootstrap:make-release-package C:\projects\esy
> node ./scripts/bootstrap/make-release-package.js
Deleting cygwin from release folder...
Creating folder...
Creating archive from /cygdrive/c/projects/esy/_release in /cygdrive/c/projects/esy/_platformrelease.
tar (child): /cygdrive/c/projects/esy/_platformrelease/esy-v0.2.5-windows-x64.tgz: Cannot open: No such file or directory
tar (child): Error is not recoverable: exiting now
./
./bin/
./bin/esy-install.js
tar: /cygdrive/c/projects/esy/_platformrelease/esy-v0.2.5-windows-x64.tgz: Cannot write: Broken pipe
tar: Child returned status 2
tar: Error is not recoverable: exiting now
Collecting artifacts...
No artifacts found matching '_platformrelease\*.tgz' path
Build success
```

I believe this might be due to a conflict with the pathing in the `mkdir` step - I'm adding some additional logging + using the normalized cygdrive path.