### PR TITLE
Clean esy manifest/package/task types

### DIFF
--- a/esy-command-expression/Lexer.mll
+++ b/esy-command-expression/Lexer.mll
@@ -16,7 +16,6 @@ let id              = ['a'-'z' 'A'-'Z' '_'] ['a'-'z' 'A'-'Z' '0'-'9' '_' '-']*
 
 rule read tokens = parse
  | '#' '{'       { expr tokens lexbuf }
- | '%' '{'       { expr (OPAM_OPEN::tokens) lexbuf }
  | '\\' '"'      { uquote tokens (buf_from_str "\"") lexbuf }
  | '\\' '''      { uquote tokens (buf_from_str "'") lexbuf }
  | '\\' '\\'     { uquote tokens (buf_from_str "\\") lexbuf }
@@ -46,7 +45,6 @@ and expr tokens = parse
    }
  | '''          { literal tokens (Buffer.create 16) lexbuf }
  | '}'          { read tokens lexbuf }
- | '}' '%'      { read (OPAM_CLOSE::tokens) lexbuf }
  | _ as c       {
      let msg = Printf.sprintf "unexpected token '%c' found" c in
      raise (Error (lexbuf.lex_curr_p, msg))

--- a/esy-command-expression/Lexer.mll
+++ b/esy-command-expression/Lexer.mll
@@ -34,7 +34,6 @@ and expr tokens = parse
  | ')'          { expr (PAREN_RIGHT::tokens) lexbuf }
  | '$'          { expr (DOLLAR::tokens) lexbuf }
  | ':'          { expr (COLON::tokens) lexbuf }
- | '+'          { expr (PLUS::tokens) lexbuf }
  | '.'          { expr (DOT::tokens) lexbuf }
  | '@'          { expr (AT::tokens) lexbuf }
  | '?'          { expr (QUESTION_MARK::tokens) lexbuf }
@@ -62,10 +61,6 @@ and uquote tokens buf = parse
  | '#' '{'     {
      let tok = STRING (Buffer.contents buf) in
      expr (tok::tokens) lexbuf
-   }
- | '%' '{'     {
-     let tok = STRING (Buffer.contents buf) in
-     expr (OPAM_OPEN::tok::tokens) lexbuf
    }
  | '\\' '"'    { Buffer.add_string buf "\""; uquote tokens buf lexbuf }
  | '\\' '''    { Buffer.add_string buf "'"; uquote tokens buf lexbuf }

--- a/esy-command-expression/Parser.mly
+++ b/esy-command-expression/Parser.mly
@@ -1,7 +1,6 @@
 %token <string> STRING
 %token <string> ID
 %token OPAM_OPEN
-%token OPAM_CLOSE
 %token QUESTION_MARK
 %token COLON
 %token DOT
@@ -58,7 +57,6 @@ exprList:
 
 atom:
     PAREN_LEFT; e = atom; PAREN_RIGHT { e }
-  | OPAM_OPEN; e = opam_id; OPAM_CLOSE { E.OpamVar e }
   | e = atomString { e }
   | e = atomId { e }
   | e = atomEnv { e }
@@ -103,13 +101,6 @@ id:
 id_namespace:
     n = ID { n }
   | AT; s = ID; SLASH; n = ID { ("@" ^ s ^ "/" ^ n) }
-
-opam_id:
-    id = ID { ([], id) }
-  | scope = opam_id_scope; COLON; id = ID { (scope, id) }
-
-opam_id_scope:
-  e = separated_nonempty_list(PLUS, ID) { e }
 
 %%
 

--- a/esy-command-expression/Parser.mly
+++ b/esy-command-expression/Parser.mly
@@ -1,6 +1,5 @@
 %token <string> STRING
 %token <string> ID
-%token OPAM_OPEN
 %token QUESTION_MARK
 %token COLON
 %token DOT
@@ -12,7 +11,6 @@
 %token EQ
 %token NEQ
 %token NOT
-%token PLUS
 %token PAREN_LEFT
 %token PAREN_RIGHT
 %token EOF

--- a/esy-command-expression/Types.ml
+++ b/esy-command-expression/Types.ml
@@ -14,7 +14,6 @@ module Expr = struct
     | Rel of relop * t * t
     | Colon
     | PathSep
-    | OpamVar of opamVar
     [@@deriving (show, eq, ord)]
 
   and opamVar = string list * string

--- a/esy/Build.ml
+++ b/esy/Build.ml
@@ -135,7 +135,7 @@ let buildAll
     =
   let queue = LwtTaskQueue.create ~concurrency () in
   let f = runTask ?force ?buildOnly ~queue cfg rootTask in
-  Task.DependencyGraph.foldWithAllDependencies ~f rootTask
+  Task.Graph.foldWithAllDependencies ~f rootTask
 
 (**
  * Build only dependencies of the task but not the task itself.
@@ -156,4 +156,4 @@ let buildDependencies
       return ()
     ) else runTask ?force ?buildOnly ~allDependencies ~dependencies ~queue cfg rootTask task
   in
-  Task.DependencyGraph.foldWithAllDependencies ~f rootTask
+  Task.Graph.foldWithAllDependencies ~f rootTask

--- a/esy/Environment.ml
+++ b/esy/Environment.ml
@@ -3,7 +3,8 @@ type t = binding list [@@deriving (show, eq, ord)]
 and binding = {
   name : string;
   value : bindingValue;
-  origin : Package.t option;
+  origin : Package.t option
+    [@printer fun fmt origin -> Fmt.(option string) fmt (Option.map ~f:(fun o -> o.Package.id) origin)];
 } [@@deriving (show, eq, ord)]
 
 (* TODO: Expand this variant to include

--- a/esy/Manifest.ml
+++ b/esy/Manifest.ml
@@ -50,6 +50,7 @@ end
 
 module Scripts = struct
 
+  [@@@ocaml.warning "-32"]
   type script = {
     command : CommandList.Command.t;
   }
@@ -111,6 +112,7 @@ end
  *)
 module Env = struct
 
+  [@@@ocaml.warning "-32"]
   type item = {
     name : string;
     value : string;
@@ -141,6 +143,7 @@ end
  *)
 module ExportedEnv = struct
 
+  [@@@ocaml.warning "-32"]
   type scope =
     | Local
     | Global
@@ -160,6 +163,7 @@ module ExportedEnv = struct
     [@@deriving of_yojson]
   end
 
+  [@@@ocaml.warning "-32"]
   type item = {
     name : string;
     value : string;

--- a/esy/Manifest.ml
+++ b/esy/Manifest.ml
@@ -1,3 +1,15 @@
+module BuildType = struct
+  include EsyBuildPackage.BuildType
+
+  let of_yojson = function
+    | `String "_build" -> Ok JbuilderLike
+    | `Bool true -> Ok InSource
+    | `Bool false -> Ok OutOfSource
+    | _ -> Error "expected false, true or \"_build\""
+end
+
+module SourceType = EsyBuildPackage.SourceType
+
 module CommandList = struct
 
   module Command = struct
@@ -48,6 +60,120 @@ module CommandList = struct
     | None -> `List []
     | Some commands -> `List (List.map ~f:Command.to_yojson commands)
 
+end
+
+module ExportedEnv = struct
+
+  [@@@ocaml.warning "-32"]
+  type scope =
+    | Local
+    | Global
+    [@@deriving (show, eq, ord)]
+
+  let scope_of_yojson = function
+    | `String "global" -> Ok Global
+    | `String "local" -> Ok Local
+    | _ -> Error "expected either \"local\" or \"global\""
+
+  module Item = struct
+    type t = {
+      value : string [@key "val"];
+      scope : (scope [@default Local]);
+      exclusive : (bool [@default false]);
+    }
+    [@@deriving of_yojson]
+  end
+
+  [@@@ocaml.warning "-32"]
+  type item = {
+    name : string;
+    value : string;
+    scope : scope;
+    exclusive : bool;
+  }
+  [@@deriving (show, eq, ord)]
+
+  type t =
+    item list
+    [@@deriving (show, eq, ord)]
+
+  let empty = []
+
+  let of_yojson = function
+    | `Assoc items ->
+      let open Result.Syntax in
+      let f items (k, v) =
+        let%bind {Item. value; scope; exclusive} = Item.of_yojson v in
+        Ok ({name = k; value; scope; exclusive}::items)
+      in
+      let%bind items = Result.List.foldLeft ~f ~init:[] items in
+      Ok (List.rev items)
+    | _ -> Error "expected an object"
+
+end
+
+module Env = struct
+
+  [@@@ocaml.warning "-32"]
+  type item = {
+    name : string;
+    value : string;
+  }
+  [@@deriving (show, eq, ord)]
+
+  type t =
+    item list
+    [@@deriving (show, eq, ord)]
+
+  let empty = []
+
+  let of_yojson = function
+    | `Assoc items ->
+      let open Result.Syntax in
+      let f items ((k, v): (string * Yojson.Safe.json)) = match v with
+      | `String value ->
+        Ok ({name = k; value;}::items)
+      | _ -> Error "expected string"
+      in
+      let%bind items = Result.List.foldLeft ~f ~init:[] items in
+      Ok (List.rev items)
+    | _ -> Error "expected an object"
+end
+
+module Build = struct
+
+  type commands =
+    | OpamCommands of OpamTypes.command list
+    | EsyCommands of CommandList.t
+
+  type t = {
+    sourceType : SourceType.t;
+    buildType : BuildType.t;
+    buildCommands : commands;
+    installCommands : commands;
+    patches : (Path.t * OpamTypes.filter option) list;
+    substs : Path.t list;
+    exportedEnv : ExportedEnv.t;
+    sandboxEnv : Env.t;
+    buildEnv : Env.t;
+  }
+
+end
+
+module Dependencies = struct
+  type t = {
+    dependencies : string list list;
+    devDependencies : string list list;
+    buildTimeDependencies : string list list;
+    optDependencies : string list list;
+  }
+end
+
+module Release = struct
+  type t = {
+    releasedBinaries: string list;
+    deleteFromBinaryRelease: (string list [@default []]);
+  } [@@deriving (of_yojson { strict = false })]
 end
 
 module Scripts = struct
@@ -109,177 +235,174 @@ module Scripts = struct
     )
 end
 
-(**
- * Environment for the entire sandbox as specified in "esy.sandboxEnv".
- *)
-module Env = struct
+module type MANIFEST = sig
+  type t
 
-  [@@@ocaml.warning "-32"]
-  type item = {
-    name : string;
-    value : string;
-  }
-  [@@deriving (show, eq, ord)]
+  (** Name. *)
+  val name : t -> string
 
-  type t =
-    item list
-    [@@deriving (show, eq, ord)]
+  (** Version. *)
+  val version : t -> string
 
-  let empty = []
+  (** License. *)
+  val license : t -> Json.t option
 
-  let of_yojson = function
-    | `Assoc items ->
-      let open Result.Syntax in
-      let f items ((k, v): (string * Yojson.Safe.json)) = match v with
-      | `String value ->
-        Ok ({name = k; value;}::items)
-      | _ -> Error "expected string"
-      in
-      let%bind items = Result.List.foldLeft ~f ~init:[] items in
-      Ok (List.rev items)
-    | _ -> Error "expected an object"
+  (** Description. *)
+  val description : t -> string option
+
+  (**
+  * Extract dependency info.
+  *)
+  val dependencies : t -> Dependencies.t
+
+  (**
+  * Extract build config from manifest
+  *
+  * Not all packages have build config defined so we return `None` in this case.
+  *)
+  val build : t -> Build.t option
+
+  (**
+  * Extract release config from manifest
+  *
+  * Not all packages have release config defined so we return `None` in this
+  * case.
+  *)
+  val release : t -> Release.t option
+
+  (**
+  * Unique id of the release.
+  *
+  * This could be a released version, git sha commit or some checksum of package
+  * contents if any.
+  *
+  * This info is used to construct a build key for the corresponding package.
+  *)
+  val uniqueDistributionId : t -> string option
 end
 
-(**
- * Environment exported from a package as specified in "esy.exportedEnv".
- *)
-module ExportedEnv = struct
+module PackageJsonDependencies = struct
+  type t = string StringMap.t
 
-  [@@@ocaml.warning "-32"]
-  type scope =
-    | Local
-    | Global
-    [@@deriving (show, eq, ord)]
+  let empty = StringMap.empty
+  let keys = StringMap.keys
 
-  let scope_of_yojson = function
-    | `String "global" -> Ok Global
-    | `String "local" -> Ok Local
-    | _ -> Error "expected either \"local\" or \"global\""
+  let of_yojson =
+    Json.Parse.(stringMap string)
 
-  module Item = struct
+end
+
+module Esy : sig
+  include MANIFEST
+
+  val ofDir : Path.t -> (t * Path.Set.t) option RunAsync.t
+  val findOfDir : Path.t -> Path.t option RunAsync.t
+end = struct
+
+  module EsyManifest = struct
+
     type t = {
-      value : string [@key "val"];
-      scope : (scope [@default Local]);
-      exclusive : (bool [@default false]);
-    }
-    [@@deriving of_yojson]
-  end
-
-  [@@@ocaml.warning "-32"]
-  type item = {
-    name : string;
-    value : string;
-    scope : scope;
-    exclusive : bool;
-  }
-  [@@deriving (show, eq, ord)]
-
-  type t =
-    item list
-    [@@deriving (show, eq, ord)]
-
-  let empty = []
-
-  let of_yojson = function
-    | `Assoc items ->
-      let open Result.Syntax in
-      let f items (k, v) =
-        let%bind {Item. value; scope; exclusive} = Item.of_yojson v in
-        Ok ({name = k; value; scope; exclusive}::items)
-      in
-      let%bind items = Result.List.foldLeft ~f ~init:[] items in
-      Ok (List.rev items)
-    | _ -> Error "expected an object"
-
-end
-
-module BuildType = struct
-  include EsyBuildPackage.BuildType
-
-  let of_yojson = function
-    | `String "_build" -> Ok JbuilderLike
-    | `Bool true -> Ok InSource
-    | `Bool false -> Ok OutOfSource
-    | _ -> Error "expected false, true or \"_build\""
-end
-
-module SourceType = EsyBuildPackage.SourceType
-
-module Release = struct
-  type t = {
-    releasedBinaries: string list;
-    deleteFromBinaryRelease: (string list [@default []]);
-  } [@@deriving (of_yojson { strict = false })]
-end
-
-module EsyManifest = struct
-
-  type t = {
-    build: (CommandList.t [@default CommandList.empty]);
-    install: (CommandList.t [@default CommandList.empty]);
-    buildsInSource: (BuildType.t [@default BuildType.OutOfSource]);
-    exportedEnv: (ExportedEnv.t [@default []]);
-    buildEnv: (Env.t [@default Env.empty]);
-    sandboxEnv: (Env.t [@default Env.empty]);
-    release: (Release.t option [@default None]);
-  } [@@deriving (of_yojson { strict = false })]
-
-end
-
-module Esy = struct
-
-  module Dependencies = struct
-    type t = string StringMap.t
-
-    let empty = StringMap.empty
-    let keys = StringMap.keys
-
-    let of_yojson =
-      Json.Parse.(stringMap string)
+      build: (CommandList.t [@default CommandList.empty]);
+      install: (CommandList.t [@default CommandList.empty]);
+      buildsInSource: (BuildType.t [@default BuildType.OutOfSource]);
+      exportedEnv: (ExportedEnv.t [@default []]);
+      buildEnv: (Env.t [@default Env.empty]);
+      sandboxEnv: (Env.t [@default Env.empty]);
+      release: (Release.t option [@default None]);
+    } [@@deriving (of_yojson { strict = false })]
 
   end
 
-  type t = {
+  type t = manifest * Json.t
+
+  and manifest = {
     name : string;
     version : string;
     description : (string option [@default None]);
     license : (Json.t option [@default None]);
-    dependencies : (Dependencies.t [@default Dependencies.empty]);
-    peerDependencies : (Dependencies.t [@default Dependencies.empty]);
-    devDependencies : (Dependencies.t [@default Dependencies.empty]);
-    optDependencies : (Dependencies.t [@default Dependencies.empty]);
-    buildTimeDependencies : (Dependencies.t [@default Dependencies.empty]);
+    dependencies : (PackageJsonDependencies.t [@default PackageJsonDependencies.empty]);
+    peerDependencies : (PackageJsonDependencies.t [@default PackageJsonDependencies.empty]);
+    devDependencies : (PackageJsonDependencies.t [@default PackageJsonDependencies.empty]);
+    optDependencies : (PackageJsonDependencies.t [@default PackageJsonDependencies.empty]);
+    buildTimeDependencies : (PackageJsonDependencies.t [@default PackageJsonDependencies.empty]);
     esy: EsyManifest.t option [@default None];
     _resolved: (string option [@default None]);
   } [@@deriving (of_yojson {strict = false})]
 
-  let dependencies manifest =
+  let name (manifest, _) = manifest.name
+  let version (manifest, _) = manifest.version
+  let description (manifest, _) = manifest.description
+  let license (manifest, _) = manifest.license
+  let _resolved (manifest, _) = manifest._resolved
+
+  let dependencies (manifest, _) =
     let dependencies =
-      manifest.dependencies
-      |> Dependencies.keys
+      let dependencies =
+        manifest.dependencies
+        |> PackageJsonDependencies.keys
+        |> List.map ~f:(fun name -> [name])
+      in
+      let peerDependencies =
+        manifest.peerDependencies
+        |> PackageJsonDependencies.keys
+        |> List.map ~f:(fun name -> [name])
+      in
+      dependencies @ peerDependencies
+    in
+
+    let devDependencies =
+      manifest.devDependencies
+      |> PackageJsonDependencies.keys
       |> List.map ~f:(fun name -> [name])
     in
-    let peerDependencies =
-      manifest.peerDependencies
-      |> Dependencies.keys
+
+    let optDependencies =
+      manifest.optDependencies
+      |> PackageJsonDependencies.keys
       |> List.map ~f:(fun name -> [name])
     in
-    dependencies @ peerDependencies
 
-  let devDependencies manifest =
-    manifest.devDependencies
-    |> Dependencies.keys
-    |> List.map ~f:(fun name -> [name])
+    let buildTimeDependencies =
+      manifest.buildTimeDependencies
+      |> PackageJsonDependencies.keys
+      |> List.map ~f:(fun name -> [name])
+    in
 
-  let optDependencies manifest =
-    manifest.optDependencies
-    |> Dependencies.keys
-    |> List.map ~f:(fun name -> [name])
+    {
+      Dependencies.
+      dependencies;
+      devDependencies;
+      optDependencies;
+      buildTimeDependencies
+    }
 
-  let buildTimeDependencies manifest =
-    manifest.buildTimeDependencies
-    |> Dependencies.keys
-    |> List.map ~f:(fun name -> [name])
+  let uniqueDistributionId (manifest, _) =
+    manifest._resolved
+
+  let release (m, _) =
+    let open Option.Syntax in
+    let%bind m = m.esy in
+    let%bind c = m.EsyManifest.release in
+    return c
+
+  let build (m, _) =
+    let open Option.Syntax in
+    let%bind esy = m.esy in
+    Some {
+      Build.
+      sourceType = (
+        match m._resolved with
+        | None -> SourceType.Transient
+        | Some _ -> SourceType.Immutable);
+      buildType = esy.EsyManifest.buildsInSource;
+      exportedEnv = esy.EsyManifest.exportedEnv;
+      buildEnv = esy.EsyManifest.buildEnv;
+      sandboxEnv = esy.EsyManifest.sandboxEnv;
+      buildCommands = EsyCommands (esy.EsyManifest.build);
+      installCommands = EsyCommands (esy.EsyManifest.install);
+      patches = [];
+      substs = [];
+    }
 
   let ofFile (path : Path.t) =
     let open RunAsync.Syntax in
@@ -291,7 +414,7 @@ module Esy = struct
     let filename = Path.(path / "esy.json") in
     if%bind Fs.exists filename
     then return (Some filename)
-    else 
+    else
       let filename = Path.(path / "package.json") in
       if%bind Fs.exists filename
       then return (Some filename)
@@ -312,7 +435,7 @@ module OpamOverride = struct
     build : (CommandList.t option [@default None]);
     install : (CommandList.t option [@default None]);
     exportedEnv : (ExportedEnv.t [@default ExportedEnv.empty]);
-    dependencies : (Esy.Dependencies.t [@default Esy.Dependencies.empty]);
+    dependencies : (PackageJsonDependencies.t [@default PackageJsonDependencies.empty]);
 
   } [@@deriving of_yojson {strict = false}]
 
@@ -324,33 +447,11 @@ module OpamOverride = struct
 end
 
 module Opam : sig
-  type t
-
-  type commands =
-    | Commands of OpamTypes.command list
-    | OverridenCommands of CommandList.t
-
-  val name : t -> string
-  val version : t -> string
-
-  val sourceType : t -> SourceType.t
-  val buildType : t -> BuildType.t
-
-  val buildCommands : t -> commands
-  val installCommands : t -> commands
-  val exportedEnv : t -> ExportedEnv.t
-
-  val dependencies : t -> string list list
-  val optDependencies : t -> string list list
+  include MANIFEST
 
   val ofDirAsInstalled : Path.t -> (t * Path.Set.t) option RunAsync.t
   val ofDirAsAggregatedRoot : Path.t -> (t * Path.Set.t) option RunAsync.t
-
-  val patches : t -> (Path.t * OpamTypes.filter option) list
-  val substs : t -> Path.t list
-
   val hasMultipleOpamFiles : t -> bool
-
 end = struct
   type t =
     | Installed of {
@@ -358,10 +459,6 @@ end = struct
         override : OpamOverride.t option;
       }
     | AggregatedRoot of (string * OpamFile.OPAM.t) list
-
-  and commands =
-    | Commands of OpamTypes.command list
-    | OverridenCommands of CommandList.t
 
   let hasMultipleOpamFiles = function
     | Installed _ -> false
@@ -395,29 +492,29 @@ end = struct
     | Installed manifest ->
       begin match manifest.override with
       | Some {OpamOverride. build = Some build; _} ->
-        OverridenCommands build
+        Build.EsyCommands build
       | Some {OpamOverride. build = None; _}
       | None ->
-        Commands (OpamFile.OPAM.build manifest.opam)
+        Build.OpamCommands (OpamFile.OPAM.build manifest.opam)
       end
     | AggregatedRoot [_name, opam] ->
-      Commands (OpamFile.OPAM.build opam)
+      Build.OpamCommands (OpamFile.OPAM.build opam)
     | AggregatedRoot _ ->
-      Commands []
+      Build.OpamCommands []
 
   let installCommands = function
     | Installed manifest ->
       begin match manifest.override with
       | Some {OpamOverride. install = Some install; _} ->
-        OverridenCommands install
+        Build.EsyCommands install
       | Some {OpamOverride. install = None; _}
       | None ->
-        Commands (OpamFile.OPAM.install manifest.opam)
+        Build.OpamCommands (OpamFile.OPAM.install manifest.opam)
       end
     | AggregatedRoot [_name, opam] ->
-      Commands (OpamFile.OPAM.install opam)
+      Build.OpamCommands (OpamFile.OPAM.install opam)
     | AggregatedRoot _ ->
-      Commands []
+      Build.OpamCommands []
 
   let patches = function
     | Installed manifest ->
@@ -467,83 +564,93 @@ end = struct
     List.map ~f:(List.map ~f) cnf
 
   let dependencies manifest =
-    let dependsOfOpam opam =
-      let f = OpamFile.OPAM.depends opam in
+    let dependencies =
+      let dependsOfOpam opam =
+        let f = OpamFile.OPAM.depends opam in
 
-      let f =
-        let env var =
-          match OpamVariable.Full.to_string var with
-          | "test" -> Some (OpamVariable.B false)
-          | "doc" -> Some (OpamVariable.B false)
-          | _ -> None
+        let f =
+          let env var =
+            match OpamVariable.Full.to_string var with
+            | "test" -> Some (OpamVariable.B false)
+            | "doc" -> Some (OpamVariable.B false)
+            | _ -> None
+          in
+          OpamFilter.partial_filter_formula env f
         in
-        OpamFilter.partial_filter_formula env f
-      in
 
-      let dependencies =
-        listPackageNamesOfFormula
-          ~build:true ~test:false ~post:true ~doc:false ~dev:false
-          f
-      in
-      let dependencies = ["ocaml"]::["@esy-ocaml/substs"]::dependencies in
-
-      dependencies
-    in
-    match manifest with
-    | Installed {opam; override} ->
-      let dependencies = dependsOfOpam opam in
-      begin
-      match override with
-      | Some {OpamOverride. dependencies = extraDependencies; _} ->
-        let extraDependencies =
-          extraDependencies
-          |> StringMap.keys
-          |> List.map ~f:(fun name -> [name])
-        in
-        List.append dependencies extraDependencies
-      | None -> dependencies
-      end
-    | AggregatedRoot opams ->
-      let namesPresent =
-        let f names (name, _) = StringSet.add ("@opam/" ^ name) names in
-        List.fold_left ~f ~init:StringSet.empty opams
-      in
-      let f dependencies (_name, opam) =
-        let update = dependsOfOpam opam in
-        let update =
-          let f name = not (StringSet.mem name namesPresent) in
-          List.map ~f:(List.filter ~f) update
-        in
-        let update =
-          let f = function | [] -> false | _ -> true in
-          List.filter ~f update
-        in
-        dependencies @ update
-      in
-      List.fold_left ~f ~init:[] opams
-
-  let optDependencies manifest =
-    match manifest with
-    | Installed {opam;_} ->
-      let dependencies =
-        let f = OpamFile.OPAM.depopts opam in
         let dependencies =
           listPackageNamesOfFormula
             ~build:true ~test:false ~post:true ~doc:false ~dev:false
             f
         in
-        match dependencies with
-        | [] -> []
-        | [single] -> List.map ~f:(fun name -> [name]) single
-        | _multi ->
-          (** apparently depopts has a different structure than depends in opam,
-           * it's always a single list of packages in cnf
-           * TODO: cleanup this mess
-           *)
-          assert false
+        let dependencies = ["ocaml"]::["@esy-ocaml/substs"]::dependencies in
+
+        dependencies
       in
-      dependencies
-    | AggregatedRoot _ -> []
+      match manifest with
+      | Installed {opam; override} ->
+        let dependencies = dependsOfOpam opam in
+        begin
+        match override with
+        | Some {OpamOverride. dependencies = extraDependencies; _} ->
+          let extraDependencies =
+            extraDependencies
+            |> StringMap.keys
+            |> List.map ~f:(fun name -> [name])
+          in
+          List.append dependencies extraDependencies
+        | None -> dependencies
+        end
+      | AggregatedRoot opams ->
+        let namesPresent =
+          let f names (name, _) = StringSet.add ("@opam/" ^ name) names in
+          List.fold_left ~f ~init:StringSet.empty opams
+        in
+        let f dependencies (_name, opam) =
+          let update = dependsOfOpam opam in
+          let update =
+            let f name = not (StringSet.mem name namesPresent) in
+            List.map ~f:(List.filter ~f) update
+          in
+          let update =
+            let f = function | [] -> false | _ -> true in
+            List.filter ~f update
+          in
+          dependencies @ update
+        in
+        List.fold_left ~f ~init:[] opams
+    in
+
+    let optDependencies =
+      match manifest with
+      | Installed {opam;_} ->
+        let dependencies =
+          let f = OpamFile.OPAM.depopts opam in
+          let dependencies =
+            listPackageNamesOfFormula
+              ~build:true ~test:false ~post:true ~doc:false ~dev:false
+              f
+          in
+          match dependencies with
+          | [] -> []
+          | [single] -> List.map ~f:(fun name -> [name]) single
+          | _multi ->
+            (** apparently depopts has a different structure than depends in opam,
+            * it's always a single list of packages in cnf
+            * TODO: cleanup this mess
+            *)
+            assert false
+        in
+        dependencies
+      | AggregatedRoot _ -> []
+    in
+    {
+      Dependencies.
+      dependencies;
+      buildTimeDependencies = [];
+      devDependencies = [];
+      optDependencies;
+    }
 
   let ofDirAsInstalled (path : Path.t) =
     let open RunAsync.Syntax in
@@ -588,182 +695,131 @@ end = struct
     in
     return (Some (AggregatedRoot opams, Path.Set.of_list paths))
 
-end
-
-type t =
-  | Esy of Esy.t
-  | Opam of Opam.t
-
-module Build = struct
-
-  type commands =
-    | OpamCommands of OpamTypes.command list
-    | EsyCommands of CommandList.t
-
-  type t = {
-    sourceType : SourceType.t;
-    buildType : BuildType.t;
-    buildCommands : commands;
-    installCommands : commands;
-    patches : (Path.t * OpamTypes.filter option) list;
-    substs : Path.t list;
-    exportedEnv : ExportedEnv.t;
-    sandboxEnv : Env.t;
-    buildEnv : Env.t;
-  }
-
-end
-
-module Dependencies = struct
-  type t = {
-    dependencies : string list list;
-    devDependencies : string list list;
-    buildTimeDependencies : string list list;
-    optDependencies : string list list;
-  }
-end
-
-let name (m : t) =
-  match m with
-  | Opam m -> Opam.name m
-  | Esy m -> m.Esy.name
-
-let version (m : t) =
-  match m with
-  | Opam m -> Opam.version m
-  | Esy m -> m.Esy.version
-
-let description (m : t) =
-  match m with
-  | Opam _ -> None
-  | Esy m -> m.Esy.description
-
-let license (m : t) =
-  match m with
-  | Opam _ -> None
-  | Esy m -> m.Esy.license
-
-let uniqueDistributionId (m : t) =
-  match m with
-  | Opam m -> Some ("opam:" ^ Opam.version m)
-  | Esy m -> m.Esy._resolved
-
-let dependencies (m : t) =
-  match m with
-  | Opam m -> {
-      Dependencies.
-      dependencies = Opam.dependencies m;
-      devDependencies = [];
-      buildTimeDependencies = [];
-      optDependencies = Opam.optDependencies m;
-    }
-  | Esy m -> {
-      Dependencies.
-      dependencies = Esy.dependencies m;
-      devDependencies = Esy.devDependencies m;
-      buildTimeDependencies = Esy.buildTimeDependencies m;
-      optDependencies = Esy.optDependencies m;
-    }
-
-let build (m : t) =
-  match m with
-  | Opam m ->
+  let release _ = None
+  let uniqueDistributionId m = Some ("opam:" ^ version m)
+  let description _ = None
+  let license _ = None
+  let build m =
     Some {
       Build.
-      sourceType = Opam.sourceType m;
-      buildType = Opam.buildType m;
-      exportedEnv = Opam.exportedEnv m;
+      sourceType = sourceType m;
+      buildType = buildType m;
+      exportedEnv = exportedEnv m;
       buildEnv = Env.empty;
       sandboxEnv = Env.empty;
-      buildCommands = (
-        match Opam.buildCommands m with
-        | Opam.Commands commands -> OpamCommands commands
-        | Opam.OverridenCommands commands -> EsyCommands commands);
-      installCommands = (
-        match Opam.installCommands m with
-        | Opam.Commands commands -> OpamCommands commands
-        | Opam.OverridenCommands commands -> EsyCommands commands);
-      patches = Opam.patches m;
-      substs = Opam.substs m;
+      buildCommands = buildCommands m;
+      installCommands = installCommands m;
+      patches = patches m;
+      substs = substs m;
     }
-  | Esy ({esy = Some esy;_} as m) ->
-    Some {
-      Build.
-      sourceType = (
-        match m.Esy._resolved with
-        | None -> SourceType.Transient
-        | Some _ -> SourceType.Immutable);
-      buildType = esy.buildsInSource;
-      exportedEnv = esy.exportedEnv;
-      buildEnv = esy.buildEnv;
-      sandboxEnv = esy.sandboxEnv;
-      buildCommands = EsyCommands (esy.EsyManifest.build);
-      installCommands = EsyCommands (esy.EsyManifest.install);
-      patches = [];
-      substs = [];
-    }
-  | Esy {esy = None;_} -> None
 
-let release (m : t) =
-  match m with
-  | Opam _ -> None
-  | Esy m ->
-    let open Option.Syntax in
-    let%bind m = m.Esy.esy in
-    let%bind c = m.EsyManifest.release in
-    return c
+end
 
-let ofDir ?(asRoot=false) (path : Path.t) =
+module EsyOrOpamManifest : sig
+  include MANIFEST
 
-  let relative p =
-    match Path.relativize ~root:path p with
-    | Some p -> p
-    | None -> p
-  in
+  val dirHasManifest : Path.t -> bool RunAsync.t
+  val findEsyManifestOfDir : Path.t -> Path.t option RunAsync.t
+  val ofDir : ?asRoot:bool -> Path.t -> (t * Path.Set.t) option RunAsync.t
+end = struct
+  type t =
+    | Esy of Esy.t
+    | Opam of Opam.t
 
-  let ppPaths fmt paths =
-    let paths = Path.Set.map relative paths in
-    let pp = Path.Set.pp ~sep:(Fmt.unit ", ") Path.pp in
-    pp fmt paths
-  in
+  let name (m : t) =
+    match m with
+    | Opam m -> Opam.name m
+    | Esy m -> Esy.name m
 
-  let open RunAsync.Syntax in
-  match%bind Esy.ofDir path with
-  | Some (manifest, paths) ->
-    let%lwt () =
-      if asRoot
-      then Logs_lwt.app (fun m -> m "found esy manifests: %a" ppPaths paths)
-      else Lwt.return ()
+  let version (m : t) =
+    match m with
+    | Opam m -> Opam.version m
+    | Esy m -> Esy.version m
+
+  let description m =
+    match m with
+    | Opam m -> Opam.description m
+    | Esy m -> Esy.description m
+
+  let license m =
+    match m with
+    | Opam m -> Opam.license m
+    | Esy m -> Esy.license m
+
+  let uniqueDistributionId m =
+    match m with
+    | Opam m -> Opam.uniqueDistributionId m
+    | Esy m -> Esy.uniqueDistributionId m
+
+  let dependencies m =
+    match m with
+    | Opam m -> Opam.dependencies m
+    | Esy m -> Esy.dependencies m
+
+  let build m =
+    match m with
+    | Opam m -> Opam.build m
+    | Esy m -> Esy.build m
+
+  let release (m : t) =
+    match m with
+    | Opam m -> Opam.release m
+    | Esy m -> Esy.release m
+
+  let ofDir ?(asRoot=false) (path : Path.t) =
+
+    let relative p =
+      match Path.relativize ~root:path p with
+      | Some p -> p
+      | None -> p
     in
-    return (Some (Esy manifest, paths))
-  | None ->
-    let opam =
-      if asRoot
-      then Opam.ofDirAsAggregatedRoot path
-      else Opam.ofDirAsInstalled path
+
+    let ppPaths fmt paths =
+      let paths = Path.Set.map relative paths in
+      let pp = Path.Set.pp ~sep:(Fmt.unit ", ") Path.pp in
+      pp fmt paths
     in
-    begin match%bind opam with
+
+    let open RunAsync.Syntax in
+    match%bind Esy.ofDir path with
     | Some (manifest, paths) ->
       let%lwt () =
         if asRoot
-        then (
-          Logs_lwt.app (fun m -> m "found opam manifests: %a" ppPaths paths);%lwt
-          if Opam.hasMultipleOpamFiles manifest
-          then Logs_lwt.warn (fun m -> m "build commands from opam files won't be executed")
-          else Lwt.return ()
-        ) else Lwt.return ()
+        then Logs_lwt.app (fun m -> m "found esy manifests: %a" ppPaths paths)
+        else Lwt.return ()
       in
-      return (Some (Opam manifest, paths))
-    | None -> return None
-    end
+      return (Some (Esy manifest, paths))
+    | None ->
+      let opam =
+        if asRoot
+        then Opam.ofDirAsAggregatedRoot path
+        else Opam.ofDirAsInstalled path
+      in
+      begin match%bind opam with
+      | Some (manifest, paths) ->
+        let%lwt () =
+          if asRoot
+          then (
+            Logs_lwt.app (fun m -> m "found opam manifests: %a" ppPaths paths);%lwt
+            if Opam.hasMultipleOpamFiles manifest
+            then Logs_lwt.warn (fun m -> m "build commands from opam files won't be executed")
+            else Lwt.return ()
+          ) else Lwt.return ()
+        in
+        return (Some (Opam manifest, paths))
+      | None -> return None
+      end
 
-let dirHasManifest (path : Path.t) =
-  let open RunAsync.Syntax in
-  let%bind names = Fs.listDir path in
-  let f = function
-    | "esy.json" | "package.json" | "opam" -> true
-    | name -> Path.(name |> v |> has_ext ".opam")
-  in
-  return (List.exists ~f names)
+  let dirHasManifest (path : Path.t) =
+    let open RunAsync.Syntax in
+    let%bind names = Fs.listDir path in
+    let f = function
+      | "esy.json" | "package.json" | "opam" -> true
+      | name -> Path.(name |> v |> has_ext ".opam")
+    in
+    return (List.exists ~f names)
 
-let findEsyManifestOfDir = Esy.findOfDir
+  let findEsyManifestOfDir = Esy.findOfDir
+end
+
+include EsyOrOpamManifest

--- a/esy/Manifest.ml
+++ b/esy/Manifest.ml
@@ -2,6 +2,7 @@ module CommandList = struct
 
   module Command = struct
 
+    [@@@ocaml.warning "-32"]
     type t =
       | Parsed of string list
       | Unparsed of string
@@ -19,6 +20,7 @@ module CommandList = struct
 
   end
 
+  [@@@ocaml.warning "-32"]
   type t =
     Command.t list option
     [@@deriving (show, eq, ord)]
@@ -207,7 +209,7 @@ module Release = struct
   type t = {
     releasedBinaries: string list;
     deleteFromBinaryRelease: (string list [@default []]);
-  } [@@deriving (show, of_yojson { strict = false })]
+  } [@@deriving (of_yojson { strict = false })]
 end
 
 module EsyManifest = struct

--- a/esy/Manifest.ml
+++ b/esy/Manifest.ml
@@ -203,7 +203,7 @@ end
 
 module SourceType = EsyBuildPackage.SourceType
 
-module EsyReleaseConfig = struct
+module ReleaseConfig = struct
   type t = {
     releasedBinaries: string list;
     deleteFromBinaryRelease: (string list [@default []]);
@@ -219,7 +219,7 @@ module EsyManifest = struct
     exportedEnv: (ExportedEnv.t [@default []]);
     buildEnv: (Env.t [@default Env.empty]);
     sandboxEnv: (Env.t [@default Env.empty]);
-    release: (EsyReleaseConfig.t option [@default None]);
+    release: (ReleaseConfig.t option [@default None]);
   } [@@deriving (of_yojson { strict = false })]
 
 end

--- a/esy/Manifest.mli
+++ b/esy/Manifest.mli
@@ -19,7 +19,6 @@ module Scripts : sig
   and script = { command : CommandList.Command.t; }
   val empty : t
   val find : string -> t -> script option
-  val ofFile : Fpath.t -> t RunAsync.t
 end
 
 module Env : sig
@@ -89,55 +88,67 @@ module Dependencies : sig
   }
 end
 
-(**
- * Manifest.
- *
- * This can be either esy manifest (package.json/esy.json) or opam manifest but
- * this type abstracts them out.
- *)
-type t
+module type MANIFEST = sig
+  (**
+   * Manifest.
+   *
+   * This can be either esy manifest (package.json/esy.json) or opam manifest but
+   * this type abstracts them out.
+   *)
+  type t
 
-(** Name. *)
-val name : t -> string
+  (** Name. *)
+  val name : t -> string
 
-(** Version. *)
-val version : t -> string
+  (** Version. *)
+  val version : t -> string
 
-(** License. *)
-val license : t -> Json.t option
+  (** License. *)
+  val license : t -> Json.t option
 
-(** Description. *)
-val description : t -> string option
+  (** Description. *)
+  val description : t -> string option
 
-(**
- * Extract dependency info.
- *)
-val dependencies : t -> Dependencies.t
+  (**
+   * Extract dependency info.
+   *)
+  val dependencies : t -> Dependencies.t
 
-(**
- * Extract build config from manifest
- *
- * Not all packages have build config defined so we return `None` in this case.
- *)
-val build : t -> Build.t option
+  (**
+   * Extract build config from manifest
+   *
+   * Not all packages have build config defined so we return `None` in this case.
+   *)
+  val build : t -> Build.t option
 
-(**
- * Extract release config from manifest
- *
- * Not all packages have release config defined so we return `None` in this
- * case.
- *)
-val release : t -> Release.t option
+  (**
+   * Extract release config from manifest
+   *
+   * Not all packages have release config defined so we return `None` in this
+   * case.
+   *)
+  val release : t -> Release.t option
 
-(**
- * Unique id of the release.
- *
- * This could be a released version, git sha commit or some checksum of package
- * contents if any.
- *
- * This info is used to construct a build key for the corresponding package.
- *)
-val uniqueDistributionId : t -> string option
+  (**
+   * Extract release config from manifest
+   *
+   * Not all packages have release config defined so we return `None` in this
+   * case.
+   *)
+  val scripts : t -> Scripts.t Run.t
+
+  (**
+   * Unique id of the release.
+   *
+   * This could be a released version, git sha commit or some checksum of package
+   * contents if any.
+   *
+   * This info is used to construct a build key for the corresponding package.
+   *)
+  val uniqueDistributionId : t -> string option
+end
+
+include MANIFEST
 
 (**
  * Load manifest given a directory.
@@ -150,5 +161,3 @@ val uniqueDistributionId : t -> string option
 val ofDir : ?asRoot:bool -> Fpath.t -> (t * Fpath.set) option RunAsync.t
 
 val dirHasManifest : Fpath.t -> bool RunAsync.t
-
-val findEsyManifestOfDir : Fpath.t -> Fpath.t option RunAsync.t

--- a/esy/Manifest.mli
+++ b/esy/Manifest.mli
@@ -108,93 +108,11 @@ module EsyReleaseConfig : sig
   val of_yojson : t Json.decoder
 end
 
-module EsyManifest : sig
-  type t = {
-    build : CommandList.t;
-    install : CommandList.t;
-    buildsInSource : BuildType.t;
-    exportedEnv : ExportedEnv.t;
-    buildEnv : Env.t;
-    sandboxEnv : Env.t;
-    release : EsyReleaseConfig.t option;
-  }
+type t
 
-  val pp : t Fmt.t
-  val show : t -> string
-
-  val of_yojson : t Json.decoder
-
-  val empty : t
-end
-
-module Esy : sig
-
-  module Dependencies : sig
-    type t = string StringMap.t
-    val empty : t
-    val pp : t Fmt.t
-    val of_yojson : t Json.decoder
-  end
-
-  type t = {
-    name : string;
-    version : string;
-    description : string option;
-    license : Json.t option;
-    dependencies : Dependencies.t;
-    peerDependencies : Dependencies.t;
-    devDependencies : Dependencies.t;
-    optDependencies : Dependencies.t;
-    buildTimeDependencies : Dependencies.t;
-    esy : EsyManifest.t option;
-    _resolved : string option;
-  }
-
-  val pp : t Fmt.t
-  val show : t -> string
-  val of_yojson : t Json.decoder
-
-  val name : t -> string
-  val version : t -> string
-  val dependencies : t -> string list list
-  val devDependencies : t -> string list list
-  val optDependencies : t -> string list list
-  val buildTimeDependencies : t -> string list list
-
-  val ofFile : Fpath.t -> t RunAsync.t
-  val findOfDir : Fpath.t -> Fpath.t option RunAsync.t
-  val ofDir : Fpath.t -> (t * Fpath.set) option RunAsync.t
-end
-
-module Opam : sig
-  type t
-
-  type commands =
-    | Commands of OpamTypes.command list
-    | OverridenCommands of CommandList.t
-
-  val opamName : t -> string
-
-  val name : t -> string
-  val version : t -> string
-
-  val sourceType : t -> SourceType.t
-  val buildType : t -> BuildType.t
-
-  val buildCommands : t -> commands
-  val installCommands : t -> commands
-  val exportedEnv : t -> ExportedEnv.t
-
-  val dependencies : t -> string list list
-  val optDependencies : t -> string list list
-
-  val patches : t -> (OpamTypes.basename * OpamTypes.filter option) list
-  val substs : t -> OpamTypes.basename list
-end
-
-type t =
-  | Esy of Esy.t
-  | Opam of Opam.t
+type kind =
+  | OpamKind
+  | EsyKind
 
 type commands =
   | OpamCommands of OpamTypes.command list
@@ -202,6 +120,8 @@ type commands =
 
 val name : t -> string
 val version : t -> string
+val license : t -> Json.t option
+val description : t -> string option
 
 val dependencies : t -> string list list
 val devDependencies : t -> string list list
@@ -212,10 +132,16 @@ val sourceType : t -> SourceType.t
 val buildType : t -> BuildType.t option
 val buildCommands : t -> commands
 val installCommands : t -> commands
+val patches : t -> (Path.t * OpamTypes.filter option) list
+val substs : t -> Path.t list
 
 val exportedEnv : t -> ExportedEnv.t
 val sandboxEnv : t -> Env.t
 val buildEnv : t -> Env.t
+
+val kind : t -> kind
+
+val releaseConfig : t -> EsyReleaseConfig.t option
 
 val uniqueDistributionId : t -> string option
 
@@ -230,3 +156,5 @@ val uniqueDistributionId : t -> string option
 val ofDir : ?asRoot:bool -> Fpath.t -> (t * Fpath.set) option RunAsync.t
 
 val dirHasManifest : Fpath.t -> bool RunAsync.t
+
+val findEsyManifestOfDir : Fpath.t -> Fpath.t option RunAsync.t

--- a/esy/Manifest.mli
+++ b/esy/Manifest.mli
@@ -1,3 +1,7 @@
+(**
+ * This module represents esy/opam manifest.
+ *)
+
 module CommandList :sig
   module Command : sig
     type t =
@@ -160,17 +164,6 @@ module Esy : sig
   val ofFile : Fpath.t -> t RunAsync.t
   val findOfDir : Fpath.t -> Fpath.t option RunAsync.t
   val ofDir : Fpath.t -> (t * Fpath.set) option RunAsync.t
-end
-
-module OpamOverride : sig
-  type t = {
-    build : CommandList.t option;
-    install : CommandList.t option;
-    exportedEnv : ExportedEnv.t;
-    dependencies : Esy.Dependencies.t;
-  }
-  val of_yojson : t Json.decoder
-  val ofFile : Fpath.t -> t RunAsync.t
 end
 
 module Opam : sig

--- a/esy/Manifest.mli
+++ b/esy/Manifest.mli
@@ -188,19 +188,45 @@ module Opam : sig
   val dependencies : t -> string list list
   val optDependencies : t -> string list list
 
-  val ofDirAsInstalled : Path.t -> (t * Path.Set.t) option RunAsync.t
-  val ofDirAsAggregatedRoot : Path.t -> (t * Path.Set.t) option RunAsync.t
-
   val patches : t -> (OpamTypes.basename * OpamTypes.filter option) list
   val substs : t -> OpamTypes.basename list
-
-  val hasMultipleOpamFiles : t -> bool
-
 end
 
 type t =
   | Esy of Esy.t
   | Opam of Opam.t
 
+type commands =
+  | OpamCommands of OpamTypes.command list
+  | EsyCommands of CommandList.t
+
+val name : t -> string
+val version : t -> string
+
+val dependencies : t -> string list list
+val devDependencies : t -> string list list
+val optDependencies : t -> string list list
+val buildTimeDependencies : t -> string list list
+
+val sourceType : t -> SourceType.t
+val buildType : t -> BuildType.t option
+val buildCommands : t -> commands
+val installCommands : t -> commands
+
+val exportedEnv : t -> ExportedEnv.t
+val sandboxEnv : t -> Env.t
+val buildEnv : t -> Env.t
+
+val uniqueDistributionId : t -> string option
+
+(**
+ * Load manifest given a directory.
+ *
+ * Return `None` is no manifets was found.
+ *
+ * If manifest was found then returns also a set of paths which were used to
+ * load manifest. Client code can check those paths to invalidate caches.
+ *)
 val ofDir : ?asRoot:bool -> Fpath.t -> (t * Fpath.set) option RunAsync.t
+
 val dirHasManifest : Fpath.t -> bool RunAsync.t

--- a/esy/Manifest.mli
+++ b/esy/Manifest.mli
@@ -1,0 +1,213 @@
+module CommandList :sig
+  module Command : sig
+    type t =
+      | Parsed of string list
+      | Unparsed of string
+    val pp : t Fmt.t
+    val show : t -> string
+
+    val equal : t -> t -> bool
+    val compare : t -> t -> int
+
+    val to_yojson : t Json.encoder
+    val of_yojson : t Json.decoder
+  end
+
+  type t = Command.t list option
+  val pp : t Fmt.t
+  val show : t -> string
+
+  val equal : t -> t -> bool
+  val compare : t -> t -> int
+
+  val to_yojson : t Json.encoder
+  val of_yojson : t Json.decoder
+
+  val empty : 'a option
+end
+
+module Scripts : sig
+  type t = script StringMap.t
+  and script = { command : CommandList.Command.t; }
+
+  type scripts = t
+
+  val equal : t -> t -> bool
+  val compare : t -> t -> int
+
+  val empty : 'a StringMap.t
+
+  val pp : t Fmt.t
+  val of_yojson : t Json.decoder
+  val find : string -> t -> script option
+
+  val ofFile : Fpath.t -> scripts RunAsync.t
+
+  module ParseManifest : sig
+    val parse : Json.t -> (scripts, string) result
+  end
+end
+
+module Env : sig
+  type t = item list
+  and item = { name : string; value : string; }
+
+  val pp : t Fmt.t
+  val show : t -> string
+  val equal : t -> t -> bool
+  val compare : t -> t -> int
+  val of_yojson : t Json.decoder
+
+  val empty : t
+end
+
+module ExportedEnv : sig
+  type t = item list
+
+  and item = {
+    name : string;
+    value : string;
+    scope : scope;
+    exclusive : bool;
+  }
+
+  and scope = Local | Global
+
+  val pp : t Fmt.t
+  val show : t -> string
+  val equal : t -> t -> bool
+  val compare : t -> t -> int
+  val empty : t
+  val of_yojson : t Json.decoder
+end
+
+module BuildType : sig
+  include module type of EsyBuildPackage.BuildType
+
+  val to_yojson : t Json.encoder
+  val of_yojson : t Json.decoder
+end
+
+module SourceType : sig
+  include module type of EsyBuildPackage.SourceType
+end
+
+module EsyReleaseConfig : sig
+  type t = {
+    releasedBinaries : string list;
+    deleteFromBinaryRelease : string list;
+  }
+
+  val pp : t Fmt.t
+  val show : t -> string
+
+  val of_yojson : t Json.decoder
+end
+
+module EsyManifest : sig
+  type t = {
+    build : CommandList.t;
+    install : CommandList.t;
+    buildsInSource : BuildType.t;
+    exportedEnv : ExportedEnv.t;
+    buildEnv : Env.t;
+    sandboxEnv : Env.t;
+    release : EsyReleaseConfig.t option;
+  }
+
+  val pp : t Fmt.t
+  val show : t -> string
+
+  val of_yojson : t Json.decoder
+
+  val empty : t
+end
+
+module Esy : sig
+
+  module Dependencies : sig
+    type t = string StringMap.t
+    val empty : t
+    val pp : t Fmt.t
+    val of_yojson : t Json.decoder
+  end
+
+  type t = {
+    name : string;
+    version : string;
+    description : string option;
+    license : Json.t option;
+    dependencies : Dependencies.t;
+    peerDependencies : Dependencies.t;
+    devDependencies : Dependencies.t;
+    optDependencies : Dependencies.t;
+    buildTimeDependencies : Dependencies.t;
+    esy : EsyManifest.t option;
+    _resolved : string option;
+  }
+
+  val pp : t Fmt.t
+  val show : t -> string
+  val of_yojson : t Json.decoder
+
+  val name : t -> string
+  val version : t -> string
+  val dependencies : t -> string list list
+  val devDependencies : t -> string list list
+  val optDependencies : t -> string list list
+  val buildTimeDependencies : t -> string list list
+
+  val ofFile : Fpath.t -> t RunAsync.t
+  val findOfDir : Fpath.t -> Fpath.t option RunAsync.t
+  val ofDir : Fpath.t -> (t * Fpath.set) option RunAsync.t
+end
+
+module OpamOverride : sig
+  type t = {
+    build : CommandList.t option;
+    install : CommandList.t option;
+    exportedEnv : ExportedEnv.t;
+    dependencies : Esy.Dependencies.t;
+  }
+  val of_yojson : t Json.decoder
+  val ofFile : Fpath.t -> t RunAsync.t
+end
+
+module Opam : sig
+  type t
+
+  type commands =
+    | Commands of OpamTypes.command list
+    | OverridenCommands of CommandList.t
+
+  val opamName : t -> string
+
+  val name : t -> string
+  val version : t -> string
+
+  val sourceType : t -> SourceType.t
+  val buildType : t -> BuildType.t
+
+  val buildCommands : t -> commands
+  val installCommands : t -> commands
+  val exportedEnv : t -> ExportedEnv.t
+
+  val dependencies : t -> string list list
+  val optDependencies : t -> string list list
+
+  val ofDirAsInstalled : Path.t -> (t * Path.Set.t) option RunAsync.t
+  val ofDirAsAggregatedRoot : Path.t -> (t * Path.Set.t) option RunAsync.t
+
+  val patches : t -> (OpamTypes.basename * OpamTypes.filter option) list
+  val substs : t -> OpamTypes.basename list
+
+  val hasMultipleOpamFiles : t -> bool
+
+end
+
+type t =
+  | Esy of Esy.t
+  | Opam of Opam.t
+
+val ofDir : ?asRoot:bool -> Fpath.t -> (t * Fpath.set) option RunAsync.t
+val dirHasManifest : Fpath.t -> bool RunAsync.t

--- a/esy/Manifest.mli
+++ b/esy/Manifest.mli
@@ -96,7 +96,7 @@ module SourceType : sig
   include module type of EsyBuildPackage.SourceType
 end
 
-module ReleaseConfig : sig
+module Release : sig
   type t = {
     releasedBinaries : string list;
     deleteFromBinaryRelease : string list;
@@ -108,40 +108,48 @@ module ReleaseConfig : sig
   val of_yojson : t Json.decoder
 end
 
+module Build : sig
+  type commands =
+    | OpamCommands of OpamTypes.command list
+    | EsyCommands of CommandList.t
+
+  type t = {
+    sourceType : SourceType.t;
+    buildType : BuildType.t;
+    buildCommands : commands;
+    installCommands : commands;
+    patches : (Path.t * OpamTypes.filter option) list;
+    substs : Path.t list;
+    exportedEnv : ExportedEnv.t;
+    sandboxEnv : Env.t;
+    buildEnv : Env.t;
+  }
+end
+
+module Dependencies : sig
+  type t = {
+    dependencies : string list list;
+    devDependencies : string list list;
+    buildTimeDependencies : string list list;
+    optDependencies : string list list;
+  }
+end
+
 type t
 
-type kind =
-  | OpamKind
-  | EsyKind
-
-type commands =
-  | OpamCommands of OpamTypes.command list
-  | EsyCommands of CommandList.t
-
 val name : t -> string
+
 val version : t -> string
+
 val license : t -> Json.t option
+
 val description : t -> string option
 
-val dependencies : t -> string list list
-val devDependencies : t -> string list list
-val optDependencies : t -> string list list
-val buildTimeDependencies : t -> string list list
+val dependencies : t -> Dependencies.t
 
-val sourceType : t -> SourceType.t
-val buildType : t -> BuildType.t option
-val buildCommands : t -> commands
-val installCommands : t -> commands
-val patches : t -> (Path.t * OpamTypes.filter option) list
-val substs : t -> Path.t list
+val build : t -> Build.t option
 
-val exportedEnv : t -> ExportedEnv.t
-val sandboxEnv : t -> Env.t
-val buildEnv : t -> Env.t
-
-val kind : t -> kind
-
-val releaseConfig : t -> ReleaseConfig.t option
+val release : t -> Release.t option
 
 val uniqueDistributionId : t -> string option
 

--- a/esy/Manifest.mli
+++ b/esy/Manifest.mli
@@ -96,7 +96,7 @@ module SourceType : sig
   include module type of EsyBuildPackage.SourceType
 end
 
-module EsyReleaseConfig : sig
+module ReleaseConfig : sig
   type t = {
     releasedBinaries : string list;
     deleteFromBinaryRelease : string list;
@@ -141,7 +141,7 @@ val buildEnv : t -> Env.t
 
 val kind : t -> kind
 
-val releaseConfig : t -> EsyReleaseConfig.t option
+val releaseConfig : t -> ReleaseConfig.t option
 
 val uniqueDistributionId : t -> string option
 

--- a/esy/NpmRelease.ml
+++ b/esy/NpmRelease.ml
@@ -73,8 +73,8 @@ let configure ~(cfg : Config.t) =
       version = Manifest.version manifest;
       license = Manifest.license manifest;
       description = Manifest.description manifest;
-      releasedBinaries = releaseCfg.Manifest.EsyReleaseConfig.releasedBinaries;
-      deleteFromBinaryRelease = releaseCfg.Manifest.EsyReleaseConfig.deleteFromBinaryRelease;
+      releasedBinaries = releaseCfg.Manifest.ReleaseConfig.releasedBinaries;
+      deleteFromBinaryRelease = releaseCfg.Manifest.ReleaseConfig.deleteFromBinaryRelease;
     }
 
 let dependenciesForRelease (task : Task.t) =

--- a/esy/NpmRelease.ml
+++ b/esy/NpmRelease.ml
@@ -66,15 +66,15 @@ let configure ~(cfg : Config.t) =
   | None -> error "no manifest found"
   | Some (manifest, _) ->
     let%bind releaseCfg =
-      RunAsync.ofOption ~err:"no release config found" (Manifest.releaseConfig manifest)
+      RunAsync.ofOption ~err:"no release config found" (Manifest.release manifest)
     in
     return {
       name = Manifest.name manifest;
       version = Manifest.version manifest;
       license = Manifest.license manifest;
       description = Manifest.description manifest;
-      releasedBinaries = releaseCfg.Manifest.ReleaseConfig.releasedBinaries;
-      deleteFromBinaryRelease = releaseCfg.Manifest.ReleaseConfig.deleteFromBinaryRelease;
+      releasedBinaries = releaseCfg.Manifest.Release.releasedBinaries;
+      deleteFromBinaryRelease = releaseCfg.Manifest.Release.deleteFromBinaryRelease;
     }
 
 let dependenciesForRelease (task : Task.t) =
@@ -144,7 +144,7 @@ let make ~esyInstallRelease ~outputPath ~concurrency ~cfg ~sandbox =
     *)
   let devModeIds =
     let f s task =
-      match task.Task.pkg.sourceType with
+      match task.Task.pkg.build.sourceType with
       | Manifest.SourceType.Immutable -> s
       | Manifest.SourceType.Transient -> StringSet.add task.id s
     in
@@ -196,16 +196,18 @@ let make ~esyInstallRelease ~outputPath ~concurrency ~cfg ~sandbox =
           name = "release-env";
           version = pkg.version;
           dependencies = [Package.Dependency pkg];
-          sourceType = Manifest.SourceType.Transient;
-          sandboxEnv = pkg.sandboxEnv;
-          buildEnv = Manifest.Env.empty;
-          buildCommands = Manifest.EsyCommands None;
-          installCommands = Manifest.EsyCommands None;
-          buildType = Manifest.BuildType.OutOfSource;
-          patches = [];
-          substs = [];
-          kind = Manifest.EsyKind;
-          exportedEnv = [];
+          build = {
+            Manifest.Build.
+            sourceType = Manifest.SourceType.Transient;
+            sandboxEnv = pkg.build.sandboxEnv;
+            buildEnv = Manifest.Env.empty;
+            buildCommands = Manifest.Build.EsyCommands None;
+            installCommands = Manifest.Build.EsyCommands None;
+            buildType = Manifest.BuildType.OutOfSource;
+            patches = [];
+            substs = [];
+            exportedEnv = [];
+          };
           sourcePath = pkg.sourcePath;
           resolution = None;
         } in

--- a/esy/NpmRelease.ml
+++ b/esy/NpmRelease.ml
@@ -114,7 +114,7 @@ let make ~esyInstallRelease ~outputPath ~concurrency ~cfg ~sandbox =
   let%bind ocamlopt = RunAsync.ofRun (
       let open Run.Syntax in
       let%bind ocaml =
-        match Task.DependencyGraph.find ~f:(fun task -> task.pkg.name = "ocaml") task with
+        match Task.Graph.find ~f:(fun task -> task.pkg.name = "ocaml") task with
         | Some(ocaml) -> return ocaml
         | None -> error "ocaml isn't available in the sandbox"
       in
@@ -125,7 +125,7 @@ let make ~esyInstallRelease ~outputPath ~concurrency ~cfg ~sandbox =
       return ocamlopt
     ) in
 
-  let tasks = Task.DependencyGraph.traverse ~traverse:dependenciesForRelease task in
+  let tasks = Task.Graph.traverse ~traverse:dependenciesForRelease task in
 
   let shouldDeleteFromBinaryRelease =
     let patterns =

--- a/esy/Package.ml
+++ b/esy/Package.ml
@@ -3,19 +3,8 @@ type t = {
   name : string;
   version : string;
   dependencies : dependencies;
-
-  buildCommands : ((Manifest.commands [@equal fun _ _ -> true]) [@compare fun _ _ -> 0]);
-  installCommands : ((Manifest.commands [@equal fun _ _ -> true]) [@compare fun _ _ -> 0]);
-  patches : (((Path.t * OpamTypes.filter option) list [@equal fun _ _ -> true]) [@compare fun _ _ -> 0]);
-  substs : Path.t list;
-
+  build : ((Manifest.Build.t [@equal fun _ _ -> true]) [@compare fun _ _ -> 0]);
   sourcePath : Config.Path.t;
-  sourceType : Manifest.SourceType.t;
-  buildType : Manifest.BuildType.t;
-  sandboxEnv : Manifest.Env.t;
-  buildEnv : Manifest.Env.t;
-  exportedEnv : Manifest.ExportedEnv.t;
-  kind : ((Manifest.kind [@equal fun _ _ -> true]) [@compare fun _ _ -> 0]);
   resolution : string option;
 } [@@deriving (eq, ord)]
 

--- a/esy/Package.ml
+++ b/esy/Package.ml
@@ -3,7 +3,7 @@ type t = {
   name : string;
   version : string;
   dependencies : dependencies;
-  
+
   buildCommands : ((Manifest.commands [@equal fun _ _ -> true]) [@compare fun _ _ -> 0]);
   installCommands : ((Manifest.commands [@equal fun _ _ -> true]) [@compare fun _ _ -> 0]);
   patches : (((Path.t * OpamTypes.filter option) list [@equal fun _ _ -> true]) [@compare fun _ _ -> 0]);
@@ -42,7 +42,7 @@ let packageOf (dep : dependency) = match dep with
 | BuildTimeDependency pkg -> Some pkg
 | InvalidDependency _ -> None
 
-module DependencyGraph = DependencyGraph.Make(struct
+module Graph = DependencyGraph.Make(struct
 
   type t = pkg
 

--- a/esy/Package.ml
+++ b/esy/Package.ml
@@ -1,44 +1,23 @@
-module EsyBuild = struct
-  type t = {
-    buildCommands : Manifest.CommandList.t;
-    installCommands : Manifest.CommandList.t;
-    buildType : Manifest.BuildType.t;
-  } [@@deriving (show, ord, eq)]
-end
-
-module OpamBuild = struct
-  type t = {
-    name : string;
-    version : string;
-    buildCommands : Manifest.Opam.commands;
-    installCommands : Manifest.Opam.commands;
-    patches : (OpamFilename.Base.t * OpamTypes.filter option) list;
-    substs : OpamFilename.Base.t list;
-    buildType : Manifest.BuildType.t;
-  }
-
-  let pp fmt _v = Fmt.pf fmt "<opam>"
-  let compare _a _b = 0
-  let equal _a _b = false
-end
-
 type t = {
   id : string;
   name : string;
   version : string;
   dependencies : dependencies;
+  
+  buildCommands : ((Manifest.commands [@equal fun _ _ -> true]) [@compare fun _ _ -> 0]);
+  installCommands : ((Manifest.commands [@equal fun _ _ -> true]) [@compare fun _ _ -> 0]);
+  patches : (((Path.t * OpamTypes.filter option) list [@equal fun _ _ -> true]) [@compare fun _ _ -> 0]);
+  substs : Path.t list;
+
   sourcePath : Config.Path.t;
   sourceType : Manifest.SourceType.t;
+  buildType : Manifest.BuildType.t;
   sandboxEnv : Manifest.Env.t;
   buildEnv : Manifest.Env.t;
   exportedEnv : Manifest.ExportedEnv.t;
+  kind : ((Manifest.kind [@equal fun _ _ -> true]) [@compare fun _ _ -> 0]);
   resolution : string option;
-  build : build;
-} [@@deriving (show, ord, eq)]
-
-and build =
-  | EsyBuild of EsyBuild.t
-  | OpamBuild of OpamBuild.t
+} [@@deriving (eq, ord)]
 
 and dependencies =
   dependency list

--- a/esy/Package.mli
+++ b/esy/Package.mli
@@ -3,19 +3,8 @@ type t = {
   name : string;
   version : string;
   dependencies : dependencies;
-
-  buildCommands : Manifest.commands;
-  installCommands : Manifest.commands;
-  patches : (Path.t * OpamTypes.filter option) list;
-  substs : Path.t list;
-
+  build : Manifest.Build.t;
   sourcePath : Config.Path.t;
-  sourceType : Manifest.SourceType.t;
-  buildType : Manifest.BuildType.t;
-  sandboxEnv : Manifest.Env.t;
-  buildEnv : Manifest.Env.t;
-  exportedEnv : Manifest.ExportedEnv.t;
-  kind : Manifest.kind;
   resolution : string option;
 }
 

--- a/esy/Package.mli
+++ b/esy/Package.mli
@@ -1,0 +1,40 @@
+type t = {
+  id : string;
+  name : string;
+  version : string;
+  dependencies : dependencies;
+
+  buildCommands : Manifest.commands;
+  installCommands : Manifest.commands;
+  patches : (Path.t * OpamTypes.filter option) list;
+  substs : Path.t list;
+
+  sourcePath : Config.Path.t;
+  sourceType : Manifest.SourceType.t;
+  buildType : Manifest.BuildType.t;
+  sandboxEnv : Manifest.Env.t;
+  buildEnv : Manifest.Env.t;
+  exportedEnv : Manifest.ExportedEnv.t;
+  kind : Manifest.kind;
+  resolution : string option;
+}
+
+and dependencies =
+  dependency list
+
+and dependency =
+  | Dependency of t
+  | OptDependency of t
+  | DevDependency of t
+  | BuildTimeDependency of t
+  | InvalidDependency of {
+    pkgName: string;
+    reason: string;
+  }
+
+val equal : t -> t -> bool
+val compare : t -> t -> int
+val packageOf : dependency -> t option
+
+module DependencySet : Set.S with type elt = dependency
+module Graph : DependencyGraph.DependencyGraph with type node = t

--- a/esy/Package.mli
+++ b/esy/Package.mli
@@ -26,4 +26,6 @@ val compare : t -> t -> int
 val packageOf : dependency -> t option
 
 module DependencySet : Set.S with type elt = dependency
-module Graph : DependencyGraph.DependencyGraph with type node = t
+module Graph : DependencyGraph.DependencyGraph
+  with type node = t
+  and type dependency := dependency

--- a/esy/Sandbox.mli
+++ b/esy/Sandbox.mli
@@ -1,3 +1,7 @@
+(**
+ * This represents sandbox.
+ *)
+
 type t = {
   root : Package.t;
   scripts : Manifest.Scripts.t;

--- a/esy/SandboxTools.re
+++ b/esy/SandboxTools.re
@@ -1,6 +1,6 @@
 let find = (~name, task: Task.t) => {
   let f = (task: Task.t) => task.pkg.name == name;
-  Task.DependencyGraph.find(~f, task);
+  Task.Graph.find(~f, task);
 };
 
 let getOcamlfind = (~cfg: Config.t, task: Task.t) =>

--- a/esy/Task.ml
+++ b/esy/Task.ml
@@ -1,10 +1,6 @@
 (**
  * Build task.
- *
- * TODO: Reconcile with BuildTask, right now we just reuse types & code
- * from there but it probably should live here instead. Fix that after we decide
- * on better package boundaries.
-*)
+ *)
 
 module Store = EsyLib.Store
 
@@ -91,14 +87,12 @@ end
 module Scope = struct
   type t =
     EsyCommandExpression.Value.t StringMap.t
-    [@@deriving eq, ord]
-
-  let pp fmt _v = Fmt.unit "<scope>" fmt ()
+    [@@deriving ord]
 end
 
 type t = {
   id : string;
-  pkg : Package.t [@printer fun fmt pkg -> Fmt.string fmt pkg.Package.id];
+  pkg : Package.t;
 
   buildCommands : CommandList.t;
   installCommands : CommandList.t;
@@ -115,7 +109,7 @@ type t = {
   platform : System.Platform.t;
   scope : Scope.t;
 }
-[@@deriving (show, eq, ord)]
+[@@deriving ord]
 
 and paths = {
   rootPath : Config.Path.t;
@@ -126,7 +120,6 @@ and paths = {
   installPath : Config.Path.t;
   logPath : Config.Path.t;
 }
-[@@deriving show]
 
 and dependency =
   | Dependency of t
@@ -1098,7 +1091,7 @@ let sandboxEnv (pkg : Package.t) =
       synPkg
   in Ok (Environment.Closed.bindings task.env)
 
-module DependencyGraph = DependencyGraph.Make(struct
+module Graph = DependencyGraph.Make(struct
     type t = task
 
     let compare = Pervasives.compare

--- a/esy/Task.ml
+++ b/esy/Task.ml
@@ -501,7 +501,7 @@ let ofPackage
 
     let ocamlVersion =
       let f pkg = pkg.Package.name = "ocaml" in
-      match Package.DependencyGraph.find ~f pkg with
+      match Package.Graph.find ~f pkg with
       | Some pkg -> Some (toOCamlVersion pkg.version)
       | None -> None
     in

--- a/esy/Task.mli
+++ b/esy/Task.mli
@@ -12,11 +12,12 @@ module CommandList : sig
   val equal : t -> t -> bool
 end
 
+(** This is an abstract type which represents a scope of a task. *)
 module Scope : sig
   type t
 end
 
-type t = {
+type t = private {
   id : string;
   pkg : Package.t;
 

--- a/esy/Task.mli
+++ b/esy/Task.mli
@@ -3,15 +3,6 @@
  * build.
  *)
 
-module CommandList : sig
-  type t
-
-  val make : string list list -> t
-
-  val show : t -> string
-  val equal : t -> t -> bool
-end
-
 (** This is an abstract type which represents a scope of a task. *)
 module Scope : sig
   type t
@@ -21,8 +12,8 @@ type t = private {
   id : string;
   pkg : Package.t;
 
-  buildCommands : CommandList.t;
-  installCommands : CommandList.t;
+  buildCommands : string list list;
+  installCommands : string list list;
 
   env : Environment.Closed.t;
   globalEnv : Environment.binding list;
@@ -37,7 +28,7 @@ type t = private {
   scope : Scope.t;
 }
 
-and paths = {
+and paths = private {
   rootPath : Config.Path.t;
   sourcePath : Config.Path.t;
   buildPath : Config.Path.t;

--- a/esy/Task.mli
+++ b/esy/Task.mli
@@ -35,7 +35,6 @@ type t = {
   platform : System.Platform.t;
   scope : Scope.t;
 }
-[@@deriving (show, eq, ord)]
 
 and paths = {
   rootPath : Config.Path.t;
@@ -46,13 +45,11 @@ and paths = {
   installPath : Config.Path.t;
   logPath : Config.Path.t;
 }
-[@@deriving show]
 
 and dependency =
   | Dependency of t
   | DevDependency of t
   | BuildTimeDependency of t
-[@@deriving (show, eq, ord)]
 
 (** Render expression in task scope. *)
 val renderExpression : cfg:Config.t -> task:t -> string -> string Run.t
@@ -82,6 +79,6 @@ val toBuildProtocolString : ?pretty:bool -> t -> string
 
 val rewritePrefix : cfg:Config.t -> origPrefix:Path.t -> destPrefix:Path.t -> Path.t -> unit RunAsync.t
 
-module DependencyGraph : DependencyGraph.DependencyGraph
+module Graph : DependencyGraph.DependencyGraph
   with type node := t
   and type dependency := dependency

--- a/esy/bin/esyCommand.ml
+++ b/esy/bin/esyCommand.ml
@@ -245,7 +245,7 @@ let withBuildTaskByPath
     let resolvedPath = packagePath |> Path.rem_empty_seg |> Path.to_string in
     let findByPath (task : Task.t) =
       String.equal resolvedPath task.pkg.id
-    in begin match Task.DependencyGraph.find ~f:findByPath info.task with
+    in begin match Task.Graph.find ~f:findByPath info.task with
       | None ->
         let msg = Printf.sprintf "No package found at %s" resolvedPath in
         error msg
@@ -506,7 +506,7 @@ let makeLsCommand ~computeTermNode ~includeTransitive cfg (info: SandboxInfo.t) 
     )
   in
 
-  match%bind Task.DependencyGraph.fold ~f ~init:(return None) info.task with
+  match%bind Task.Graph.fold ~f ~init:(return None) info.task with
   | Some tree -> return (print_endline (Esy.TermTree.toString tree))
   | None -> return ()
 
@@ -890,7 +890,7 @@ let () =
 
         let tasks =
           rootTask
-          |> Task.DependencyGraph.traverse ~traverse:dependenciesForExport
+          |> Task.Graph.traverse ~traverse:dependenciesForExport
           |> List.filter ~f:(fun (task : Task.t) -> not (task.id = rootTask.id))
         in
 
@@ -978,7 +978,7 @@ let () =
 
         let pkgs =
           rootTask
-          |> Task.DependencyGraph.traverse ~traverse:dependenciesForExport
+          |> Task.Graph.traverse ~traverse:dependenciesForExport
           |> List.filter ~f:(fun (task : Task.t) -> not (task.Task.id = rootTask.id))
         in
 

--- a/test-e2e/build/variables.test.js
+++ b/test-e2e/build/variables.test.js
@@ -1,0 +1,255 @@
+// @flow
+
+const outdent = require('outdent');
+const helpers = require('../test/helpers.js');
+const {file, dir, packageJson, createTestSandbox, ocamlPackage} = helpers;
+
+describe('Variables available for builds', () => {
+  it('provides esy variables via #{..} syntax', async () => {
+    const fixture = [
+      packageJson({
+        name: 'root',
+        version: '0.1.0',
+        dependencies: {
+          ocaml: '*',
+          dep: '*',
+        },
+        esy: {
+          buildsInSource: true,
+          build: [['ocamlopt', '-o', '#{self.bin/}hello.exe', './hello.ml']],
+          buildEnv: {
+            build_root_name: '#{self.name}',
+            build_root_version: '#{self.version}',
+            build_root_root: '#{self.root}',
+            build_root_original_root: '#{self.original_root}',
+            build_root_target_dir: '#{self.target_dir}',
+            build_root_install: '#{self.install}',
+            build_root_bin: '#{self.bin}',
+            build_root_sbin: '#{self.sbin}',
+            build_root_lib: '#{self.lib}',
+            build_root_man: '#{self.man}',
+            build_root_doc: '#{self.doc}',
+            build_root_stublibs: '#{self.stublibs}',
+            build_root_toplevel: '#{self.toplevel}',
+            build_root_share: '#{self.share}',
+            build_root_etc: '#{self.etc}',
+          },
+          exportedEnv: {
+            export_root_name: {val: '#{self.name}'},
+            export_root_version: {val: '#{self.version}'},
+            export_root_root: {val: '#{self.root}'},
+            export_root_original_root: {val: '#{self.original_root}'},
+            export_root_target_dir: {val: '#{self.target_dir}'},
+            export_root_install: {val: '#{self.install}'},
+            export_root_bin: {val: '#{self.bin}'},
+            export_root_sbin: {val: '#{self.sbin}'},
+            export_root_lib: {val: '#{self.lib}'},
+            export_root_man: {val: '#{self.man}'},
+            export_root_doc: {val: '#{self.doc}'},
+            export_root_stublibs: {val: '#{self.stublibs}'},
+            export_root_toplevel: {val: '#{self.toplevel}'},
+            export_root_share: {val: '#{self.share}'},
+            export_root_etc: {val: '#{self.etc}'},
+          },
+        },
+      }),
+      file(
+        'hello.ml',
+        outdent`
+
+          let var_names = [
+            "build_root_name";
+            "build_root_version";
+            "build_root_root";
+            "build_root_original_root";
+            "build_root_target_dir";
+            "build_root_install";
+            "build_root_bin";
+            "build_root_sbin";
+            "build_root_lib";
+            "build_root_man";
+            "build_root_doc";
+            "build_root_stublibs";
+            "build_root_toplevel";
+            "build_root_share";
+            "build_root_etc";
+            "build_dep_name";
+            "build_dep_version";
+            "build_dep_root";
+            "build_dep_original_root";
+            "build_dep_target_dir";
+            "build_dep_install";
+            "build_dep_bin";
+            "build_dep_sbin";
+            "build_dep_lib";
+            "build_dep_man";
+            "build_dep_doc";
+            "build_dep_stublibs";
+            "build_dep_toplevel";
+            "build_dep_share";
+            "build_dep_etc";
+            "export_root_name";
+            "export_root_version";
+            "export_root_root";
+            "export_root_original_root";
+            "export_root_target_dir";
+            "export_root_install";
+            "export_root_bin";
+            "export_root_sbin";
+            "export_root_lib";
+            "export_root_man";
+            "export_root_doc";
+            "export_root_stublibs";
+            "export_root_toplevel";
+            "export_root_share";
+            "export_root_etc";
+            "export_dep_name";
+            "export_dep_version";
+            "export_dep_root";
+            "export_dep_original_root";
+            "export_dep_target_dir";
+            "export_dep_install";
+            "export_dep_bin";
+            "export_dep_sbin";
+            "export_dep_lib";
+            "export_dep_man";
+            "export_dep_doc";
+            "export_dep_stublibs";
+            "export_dep_toplevel";
+            "export_dep_share";
+            "export_dep_etc";
+          ]
+
+          let () =
+            let f name =
+              let v =
+                match Sys.getenv_opt name with
+                | Some v -> v
+                | None -> "<novalue>"
+              in
+              print_endline (name ^ "=" ^ v)
+            in
+            List.iter f var_names
+        `,
+      ),
+      dir(
+        'node_modules',
+        ocamlPackage(),
+        dir(
+          'dep',
+          packageJson({
+            name: 'dep',
+            version: '0.2.0',
+            esy: {
+              buildsInSource: true,
+              build: 'true',
+              buildEnv: {
+                build_dep_name: '#{self.name}',
+                build_dep_version: '#{self.version}',
+                build_dep_root: '#{self.root}',
+                build_dep_original_root: '#{self.original_root}',
+                build_dep_target_dir: '#{self.target_dir}',
+                build_dep_install: '#{self.install}',
+                build_dep_bin: '#{self.bin}',
+                build_dep_sbin: '#{self.sbin}',
+                build_dep_lib: '#{self.lib}',
+                build_dep_man: '#{self.man}',
+                build_dep_doc: '#{self.doc}',
+                build_dep_stublibs: '#{self.stublibs}',
+                build_dep_toplevel: '#{self.toplevel}',
+                build_dep_share: '#{self.share}',
+                build_dep_etc: '#{self.etc}',
+              },
+              exportedEnv: {
+                export_dep_name: {val: '#{self.name}', scope: 'global'},
+                export_dep_version: {val: '#{self.version}', scope: 'global'},
+                export_dep_root: {val: '#{self.root}', scope: 'global'},
+                export_dep_original_root: {val: '#{self.original_root}', scope: 'global'},
+                export_dep_target_dir: {val: '#{self.target_dir}', scope: 'global'},
+                export_dep_install: {val: '#{self.install}', scope: 'global'},
+                export_dep_bin: {val: '#{self.bin}', scope: 'global'},
+                export_dep_sbin: {val: '#{self.sbin}', scope: 'global'},
+                export_dep_lib: {val: '#{self.lib}', scope: 'global'},
+                export_dep_man: {val: '#{self.man}', scope: 'global'},
+                export_dep_doc: {val: '#{self.doc}', scope: 'global'},
+                export_dep_stublibs: {val: '#{self.stublibs}', scope: 'global'},
+                export_dep_toplevel: {val: '#{self.toplevel}', scope: 'global'},
+                export_dep_share: {val: '#{self.share}', scope: 'global'},
+                export_dep_etc: {val: '#{self.etc}', scope: 'global'},
+              },
+            },
+          }),
+        ),
+      ),
+    ];
+    const p = await createTestSandbox(...fixture);
+    await p.esy('build');
+
+    const rootId = JSON.parse((await p.esy('build-plan')).stdout).id;
+    const depId = JSON.parse((await p.esy('build-plan ./node_modules/dep')).stdout).id;
+
+    const {stdout} = await p.esy('x hello.exe');
+    expect(stdout.trim()).toEqual(outdent`
+build_root_name=<novalue>
+build_root_version=<novalue>
+build_root_root=<novalue>
+build_root_original_root=<novalue>
+build_root_target_dir=<novalue>
+build_root_install=<novalue>
+build_root_bin=<novalue>
+build_root_sbin=<novalue>
+build_root_lib=<novalue>
+build_root_man=<novalue>
+build_root_doc=<novalue>
+build_root_stublibs=<novalue>
+build_root_toplevel=<novalue>
+build_root_share=<novalue>
+build_root_etc=<novalue>
+build_dep_name=<novalue>
+build_dep_version=<novalue>
+build_dep_root=<novalue>
+build_dep_original_root=<novalue>
+build_dep_target_dir=<novalue>
+build_dep_install=<novalue>
+build_dep_bin=<novalue>
+build_dep_sbin=<novalue>
+build_dep_lib=<novalue>
+build_dep_man=<novalue>
+build_dep_doc=<novalue>
+build_dep_stublibs=<novalue>
+build_dep_toplevel=<novalue>
+build_dep_share=<novalue>
+build_dep_etc=<novalue>
+export_root_name=root
+export_root_version=0.1.0
+export_root_root=${p.projectPath}/node_modules/.cache/_esy/store/b/${rootId}
+export_root_original_root=${p.projectPath}
+export_root_target_dir=${p.projectPath}/node_modules/.cache/_esy/store/b/${rootId}
+export_root_install=${p.projectPath}/node_modules/.cache/_esy/store/i/${rootId}
+export_root_bin=${p.projectPath}/node_modules/.cache/_esy/store/i/${rootId}/bin
+export_root_sbin=${p.projectPath}/node_modules/.cache/_esy/store/i/${rootId}/sbin
+export_root_lib=${p.projectPath}/node_modules/.cache/_esy/store/i/${rootId}/lib
+export_root_man=${p.projectPath}/node_modules/.cache/_esy/store/i/${rootId}/man
+export_root_doc=${p.projectPath}/node_modules/.cache/_esy/store/i/${rootId}/doc
+export_root_stublibs=${p.projectPath}/node_modules/.cache/_esy/store/i/${rootId}/stublibs
+export_root_toplevel=${p.projectPath}/node_modules/.cache/_esy/store/i/${rootId}/toplevel
+export_root_share=${p.projectPath}/node_modules/.cache/_esy/store/i/${rootId}/share
+export_root_etc=${p.projectPath}/node_modules/.cache/_esy/store/i/${rootId}/etc
+export_dep_name=dep
+export_dep_version=0.2.0
+export_dep_root=${p.projectPath}/node_modules/.cache/_esy/store/b/${depId}
+export_dep_original_root=${p.projectPath}/node_modules/dep
+export_dep_target_dir=${p.projectPath}/node_modules/.cache/_esy/store/b/${depId}
+export_dep_install=${p.projectPath}/node_modules/.cache/_esy/store/i/${depId}
+export_dep_bin=${p.projectPath}/node_modules/.cache/_esy/store/i/${depId}/bin
+export_dep_sbin=${p.projectPath}/node_modules/.cache/_esy/store/i/${depId}/sbin
+export_dep_lib=${p.projectPath}/node_modules/.cache/_esy/store/i/${depId}/lib
+export_dep_man=${p.projectPath}/node_modules/.cache/_esy/store/i/${depId}/man
+export_dep_doc=${p.projectPath}/node_modules/.cache/_esy/store/i/${depId}/doc
+export_dep_stublibs=${p.projectPath}/node_modules/.cache/_esy/store/i/${depId}/stublibs
+export_dep_toplevel=${p.projectPath}/node_modules/.cache/_esy/store/i/${depId}/toplevel
+export_dep_share=${p.projectPath}/node_modules/.cache/_esy/store/i/${depId}/share
+export_dep_etc=${p.projectPath}/node_modules/.cache/_esy/store/i/${depId}/etc
+    `);
+  });
+});

--- a/test-e2e/build/variables.test.js
+++ b/test-e2e/build/variables.test.js
@@ -1,5 +1,6 @@
 // @flow
 
+const path = require('path');
 const outdent = require('outdent');
 const helpers = require('../test/helpers.js');
 const {file, dir, packageJson, createTestSandbox, ocamlPackage} = helpers;
@@ -222,34 +223,244 @@ build_dep_share=<novalue>
 build_dep_etc=<novalue>
 export_root_name=root
 export_root_version=0.1.0
-export_root_root=${p.projectPath}/node_modules/.cache/_esy/store/b/${rootId}
+export_root_root=${path.join(
+      p.projectPath,
+      'node_modules',
+      '.cache',
+      '_esy',
+      'store',
+      'b',
+      rootId,
+    )}
 export_root_original_root=${p.projectPath}
-export_root_target_dir=${p.projectPath}/node_modules/.cache/_esy/store/b/${rootId}
-export_root_install=${p.projectPath}/node_modules/.cache/_esy/store/i/${rootId}
-export_root_bin=${p.projectPath}/node_modules/.cache/_esy/store/i/${rootId}/bin
-export_root_sbin=${p.projectPath}/node_modules/.cache/_esy/store/i/${rootId}/sbin
-export_root_lib=${p.projectPath}/node_modules/.cache/_esy/store/i/${rootId}/lib
-export_root_man=${p.projectPath}/node_modules/.cache/_esy/store/i/${rootId}/man
-export_root_doc=${p.projectPath}/node_modules/.cache/_esy/store/i/${rootId}/doc
-export_root_stublibs=${p.projectPath}/node_modules/.cache/_esy/store/i/${rootId}/stublibs
-export_root_toplevel=${p.projectPath}/node_modules/.cache/_esy/store/i/${rootId}/toplevel
-export_root_share=${p.projectPath}/node_modules/.cache/_esy/store/i/${rootId}/share
-export_root_etc=${p.projectPath}/node_modules/.cache/_esy/store/i/${rootId}/etc
+export_root_target_dir=${path.join(
+      p.projectPath,
+      'node_modules',
+      '.cache',
+      '_esy',
+      'store',
+      'b',
+      rootId,
+    )}
+export_root_install=${path.join(
+      p.projectPath,
+      'node_modules',
+      '.cache',
+      '_esy',
+      'store',
+      'i',
+      rootId,
+    )}
+export_root_bin=${path.join(
+      p.projectPath,
+      'node_modules',
+      '.cache',
+      '_esy',
+      'store',
+      'i',
+      rootId,
+      'bin',
+    )}
+export_root_sbin=${path.join(
+      p.projectPath,
+      'node_modules',
+      '.cache',
+      '_esy',
+      'store',
+      'i',
+      rootId,
+      'sbin',
+    )}
+export_root_lib=${path.join(
+      p.projectPath,
+      'node_modules',
+      '.cache',
+      '_esy',
+      'store',
+      'i',
+      rootId,
+      'lib',
+    )}
+export_root_man=${path.join(
+      p.projectPath,
+      'node_modules',
+      '.cache',
+      '_esy',
+      'store',
+      'i',
+      rootId,
+      'man',
+    )}
+export_root_doc=${path.join(
+      p.projectPath,
+      'node_modules',
+      '.cache',
+      '_esy',
+      'store',
+      'i',
+      rootId,
+      'doc',
+    )}
+export_root_stublibs=${path.join(
+      p.projectPath,
+      'node_modules',
+      '.cache',
+      '_esy',
+      'store',
+      'i',
+      rootId,
+      'stublibs',
+    )}
+export_root_toplevel=${path.join(
+      p.projectPath,
+      'node_modules',
+      '.cache',
+      '_esy',
+      'store',
+      'i',
+      rootId,
+      'toplevel',
+    )}
+export_root_share=${path.join(
+      p.projectPath,
+      'node_modules',
+      '.cache',
+      '_esy',
+      'store',
+      'i',
+      rootId,
+      'share',
+    )}
+export_root_etc=${path.join(
+      p.projectPath,
+      'node_modules',
+      '.cache',
+      '_esy',
+      'store',
+      'i',
+      rootId,
+      'etc',
+    )}
 export_dep_name=dep
 export_dep_version=0.2.0
-export_dep_root=${p.projectPath}/node_modules/.cache/_esy/store/b/${depId}
-export_dep_original_root=${p.projectPath}/node_modules/dep
-export_dep_target_dir=${p.projectPath}/node_modules/.cache/_esy/store/b/${depId}
-export_dep_install=${p.projectPath}/node_modules/.cache/_esy/store/i/${depId}
-export_dep_bin=${p.projectPath}/node_modules/.cache/_esy/store/i/${depId}/bin
-export_dep_sbin=${p.projectPath}/node_modules/.cache/_esy/store/i/${depId}/sbin
-export_dep_lib=${p.projectPath}/node_modules/.cache/_esy/store/i/${depId}/lib
-export_dep_man=${p.projectPath}/node_modules/.cache/_esy/store/i/${depId}/man
-export_dep_doc=${p.projectPath}/node_modules/.cache/_esy/store/i/${depId}/doc
-export_dep_stublibs=${p.projectPath}/node_modules/.cache/_esy/store/i/${depId}/stublibs
-export_dep_toplevel=${p.projectPath}/node_modules/.cache/_esy/store/i/${depId}/toplevel
-export_dep_share=${p.projectPath}/node_modules/.cache/_esy/store/i/${depId}/share
-export_dep_etc=${p.projectPath}/node_modules/.cache/_esy/store/i/${depId}/etc
+export_dep_root=${path.join(
+      p.projectPath,
+      'node_modules',
+      '.cache',
+      '_esy',
+      'store',
+      'b',
+      depId,
+    )}
+export_dep_original_root=${path.join(p.projectPath, 'node_modules', 'dep')}
+export_dep_target_dir=${path.join(
+      p.projectPath,
+      'node_modules',
+      '.cache',
+      '_esy',
+      'store',
+      'b',
+      depId,
+    )}
+export_dep_install=${path.join(
+      p.projectPath,
+      'node_modules',
+      '.cache',
+      '_esy',
+      'store',
+      'i',
+      depId,
+    )}
+export_dep_bin=${path.join(
+      p.projectPath,
+      'node_modules',
+      '.cache',
+      '_esy',
+      'store',
+      'i',
+      depId,
+      'bin',
+    )}
+export_dep_sbin=${path.join(
+      p.projectPath,
+      'node_modules',
+      '.cache',
+      '_esy',
+      'store',
+      'i',
+      depId,
+      'sbin',
+    )}
+export_dep_lib=${path.join(
+      p.projectPath,
+      'node_modules',
+      '.cache',
+      '_esy',
+      'store',
+      'i',
+      depId,
+      'lib',
+    )}
+export_dep_man=${path.join(
+      p.projectPath,
+      'node_modules',
+      '.cache',
+      '_esy',
+      'store',
+      'i',
+      depId,
+      'man',
+    )}
+export_dep_doc=${path.join(
+      p.projectPath,
+      'node_modules',
+      '.cache',
+      '_esy',
+      'store',
+      'i',
+      depId,
+      'doc',
+    )}
+export_dep_stublibs=${path.join(
+      p.projectPath,
+      'node_modules',
+      '.cache',
+      '_esy',
+      'store',
+      'i',
+      depId,
+      'stublibs',
+    )}
+export_dep_toplevel=${path.join(
+      p.projectPath,
+      'node_modules',
+      '.cache',
+      '_esy',
+      'store',
+      'i',
+      depId,
+      'toplevel',
+    )}
+export_dep_share=${path.join(
+      p.projectPath,
+      'node_modules',
+      '.cache',
+      '_esy',
+      'store',
+      'i',
+      depId,
+      'share',
+    )}
+export_dep_etc=${path.join(
+      p.projectPath,
+      'node_modules',
+      '.cache',
+      '_esy',
+      'store',
+      'i',
+      depId,
+      'etc',
+    )}
     `);
   });
 });

--- a/test-e2e/build/variables.test.js
+++ b/test-e2e/build/variables.test.js
@@ -3,7 +3,16 @@
 const path = require('path');
 const outdent = require('outdent');
 const helpers = require('../test/helpers.js');
-const {file, dir, packageJson, createTestSandbox, ocamlPackage} = helpers;
+const {
+  file,
+  dir,
+  packageJson,
+  createTestSandbox,
+  ocamlPackage,
+  skipSuiteOnWindows,
+} = helpers;
+
+skipSuiteOnWindows('mixed slashes and backslashes in paths');
 
 describe('Variables available for builds', () => {
   it('provides esy variables via #{..} syntax', async () => {

--- a/test-e2e/build/variables.test.js
+++ b/test-e2e/build/variables.test.js
@@ -143,7 +143,6 @@ describe('Variables available for builds', () => {
             version: '0.2.0',
             esy: {
               buildsInSource: true,
-              build: 'true',
               buildEnv: {
                 build_dep_name: '#{self.name}',
                 build_dep_version: '#{self.version}',

--- a/test-e2e/common/anycmd.test.js
+++ b/test-e2e/common/anycmd.test.js
@@ -4,12 +4,7 @@ const path = require('path');
 const fs = require('fs-extra');
 const os = require('os');
 
-const {
-  createTestSandbox,
-  promiseExec,
-  ESYCOMMAND,
-  skipSuiteOnWindows,
-} = require('../test/helpers');
+const {createTestSandbox, skipSuiteOnWindows} = require('../test/helpers');
 const fixture = require('./fixture.js');
 
 skipSuiteOnWindows();
@@ -64,9 +59,7 @@ describe('Common - anycmd', () => {
     await fs.writeFile(path.join(p.projectPath, 'subdir', 'X'), '');
 
     await expect(
-      promiseExec(`${ESYCOMMAND} ls -1`, {
-        cwd: path.join(p.projectPath, 'subdir'),
-      }),
+      p.esy('ls -1', {cwd: path.join(p.projectPath, 'subdir')}),
     ).resolves.toEqual(expect.objectContaining({stdout: 'X\n'}));
   });
 });

--- a/test-e2e/common/symlink-workflow.test.js
+++ b/test-e2e/common/symlink-workflow.test.js
@@ -118,9 +118,8 @@ describe('Common - symlink workflow', () => {
     p = await createTestSandbox(...fixture);
 
     appEsy = args =>
-      promiseExec(`${ESYCOMMAND} ${args}`, {
-        cwd: path.resolve(p.projectPath, 'app'),
-        env: {...process.env, ESY__PREFIX: p.esyPrefixPath},
+      p.esy(`${args}`, {
+        cwd: path.join(p.projectPath, 'app'),
       });
 
     await appEsy('install');

--- a/test-e2e/common/x-anycmd.test.js
+++ b/test-e2e/common/x-anycmd.test.js
@@ -3,12 +3,7 @@
 const path = require('path');
 const fs = require('fs-extra');
 
-const {
-  createTestSandbox,
-  promiseExec,
-  ESYCOMMAND,
-  skipSuiteOnWindows,
-} = require('../test/helpers');
+const {createTestSandbox, skipSuiteOnWindows} = require('../test/helpers');
 const fixture = require('./fixture.js');
 
 skipSuiteOnWindows();
@@ -71,9 +66,7 @@ describe('Common - x anycmd', () => {
     await fs.writeFile(path.join(p.projectPath, 'subdir', 'X'), '');
 
     await expect(
-      promiseExec(`${ESYCOMMAND} x ls -1`, {
-        cwd: path.join(p.projectPath, 'subdir'),
-      }),
+      p.esy('x ls -1', {cwd: path.join(p.projectPath, 'subdir')}),
     ).resolves.toEqual(expect.objectContaining({stdout: 'X\n'}));
   });
 });

--- a/test-e2e/test/helpers.js
+++ b/test-e2e/test/helpers.js
@@ -91,7 +91,7 @@ export type TestSandbox = {
 async function createTestSandbox(...fixture: Fixture): Promise<TestSandbox> {
   // use /tmp on unix b/c sometimes it's too long to host the esy store
   const tmp = isWindows ? os.tmpdir() : '/tmp';
-  const rootPath = await fs.mkdtemp(path.join(tmp, 'XXXX'));
+  const rootPath = await fs.realpath(await fs.mkdtemp(path.join(tmp, 'XXXX')));
   const projectPath = path.join(rootPath, 'project');
   const binPath = path.join(rootPath, 'bin');
   const npmPrefixPath = path.join(rootPath, 'npm');

--- a/test-e2e/test/helpers.js
+++ b/test-e2e/test/helpers.js
@@ -53,7 +53,7 @@ export type TestSandbox = {
   run: (args: string) => Promise<{stderr: string, stdout: string}>,
   esy: (
     args?: string,
-    options: ?{noEsyPrefix?: boolean, env?: Object},
+    options: ?{noEsyPrefix?: boolean, env?: Object, p?: string},
   ) => Promise<{stderr: string, stdout: string}>,
   npm: (args: string) => Promise<{stderr: string, stdout: string}>,
 
@@ -118,6 +118,10 @@ async function createTestSandbox(...fixture: Fixture): Promise<TestSandbox> {
     if (options.env != null) {
       env = {...env, ...options.env};
     }
+    let cwd = projectPath;
+    if (options.cwd != null) {
+      cwd = options.cwd;
+    }
     if (!options.noEsyPrefix) {
       env = {
         ...env,
@@ -130,10 +134,7 @@ async function createTestSandbox(...fixture: Fixture): Promise<TestSandbox> {
     }
 
     const execCommand = args != null ? `${ESYCOMMAND} ${args}` : ESYCOMMAND;
-    return promiseExec(execCommand, {
-      cwd: projectPath,
-      env,
-    });
+    return promiseExec(execCommand, {cwd, env});
   }
 
   function npm(args: string) {

--- a/test/Task.ml
+++ b/test/Task.ml
@@ -23,8 +23,8 @@ module TestCommandExpr = struct
     version = "1.0.0";
     dependencies = [];
     build = Package.EsyBuild {
-      buildCommands = None;
-      installCommands = None;
+      buildCommands = Manifest.EsyCommands None;
+      installCommands = Manifest.EsyCommands None;
       buildType = Manifest.BuildType.InSource;
     };
     sourceType = Manifest.SourceType.Immutable;
@@ -56,11 +56,13 @@ module TestCommandExpr = struct
     version = "1.0.0";
     dependencies = [Dependency dep];
     build = Package.EsyBuild {
-      buildCommands = Some [
+      buildCommands = Manifest.EsyCommands (Some [
         Manifest.CommandList.Command.Unparsed "cp ./hello #{self.bin}";
         Manifest.CommandList.Command.Unparsed "cp ./hello2 #{pkg.bin}";
-      ];
-      installCommands = Some [Manifest.CommandList.Command.Parsed ["cp"; "./man"; "#{self.man}"]];
+      ]);
+      installCommands = Manifest.EsyCommands (Some [
+        Manifest.CommandList.Command.Parsed ["cp"; "./man"; "#{self.man}"]
+      ]);
       buildType = Manifest.BuildType.InSource;
     };
     sourceType = Manifest.SourceType.Immutable;
@@ -94,12 +96,12 @@ module TestCommandExpr = struct
     let pkg = Package.{
       pkg with
       build = Package.EsyBuild {
-        buildCommands = Some [
+        buildCommands = Manifest.EsyCommands (Some [
           Manifest.CommandList.Command.Unparsed "#{os == 'linux' ? 'apt-get install pkg' : 'true'}";
-        ];
-        installCommands = Some [
+        ]);
+        installCommands = Manifest.EsyCommands (Some [
           Manifest.CommandList.Command.Unparsed "make #{os == 'linux' ? 'install-linux' : 'install'}";
-        ];
+        ]);
         buildType = Manifest.BuildType.InSource;
       }
     } in

--- a/test/dune
+++ b/test/dune
@@ -3,6 +3,6 @@
   (library_flags (-linkall))
   (libraries Esy EsyLib ppx_inline_test.runtime-lib)
   (modules (:standard))
-  (preprocess (pps lwt_ppx ppx_let ppx_inline_test ppxlib.runner))
+  (preprocess (pps lwt_ppx ppx_let ppx_inline_test ppxlib.runner ppx_deriving.std))
   )
 


### PR DESCRIPTION
We have opam/esy variants spread over `esy` codebase, this PR attempts to unify opam and esy as soon as possible — at `Manifest.t`.