### PR TITLE
[WIP] Windows - esyi: Use forked OPAM repo on Windows for esyi

### DIFF
--- a/esyi/Config.re
+++ b/esyi/Config.re
@@ -37,7 +37,6 @@ let make =
       ~cacheTarballsPath=?,
       ~opamRepository=?,
       ~esyOpamOverride=?,
-      ~platform=System.Platform.host,
       ~solveTimeout=60.0,
       ~esySolveCmd,
       ~createProgressReporter,

--- a/esyi/Config.re
+++ b/esyi/Config.re
@@ -37,6 +37,7 @@ let make =
       ~cacheTarballsPath=?,
       ~opamRepository=?,
       ~esyOpamOverride=?,
+      ~platform=System.Platform.host,
       ~solveTimeout=60.0,
       ~esySolveCmd,
       ~createProgressReporter,
@@ -67,7 +68,11 @@ let make =
       let opamArchivesIndexPath = Path.(cachePath / "opam-urls.txt");
 
       let opamRepository = {
-        let defaultRemote = "https://github.com/ocaml/opam-repository";
+        let defaultRemote =
+            switch (System.Platform.host) {
+            | Windows => "https://github.com/fdopen/opam-repository-mingw"
+            | _ => "https://github.com/ocaml/opam-repository"
+            };
         let defaultLocal = Path.(cachePath / "opam-repository");
         configureCheckout(~defaultLocal, ~defaultRemote, opamRepository);
       };


### PR DESCRIPTION
The forked OPAM repository here: https://github.com/fdopen/opam-repository-mingw has windows-specific patches and fixes for popular packages, making this more reliable for windows builds.