### PR TITLE
Windows: Fix extraneous symlink error + enable affected tests

### DIFF
--- a/esy-build-package/Build.re
+++ b/esy-build-package/Build.re
@@ -314,7 +314,7 @@ module Installer =
 
 let install = (~prefixPath, ~rootPath, ~installFilename=?, ()) => {
   Logs.app(m =>
-    m("# esy-build-package: installing using built-in installer")
+    m("# esy-build-package: installing using built-in installer2")
   );
   let res = Installer.run(~prefixPath, ~rootPath, installFilename);
   Run.coerceFromClosed(res);
@@ -389,7 +389,7 @@ let commitBuildToStore = (config: Config.t, build: build) => {
     | None => ok
     };
   };
-  let relocate = (path: Path.t, stats: Unix.stats) =>
+  let relocate = (path: Path.t, stats: Unix.stats) => {
     switch (stats.st_kind) {
     | Unix.S_REG =>
       rewritePrefixesInFile(
@@ -405,6 +405,7 @@ let commitBuildToStore = (config: Config.t, build: build) => {
       )
     | _ => Ok()
     };
+};
   let%bind () =
     write(
       ~data=Path.to_string(config.storePath),

--- a/esy-build-package/Run.re
+++ b/esy-build-package/Run.re
@@ -1,5 +1,6 @@
 module Result = EsyLib.Result;
 module Path = EsyLib.Path;
+module System = EsyLib.System;
 
 type err('b) =
   [> | `Msg(string) | `CommandError(Cmd.t, Bos.OS.Cmd.status)] as 'b;
@@ -36,7 +37,30 @@ let rm = path => Bos.OS.Path.delete(~must_exist=false, ~recurse=true, path);
 let stat = Bos.OS.Path.stat;
 let lstat = Bos.OS.Path.symlink_stat;
 let link = Bos.OS.Path.link;
-let symlink = Bos.OS.Path.symlink;
+let symlink = (~force=?, ~target, dest) => {
+    let result = Bos.OS.Path.symlink(~force=?force, ~target, dest);
+    /**
+     * Windows sometimes reports a failure result even on success.
+     * May be related to: https://github.com/dbuenzli/bos/issues/41
+     */
+    switch (System.Platform.host) {
+    | Windows =>
+        let errorRegex = Str.regexp(".*?The operation completed successfully.*?");
+        switch (result) {
+            | Ok(_) => result
+            | Error(`Msg(msg)) => 
+                let r = Str.string_match(errorRegex, msg, 0);
+                /* If the error message is "The operation completed successfully", we'll ignore. */
+                if (r) {
+                    ok;
+                } else {
+                    result;
+                }
+            | _ => result
+        };
+    | _ => result
+    };
+};
 let readlink = Bos.OS.Path.symlink_target;
 
 let write = (~perm=?, ~data, path) =>
@@ -57,11 +81,12 @@ let rec realpath = (p: Fpath.t) => {
       Ok(p |> Fpath.append(cwd) |> Fpath.normalize);
     };
   let _realpath = (p: Fpath.t) => {
-    let isSymlinkAndExists = p =>
+    let isSymlinkAndExists = p => {
       switch (Bos.OS.Path.symlink_stat(p)) {
       | Ok({Unix.st_kind: Unix.S_LNK, _}) => Ok(true)
       | _ => Ok(false)
       };
+    };
     if (Fpath.is_root(p)) {
       Ok(p);
     } else {

--- a/test-e2e/build/augment-path.test.js
+++ b/test-e2e/build/augment-path.test.js
@@ -8,10 +8,7 @@ const {
   dir,
   file,
   ocamlPackage,
-  skipSuiteOnWindows,
 } = require('../test/helpers');
-
-skipSuiteOnWindows();
 
 const fixture = [
   packageJson({

--- a/test-e2e/build/custom-prefix.test.js
+++ b/test-e2e/build/custom-prefix.test.js
@@ -11,10 +11,7 @@ const {
   packageJson,
   file,
   exeExtension,
-  skipSuiteOnWindows,
 } = require('../test/helpers');
-
-skipSuiteOnWindows();
 
 const fixture = [
   packageJson({

--- a/test-e2e/build/has-build-time-deps.test.js
+++ b/test-e2e/build/has-build-time-deps.test.js
@@ -10,10 +10,7 @@ const {
   dir,
   file,
   ocamlPackage,
-  skipSuiteOnWindows,
 } = require('../test/helpers');
-
-skipSuiteOnWindows();
 
 const fixture = [
   packageJson({

--- a/test-e2e/build/no-deps-backslash.test.js
+++ b/test-e2e/build/no-deps-backslash.test.js
@@ -1,5 +1,6 @@
 // @flow
 
+const os = require('os');
 const path = require('path');
 const outdent = require('outdent');
 const {
@@ -9,10 +10,7 @@ const {
   file,
   packageJson,
   exeExtension,
-  skipSuiteOnWindows,
 } = require('../test/helpers');
-
-skipSuiteOnWindows();
 
 const fixture = [
   packageJson({
@@ -50,5 +48,5 @@ it('Build - no deps backslash', async () => {
   await p.esy('build');
 
   const {stdout} = await p.esy('x no-deps-backslash');
-  expect(stdout).toEqual('\\ no-deps-backslash \\\n');
+  expect(stdout).toEqual('\\ no-deps-backslash \\' + os.EOL);
 });

--- a/test-e2e/build/no-deps.test.js
+++ b/test-e2e/build/no-deps.test.js
@@ -10,10 +10,7 @@ const {
   file,
   packageJson,
   exeExtension,
-  skipSuiteOnWindows,
 } = require('../test/helpers');
-
-skipSuiteOnWindows();
 
 const fixture = [
   packageJson({

--- a/test-e2e/build/sandbox-stress-_build.test.js
+++ b/test-e2e/build/sandbox-stress-_build.test.js
@@ -1,9 +1,7 @@
 // @flow
 
 const path = require('path');
-const {createTestSandbox, packageJson, skipSuiteOnWindows} = require('../test/helpers');
-
-skipSuiteOnWindows();
+const {createTestSandbox, packageJson} = require('../test/helpers');
 
 const fixture = [
   packageJson({

--- a/test-e2e/build/sandbox-stress.test.js
+++ b/test-e2e/build/sandbox-stress.test.js
@@ -1,9 +1,7 @@
 // @flow
 
 const path = require('path');
-const {createTestSandbox, packageJson, skipSuiteOnWindows} = require('../test/helpers');
-
-skipSuiteOnWindows();
+const {createTestSandbox, packageJson} = require('../test/helpers');
 
 const fixture = [
   packageJson({

--- a/test-e2e/build/with-dep-_build.test.js
+++ b/test-e2e/build/with-dep-_build.test.js
@@ -8,10 +8,7 @@ const {
   file,
   ocamlPackage,
   exeExtension,
-  skipSuiteOnWindows,
 } = require('../test/helpers');
-
-skipSuiteOnWindows();
 
 const fixture = [
   packageJson({

--- a/test-e2e/build/with-dep-in-source.test.js
+++ b/test-e2e/build/with-dep-in-source.test.js
@@ -9,10 +9,7 @@ const {
   file,
   ocamlPackage,
   exeExtension,
-  skipSuiteOnWindows,
 } = require('../test/helpers');
-
-skipSuiteOnWindows();
 
 const fixture = [
   packageJson({

--- a/test-e2e/build/with-dep.test.js
+++ b/test-e2e/build/with-dep.test.js
@@ -7,10 +7,7 @@ const {
   dir,
   file,
   ocamlPackage,
-  skipSuiteOnWindows,
 } = require('../test/helpers');
-
-skipSuiteOnWindows();
 
 const fixture = [
   packageJson({

--- a/test-e2e/build/with-dev-dep.test.js
+++ b/test-e2e/build/with-dev-dep.test.js
@@ -8,10 +8,7 @@ const {
   file,
   ocamlPackage,
   exeExtension,
-  skipSuiteOnWindows,
 } = require('../test/helpers');
-
-skipSuiteOnWindows();
 
 const fixture = [
   packageJson({

--- a/test-e2e/build/with-linked-dep-_build.test.js
+++ b/test-e2e/build/with-linked-dep-_build.test.js
@@ -11,10 +11,7 @@ const {
   symlink,
   ocamlPackage,
   exeExtension,
-  skipSuiteOnWindows,
 } = require('../test/helpers');
-
-skipSuiteOnWindows();
 
 const fixture = [
   packageJson({

--- a/test-e2e/build/with-linked-dep-in-source.test.js
+++ b/test-e2e/build/with-linked-dep-in-source.test.js
@@ -10,10 +10,7 @@ const {
   dir,
   symlink,
   ocamlPackage,
-  skipSuiteOnWindows,
 } = require('../test/helpers');
-
-skipSuiteOnWindows();
 
 const fixture = [
   packageJson({

--- a/test-e2e/build/with-linked-dep-sandbox-env.test.js
+++ b/test-e2e/build/with-linked-dep-sandbox-env.test.js
@@ -11,10 +11,7 @@ const {
   symlink,
   file,
   dir,
-  skipSuiteOnWindows,
 } = require('../test/helpers');
-
-skipSuiteOnWindows();
 
 const fixture = [
   packageJson({

--- a/test-e2e/build/with-linked-dep.test.js
+++ b/test-e2e/build/with-linked-dep.test.js
@@ -14,10 +14,7 @@ const {
   symlink,
   ocamlPackage,
   exeExtension,
-  skipSuiteOnWindows,
 } = require('../test/helpers');
-
-skipSuiteOnWindows();
 
 const fixture = [
   packageJson({


### PR DESCRIPTION
__Issue:__ Several of our `build` tests were hitting an error of the form:
```
esy-build-package: symlink
                   C:\Users\bryph\AppData\Local\Temp\XXXXaNagzr\project\node_modules\.cache\_esy\store\b\no_deps-1.0.0-8c176443
                   to
                   C:\Users\bryph\AppData\Local\Temp\XXXXaNagzr\project\_build:
                   The operation completed successfully.

esy: error, exiting...
     build failed
       Building no-deps@1.0.0
```

It's bizarre that we see _the operation completed successfully_, and the symlink is created correctly (the command runs).  Based on dbuenzli/bos#41, it seems like there may be some quirks with the symlink command on Windows.

__Fix:__ This proposed fix special-cases this, and on Windows, we check if the error contains "The operation completed successfully", and if so, ignore it. There may be a more robust way to check this condition... let me know if you have any ideas!

__Test Impact:__ This was a blocking issue for several of our `build` tests, so with this change, I'm able to enable those on Windows.