### PR TITLE
Specify error and context in Run/RunAsync monads with formatters

### DIFF
--- a/esy-build-package/Build.re
+++ b/esy-build-package/Build.re
@@ -311,14 +311,7 @@ module Installer =
         | Ok(stats) => Run.return(`Stats(stats))
         | Error((Unix.ENOENT, _call, _msg)) => Run.return(`DoesNotExist)
         | Error((errno, _call, _msg)) =>
-          let msg =
-            Format.asprintf(
-              "stat %a: %s",
-              Path.pp,
-              path,
-              Unix.error_message(errno),
-            );
-          Run.error(msg);
+          Run.errorf("stat %a: %s", Path.pp, path, Unix.error_message(errno))
         };
       let readdir = Run.ls;
       let mkdir = Run.mkdir;

--- a/esy-build-package/PathSyntax.re
+++ b/esy-build-package/PathSyntax.re
@@ -21,11 +21,9 @@ let renderExn = (env: env, path: string) => {
 let render = (env: env, path: string) =>
   try (Ok(renderExn(env, path))) {
   | UnknownPathVariable(name) =>
-    let msg =
-      Printf.sprintf(
-        "unable to render path: '%s' because of unknown variable %s",
-        path,
-        name,
-      );
-    Error(`Msg(msg));
+    Run.errorf(
+      "unable to render path: '%s' because of unknown variable %s",
+      path,
+      name,
+    )
   };

--- a/esy-build-package/PathSyntax.rei
+++ b/esy-build-package/PathSyntax.rei
@@ -9,7 +9,7 @@
 type env = string => option(string);
 
 /** Render string using env. */
-let render : (env, string) => result(string, [> `Msg(string) ])
+let render : (env, string) => Run.t(string, 'e)
 
 exception UnknownPathVariable(string);
 

--- a/esy-build-package/Run.re
+++ b/esy-build-package/Run.re
@@ -17,6 +17,11 @@ let ok = Result.ok;
 let return = v => Ok(v);
 let error = msg => Error(`Msg(msg));
 
+let errorf = fmt => {
+  let kerr = _ => Error(`Msg(Format.flush_str_formatter()));
+  Format.kfprintf(kerr, Format.str_formatter, fmt);
+};
+
 let v = Fpath.v;
 let (/) = Fpath.(/);
 

--- a/esy-build-package/Run.rei
+++ b/esy-build-package/Run.rei
@@ -15,6 +15,7 @@ type t('v, 'e) = result('v, err('e));
 
 let return : 'v => t('v, _);
 let error : string => t(_, _);
