### PR TITLE
Fix esyInstallRelease.js not to rewrite bin wrappers multiple times

### DIFF
--- a/bin/.prettierrc
+++ b/bin/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "printWidth": 90,
+  "singleQuote": true,
+  "bracketSpacing": false,
+  "trailingComma": "none",
+  "jsxBracketSameLine": true
+}


### PR DESCRIPTION
Previously we were rewriting bin wrappers on each build rewrite which is wrong as parallel rewrites were racing with each other and corrupted binaries.