### PR TITLE
AppVeyor: Cache .esytest folder

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,7 @@ platform:
 
 cache:
     - C:\Users\appveyor\.opam -> **\dune
+    - C:\Users\appveyor\.esytest
 
 install:
     - where git


### PR DESCRIPTION
__Issue:__ AppVeyor build is taking a long time to complete - >40 minutes.

__Defect:__ One bottleneck is that we rebuild the OCaml compiler every time for our `test-e2e` - building the compiler takes a long time on Windows. On the build machine, it takes about ~12 minutes:

```
[00:28:02] Mode                LastWriteTime         Length Name                          
[00:28:02] ----                -------------         ------ ----                          
[00:28:02] d-----         8/2/2018   3:40 PM                esy-home                      
[00:28:03] 
[00:28:03] > esy@0.2.5 test-e2e C:\projects\esy
[00:28:03] > jest --runInBand test-e2e
[00:28:03] 
[00:40:11] PASS e2e:fast test-e2e/install/basic-npm.test.j
```
(That 12 minute gap is mostly building the OCaml compiler)

__Fix:__ Cache the compiled compiler