+let errorf : format4('a, Format.formatter, unit, t('v, 'e)) => 'a
 let bind : (~f: 'a => result('b, 'c), result('a, 'c)) => result('b, 'c)
 let coerceFromMsgOnly : result('a, [ `Msg(string) ]) => t('a, _);
 let coerceFromClosed : result('a, [ `Msg(string) | `CommandError(Cmd.t, Bos.OS.Cmd.status) ]) => t('a, _);

--- a/esy-lib/Curl.ml
+++ b/esy-lib/Curl.ml
@@ -44,19 +44,13 @@ let runCurl cmd =
       | Ok (_stdout, meta) when meta.Meta.code = 404 ->
         RunAsync.return NotFound
       | Ok (_stdout, meta) ->
-        let msg =
-          Format.asprintf
-            "@[<v>error running curl: %a:@\ncode: %i@\nstderr:@[<v 2>@\n%a@]@]"
-            Cmd.pp cmd meta.code Fmt.lines stderr
-        in
-        RunAsync.error msg
+        RunAsync.errorf
+          "@[<v>error running curl: %a:@\ncode: %i@\nstderr:@[<v 2>@\n%a@]@]"
+          Cmd.pp cmd meta.code Fmt.lines stderr
       | _ ->
-        let msg =
-          Format.asprintf
-            "@[<v>error running curl: %a:@\nstderr:@[<v 2>@\n%a@]@]"
-            Cmd.pp cmd Fmt.lines stderr
-        in
-        RunAsync.error msg
+        RunAsync.errorf
+          "@[<v>error running curl: %a:@\nstderr:@[<v 2>@\n%a@]@]"
+          Cmd.pp cmd Fmt.lines stderr
     end
   in
   try%lwt

--- a/esy-lib/Fs.ml
+++ b/esy-lib/Fs.ml
@@ -32,9 +32,7 @@ let readJsonFile (path : Path.t) =
   let%bind data = readFile path in
   try return (Yojson.Safe.from_string data)
   with Yojson.Json_error msg ->
-    let msg = Format.asprintf
-      "error reading JSON file: %a@\n%s" Path.pp path msg
-    in error msg
+    errorf "error reading JSON file: %a@\n%s" Path.pp path msg
 
 let writeJsonFile ~json path =
   let data = Yojson.Safe.pretty_to_string json in

--- a/esy-lib/Git.ml
+++ b/esy-lib/Git.ml
@@ -11,12 +11,9 @@ let runGit cmd =
     | Unix.WEXITED 0 ->
       RunAsync.return ()
     | _ ->
-      let msg =
-        Format.asprintf
-          "@[<v>command failed: %a@\nstderr:@[<v 2>@\n%a@]@\nstdout:@[<v 2>@\n%a@]@]"
-          Cmd.pp cmd Fmt.lines stderr Fmt.lines stdout
-      in
-      RunAsync.error msg
+      RunAsync.errorf
+        "@[<v>command failed: %a@\nstderr:@[<v 2>@\n%a@]@\nstdout:@[<v 2>@\n%a@]@]"
+        Cmd.pp cmd Fmt.lines stderr Fmt.lines stdout
   in
   try%lwt
     let cmd = Cmd.getToolAndLine cmd in

--- a/esy-lib/Run.ml
+++ b/esy-lib/Run.ml
@@ -39,11 +39,6 @@ let contextf v fmt =
   let kerr _ = context v (Format.flush_str_formatter ()) in
   Format.kfprintf kerr Format.str_formatter fmt
 
-let withContext line v =
-  match v with
-  | Ok v -> Ok v
-  | Error (msg, context) -> Error (msg, (Line line)::context)
-
 let bind ~f v = match v with
   | Ok v -> f v
   | Error err -> Error err

--- a/esy-lib/Run.mli
+++ b/esy-lib/Run.mli
@@ -31,11 +31,6 @@ val context : 'v t -> string -> 'v t
 val contextf : 'v t -> ('a, Format.formatter, unit, 'v t) format4 -> 'a
 
 (**
- * Same as [context] but with order of arguments swapped.
- *)
-val withContext : string -> 'a t -> 'a t
-
-(**
  * Wrap computation with a context which will be reported in case of error
  *)
 val withContextOfLog : ?header:string -> string -> 'a t -> 'a t

--- a/esy-lib/Run.mli
+++ b/esy-lib/Run.mli
@@ -1,18 +1,37 @@
 (**
  * A computation which might result in an error.
  *)
-type 'a t = ('a, error) result
+type 'v t = ('v, error) result
 
 and error
 
-val return : 'a -> 'a t
+(**
+ * Failied computation with an error specified by a message.
+ *)
+val return : 'v -> 'v t
 
-val error : string -> 'a t
+(**
+ * Failied computation with an error specified by a message.
+ *)
+val error : string -> 'v t
 
-val ppError : error Fmt.t
+(**
+ * Same with [error] but defined with a formatted string.
+ *)
+val errorf : ('a, Format.formatter, unit, 'v t) format4 -> 'a
 
 (**
  * Wrap computation with a context which will be reported in case of error
+ *)
+val context : 'v t -> string -> 'v t
+
+(**
+ * Same as [context] but defined with a formatter.
+ *)
+val contextf : 'v t -> ('a, Format.formatter, unit, 'v t) format4 -> 'a
+
+(**
+ * Same as [context] but with order of arguments swapped.
  *)
 val withContext : string -> 'a t -> 'a t
 
@@ -25,6 +44,8 @@ val withContextOfLog : ?header:string -> string -> 'a t -> 'a t
  * Format error.
  *)
 val formatError : error -> string
