### PR TITLE
esy: suggest to run `esy install` on missing packages error

### DIFF
--- a/esy/Package.ml
+++ b/esy/Package.ml
@@ -17,8 +17,8 @@ and dependency =
   | DevDependency of t
   | BuildTimeDependency of t
   | InvalidDependency of {
-    pkgName: string;
-    reason: string;
+    name: string;
+    reason: [ | `Reason of string | `Missing ];
   }
 
 type pkg = t

--- a/esy/Package.mli
+++ b/esy/Package.mli
@@ -17,8 +17,8 @@ and dependency =
   | DevDependency of t
   | BuildTimeDependency of t
   | InvalidDependency of {
-    pkgName: string;
-    reason: string;
+    name: string;
+    reason: [ | `Reason of string | `Missing ];
   }
 
 val equal : t -> t -> bool

--- a/esy/Sandbox.ml
+++ b/esy/Sandbox.ml
@@ -112,15 +112,15 @@ let ofDir (cfg : Config.t) =
           in
           StringMap.fold f transitiveDependencies dependencies
         | Ok (_, `Ignored) -> dependencies
-        | Ok (pkgName, `Unresolved) ->
+        | Ok (name, `Unresolved) ->
           if skipUnresolved
           then dependencies
           else
-            let dep = Package.InvalidDependency {pkgName; reason="unable to resolve package";} in
-            StringMap.add pkgName dep dependencies
-        | Error (pkgName, reason) ->
-          let dep = Package.InvalidDependency {pkgName;reason;} in
-          StringMap.add pkgName dep dependencies
+            let dep = Package.InvalidDependency {name; reason = `Missing;} in
+            StringMap.add name dep dependencies
+        | Error (name, reason) ->
+          let dep = Package.InvalidDependency {name;reason = `Reason reason;} in
+          StringMap.add name dep dependencies
       in
       Lwt.return (List.fold_left ~f ~init:prevDependencies dependencies)
     in

--- a/esy/Task.ml
+++ b/esy/Task.ml
@@ -590,9 +590,10 @@ let ofPackage
         let dependencies = (DevDependency task)::dependencies in
         let seen = Package.DependencySet.add dep seen in
         return (seen, dependencies)
-    | Package.InvalidDependency { pkgName; reason; } ->
-      let msg = Printf.sprintf "invalid dependency %s: %s" pkgName reason in
-      Run.error msg
+    | Package.InvalidDependency { name; reason = `Missing; } ->
+      Run.errorf "package %s is missing, run 'esy install' to fix that" name
+    | Package.InvalidDependency { name; reason = `Reason reason; } ->
+      Run.errorf "invalid package %s: %s" name reason
 
   and directDependenciesOf (pkg : Package.t) =
     let seen = Package.DependencySet.empty in

--- a/test-e2e/build/not-enough-deps.test.js
+++ b/test-e2e/build/not-enough-deps.test.js
@@ -26,7 +26,7 @@ describe('Build - not enough deps', () => {
         expect.stringMatching('processing package: not-enough-deps@1.0.0'),
       );
       expect(e.stderr).toEqual(
-        expect.stringMatching('invalid dependency dep: unable to resolve package'),
+        expect.stringMatching("package dep is missing, run 'esy install' to fix that"),
       );
     });
   });


### PR DESCRIPTION
before:
```
info esy build 0.2.4
info found esy manifests: package.json
esy: error, exiting...
     invalid dependency @opam/cppo: unable to resolve package
       processing package: hello-ocaml@0.1.0
       processing package: @opam/yojson@1.4.1
```
after:
```
info esy build 0.2.5
info found esy manifests: package.json
esy: error, exiting...
     package @opam/cppo is missing, run 'esy install' to fix that
       processing package: hello-ocaml@0.1.0
       processing package: @opam/yojson@1.4.1
```

This is a minor improvement to output, mostly we just store more structured info on why package is invalid. To improve the output further we need to rework how we run cmdliner terms, right now we use default formatting for errors but it seems it doesn't suit use well.