+
+val ppError : error Fmt.t
 
 (**
  * Run computation and raise an exception in case of failure.
@@ -60,6 +81,7 @@ module Syntax : sig
 
   val return : 'a -> 'a t
   val error : string -> 'a t
+  val errorf : ('a, Format.formatter, unit, 'v t) format4 -> 'a
 
   module Let_syntax : sig
     val bind : f:('a -> 'b t) -> 'a t -> 'b t

--- a/esy-lib/RunAsync.ml
+++ b/esy-lib/RunAsync.ml
@@ -5,6 +5,18 @@ let return v = Lwt.return (Ok v)
 let error msg =
   Lwt.return (Run.error msg)
 
+let errorf fmt =
+  let kerr _ = Lwt.return (Run.error (Format.flush_str_formatter ())) in
+  Format.kfprintf kerr Format.str_formatter fmt
+
+let context v msg =
+  let%lwt v = v in
+  Lwt.return (Run.withContext msg v)
+
+let contextf v fmt =
+  let kerr _ = context v (Format.flush_str_formatter ()) in
+  Format.kfprintf kerr Format.str_formatter fmt
+
 let withContext msg v =
   let%lwt v = v in
   Lwt.return (Run.withContext msg v)
@@ -37,6 +49,7 @@ let ofBosError r = ofRun (Run.ofBosError r)
 module Syntax = struct
   let return = return
   let error = error
+  let errorf = errorf
 
   module Let_syntax = struct
     let bind = bind

--- a/esy-lib/RunAsync.ml
+++ b/esy-lib/RunAsync.ml
@@ -11,15 +11,11 @@ let errorf fmt =
 
 let context v msg =
   let%lwt v = v in
-  Lwt.return (Run.withContext msg v)
+  Lwt.return (Run.context v msg)
 
 let contextf v fmt =
   let kerr _ = context v (Format.flush_str_formatter ()) in
   Format.kfprintf kerr Format.str_formatter fmt
-
-let withContext msg v =
-  let%lwt v = v in
-  Lwt.return (Run.withContext msg v)
 
 let withContextOfLog ?header content v =
   let%lwt v = v in

--- a/esy-lib/RunAsync.mli
+++ b/esy-lib/RunAsync.mli
@@ -30,21 +30,6 @@ val context : 'v t -> string -> 'v t
 val contextf : 'v t -> ('a, Format.formatter, unit, 'v t) format4 -> 'a
 
 (**
- * Wrap computation with a context which will be reported in case of error.
- *
- * Example usage:
- *
- *   let build = withContext "building ocaml" build in ...
- *
- * In case build fails the error message would look like:
- *
- *   Error: command not found aclocal
- *     While building ocaml
- *
- *)
-val withContext : string -> 'a t -> 'a t
-
-(**
  * Same as with the [withContext] but will be formatted as differently, as a
  * single block of text.
  *)

--- a/esy-lib/RunAsync.mli
+++ b/esy-lib/RunAsync.mli
@@ -15,6 +15,21 @@ val return : 'a -> 'a t
 val error : string -> 'a t
 
 (**
+ * Same with [error] but defined with a formatted string.
+ *)
+val errorf : ('a, Format.formatter, unit, 'v t) format4 -> 'a
+
+(**
+ * Wrap computation with a context which will be reported in case of error
+ *)
+val context : 'v t -> string -> 'v t
+
+(**
+ * Same as [context] but defined with a formatter.
+ *)
+val contextf : 'v t -> ('a, Format.formatter, unit, 'v t) format4 -> 'a
+
+(**
  * Wrap computation with a context which will be reported in case of error.
  *
  * Example usage:
@@ -84,6 +99,7 @@ module Syntax : sig
   val return : 'a -> 'a t
 
   val error : string -> 'a t
+  val errorf : ('a, Format.formatter, unit, 'v t) format4 -> 'a
 
   module Let_syntax : sig
     val bind : f:('a -> 'b t) -> 'a t -> 'b t

--- a/esy/Build.ml
+++ b/esy/Build.ml
@@ -13,9 +13,11 @@ let buildTask ?(quiet=false) ?force ?stderrout ~buildOnly cfg (task : Task.t) =
       then Logs_lwt.app(fun m -> m "%s: starting" context)
       else Lwt.return ()
     in
-    let%bind () = RunAsync.withContext context (
-      PackageBuilder.build ~quiet ?stderrout ?force ~buildOnly cfg task
-    ) in
+    let%bind () =
+      RunAsync.context (
+        PackageBuilder.build ~quiet ?stderrout ?force ~buildOnly cfg task
+      ) context
+    in
     let%lwt () = if not quiet
       then Logs_lwt.app(fun m -> m "%s: complete" context)
       else Lwt.return ()

--- a/esyi/Fetch.ml
+++ b/esyi/Fetch.ml
@@ -695,13 +695,10 @@ let fetch ~(sandbox : Sandbox.t) (solution : Solution.t) =
 
     let%bind installed =
       let install installation =
-        let msg =
-          Format.asprintf
-            "installing %a"
-            Layout.pp_installation installation
-        in
-        LwtTaskQueue.submit queue (f installation)
-        |> RunAsync.withContext msg
+        RunAsync.contextf
+          (LwtTaskQueue.submit queue (f installation))
+          "installing %a"
+          Layout.pp_installation installation
       in
       layout
       |> List.map ~f:install
@@ -720,15 +717,12 @@ let fetch ~(sandbox : Sandbox.t) (solution : Solution.t) =
 
     let f = function
       | (installation, Some ({Manifest. esy = None; _} as manifest)) ->
-        let msg =
-          Format.asprintf
-            "running lifecycle %a"
-            Layout.pp_installation installation
-        in
-        LwtTaskQueue.submit
-          queue
-          (runLifecycle ~installation ~manifest)
-        |> RunAsync.withContext msg
+        RunAsync.contextf
+          (LwtTaskQueue.submit
+            queue
+            (runLifecycle ~installation ~manifest))
+          "running lifecycle %a"
+          Layout.pp_installation installation
       | (_installation, Some {Manifest. esy = Some _; _})
       | (_installation, None) -> return ()
     in

--- a/esyi/FetchStorage.ml
+++ b/esyi/FetchStorage.ml
@@ -192,8 +192,7 @@ let fetch ~(cfg : Config.t) (record : Solution.Record.t) =
     | _, false ->
       Fs.withTempDir (fun sourcePath ->
         let%bind fetched =
-          let msg = Format.asprintf "fetching %a" Package.Source.pp source in
-          RunAsync.withContext msg (
+          RunAsync.contextf (
             let%bind () = Fs.createDir sourcePath in
             match%bind doFetch sourcePath source with
             | `Done ->
@@ -201,6 +200,7 @@ let fetch ~(cfg : Config.t) (record : Solution.Record.t) =
               return `Done
             | `TryNext err -> return (`TryNext err)
           )
+          "fetching %a" Package.Source.pp source
         in
 
         match fetched with

--- a/esyi/OpamOverrides.re
+++ b/esyi/OpamOverrides.re
@@ -78,14 +78,16 @@ let load = baseDir => {
   let packageJson = Path.(baseDir / "package.json");
   let filesPath = Path.(baseDir / "files");
   let%bind override =
-    RunAsync.withContext(
-      "Reading " ++ Path.toString(packageJson),
+    RunAsync.contextf(
       {
         let%bind json = Fs.readJsonFile(packageJson);
         RunAsync.ofRun(
           Json.parseJsonWith(Package.OpamOverride.of_yojson, json),
         );
       },
+      "Reading %a",
+      Path.pp,
+      packageJson,
     );
   let%bind files =
     if%bind (Fs.exists(filesPath)) {

--- a/esyi/OpamRegistry.ml
+++ b/esyi/OpamRegistry.ml
@@ -338,11 +338,11 @@ module Manifest = struct
 
       let%bind dependencies =
         let%bind formula =
-          RunAsync.withContext "processing depends field" (
+          RunAsync.context (
             translateFilteredFormula
               ~build:true ~post:true ~test:false ~doc:false ~dev:false
               (OpamFile.OPAM.depends opam)
-          )
+          ) "processing depends field"
         in
         let formula =
           formula
@@ -359,13 +359,13 @@ module Manifest = struct
       in
 
       let%bind devDependencies =
-        RunAsync.withContext "processing depends field" (
+        RunAsync.context (
           let%bind formula =
             translateFilteredFormula
               ~build:false ~post:false ~test:true ~doc:true ~dev:true
               (OpamFile.OPAM.depends opam)
           in return (Package.Dependencies.OpamFormula formula)
-        )
+        ) "processing depends field"
       in
 
       let readOpamFilesForPackage path () =

--- a/esyi/OpamRegistry.ml
+++ b/esyi/OpamRegistry.ml
@@ -221,8 +221,7 @@ module Manifest = struct
   let toPackage ~name ~version
     {name = opamName; version = opamVersion; opam; url; path; override; archive} =
     let open RunAsync.Syntax in
-    let context = Format.asprintf "processing %a opam package" Path.pp path in
-    RunAsync.withContext context (
+    RunAsync.contextf (
 
       let%bind source = RunAsync.ofRun (
         let open Run.Syntax in
@@ -239,7 +238,7 @@ module Manifest = struct
             in
             match List.map ~f checksums with
             | [] ->
-              error (Format.asprintf "no checksum provided for %s@%a" name Version.pp version)
+              errorf "no checksum provided for %s@%a" name Version.pp version
             | checksum::_ -> return checksum
           in
 
@@ -391,7 +390,7 @@ module Manifest = struct
         dependencies;
         devDependencies;
       }
-    )
+    ) "processing %a opam package" Path.pp path
 end
 
 let make ~cfg () =

--- a/esyi/Resolver.ml
+++ b/esyi/Resolver.ml
@@ -141,12 +141,9 @@ let package ~(resolution : Resolution.t) resolver =
             let manifest = {manifest with name = resolution.name} in
             return (`PackageJson manifest)
           | Error err ->
-            let msg =
-              Format.asprintf
-                "cannot read manifest at %a: %s"
-                Source.pp source (Run.formatError err)
-            in
-            error msg
+            errorf
+              "cannot read manifest at %a: %s"
+              Source.pp source (Run.formatError err)
         end
       | Version.Source (Github {user; repo; commit}) ->
         begin match%bind Github.getManifest ~user ~repo ~ref:commit () with
@@ -197,12 +194,9 @@ let resolveSource ~name ~(sourceSpec : SourceSpec.t) (resolver : t) =
   let open RunAsync.Syntax in
 
   let errorResolvingSource msg =
-    let msg =
-      Format.asprintf
-        "unable to resolve %s@%a: %s"
-        name SourceSpec.pp sourceSpec msg
-    in
-    error msg
+    errorf
+      "unable to resolve %s@%a: %s"
+      name SourceSpec.pp sourceSpec msg
   in
 
   SourceCache.compute resolver.srcCache sourceSpec begin fun _ ->
@@ -275,9 +269,7 @@ let resolve ?(fullMetadata=false) ~(name : string) ?(spec : VersionSpec.t option
               resolver.npmRegistryQueue
               (NpmRegistry.versions ~fullMetadata ~cfg:resolver.cfg ~name)
           with
-          | [] ->
-            let msg = Format.asprintf "no npm package %s found" name in
-            error msg
+          | [] -> errorf "no npm package %s found" name
           | versions -> return versions
         in
 

--- a/esyi/Solution.ml
+++ b/esyi/Solution.ml
@@ -307,17 +307,14 @@ module LockfileV1 = struct
           return (Some solution)
         else return None
       | Error err ->
-        let msg =
-          let path =
-            Option.orDefault
-              ~default:path
-              (Path.relativize ~root:sandbox.path path)
-          in
-          Format.asprintf
-            "corrupted %a lockfile@\nyou might want to remove it and install from scratch@\nerror: %a"
-            Path.pp path Run.ppError err
+        let path =
+          Option.orDefault
+            ~default:path
+            (Path.relativize ~root:sandbox.path path)
         in
-        error msg
+        errorf
+          "corrupted %a lockfile@\nyou might want to remove it and install from scratch@\nerror: %a"
+          Path.pp path Run.ppError err
     else
       return None
 

--- a/esyi/Solver.ml
+++ b/esyi/Solver.ml
@@ -301,8 +301,9 @@ let add ~(dependencies : Dependencies.t) solver =
       report status
     in
     let%bind resolutions, spec =
-      Resolver.resolve ~fullMetadata:true ~name:req.name ~spec:req.spec solver.resolver
-      |> RunAsync.withContext (Format.asprintf "resolving %a" Req.pp req)
+      RunAsync.contextf (
+        Resolver.resolve ~fullMetadata:true ~name:req.name ~spec:req.spec solver.resolver
+      ) "resolving %a" Req.pp req
     in
 
     let%bind packages =

--- a/esyi/Solver.ml
+++ b/esyi/Solver.ml
@@ -307,9 +307,9 @@ let add ~(dependencies : Dependencies.t) solver =
 
     let%bind packages =
       let fetchPackage resolution =
-        Resolver.package ~resolution solver.resolver
-        |> RunAsync.withContext (
-            Format.asprintf "resolving metadata %a" Resolver.Resolution.pp resolution)
+        RunAsync.contextf
+          (Resolver.package ~resolution solver.resolver)
+          "resolving metadata %a" Resolver.Resolution.pp resolution
       in
       resolutions
       |> List.map ~f:fetchPackage
@@ -372,12 +372,9 @@ let solveDependencies ~installed ~strategy dependencies solver =
       | Unix.WEXITED 0 ->
         RunAsync.return ()
       | _ ->
-        let msg =
-          Format.asprintf
-            "@[<v>command failed: %a@\nstderr:@[<v 2>@\n%a@]@\nstdout:@[<v 2>@\n%a@]@]"
-            Cmd.pp cmd Fmt.lines stderr Fmt.lines stdout
-        in
-        RunAsync.error msg
+        RunAsync.errorf
+          "@[<v>command failed: %a@\nstderr:@[<v 2>@\n%a@]@\nstdout:@[<v 2>@\n%a@]@]"
+          Cmd.pp cmd Fmt.lines stderr Fmt.lines stdout
     in
 
     let cmd = Cmd.getToolAndLine cmd in
@@ -520,9 +517,7 @@ let solveDependenciesNaively
     let%bind pkg =
       match resolveOfInstalled req with
       | None -> begin match%bind resolveOfOutside req with
-        | None ->
-          let msg = Format.asprintf "unable to find a match for %a" Req.pp req in
-          error msg
+        | None -> errorf "unable to find a match for %a" Req.pp req
         | Some pkg -> return pkg
         end
       | Some pkg -> return pkg
@@ -560,10 +555,9 @@ let solveDependenciesNaively
     let%bind pkgs =
       let f req =
         let%bind pkg =
-          let context = Format.asprintf "resolving request %a" Req.pp req in
-          RunAsync.withContext
-            context
+          RunAsync.contextf
             (resolve req)
+            "resolving request %a" Req.pp req
         in
         addToInstalled pkg;
         return pkg
@@ -583,10 +577,9 @@ let solveDependenciesNaively
       | false ->
         let seen = Package.Set.add pkg seen in
         let%bind dependencies =
-          let context = Format.asprintf "solving dependencies of %a" Package.pp pkg in
-          RunAsync.withContext
-            context
+          RunAsync.contextf
             (solveDependencies pkg.dependencies)
+            "solving dependencies of %a" Package.pp pkg
         in
         addDependencies pkg dependencies;
         loop seen (rest @ dependencies)
@@ -646,11 +639,9 @@ let solve (sandbox : Sandbox.t) =
   let getResultOrExplain = function
     | Ok dependencies -> return dependencies
     | Error explanation ->
-      let msg = Format.asprintf
+      errorf
         "@[<v>No solution found:@;@;%a@]"
         Explanation.pp explanation
-      in
-      error msg
   in
 
   let opamRegistry = OpamRegistry.make ~cfg:sandbox.cfg () in


### PR DESCRIPTION
This PR introduces ergonomical API addition to Run/RunAsync monads:
```ocaml
val errorf : ('a, Format.formatter, unit, 'v t) format4 -> 'a
val contextf : 'v t -> ('a, Format.formatter, unit, 'v t) format4 -> 'a
```
which allows to specify computation error/context with a formatter:

```ocaml
Run.errorf "fetching %a failed" Req.pp req

Run.contextf comp "fetching %a" Req.pp req
```
instead of the previous:
```ocaml
let msg = Format.asprintf "fetching %a failed" Req.pp req in
Run.error msg

let msg = Format.asprintf "fetching %a" Req.pp req in
Run.context comp msg
```