### PR TITLE
Fixes to path handling

### DIFF
--- a/esy-build-package/Build.re
+++ b/esy-build-package/Build.re
@@ -25,8 +25,7 @@ let isRoot = (build: t) =>
   Config.Value.equal(build.task.sourcePath, Config.Value.sandbox);
 
 let regex = (base, segments) => {
-  let pat =
-    String.concat(Path.dir_sep, [Path.to_string(base), ...segments]);
+  let pat = String.concat(Path.dirSep, [Path.toString(base), ...segments]);
   Sandbox.Regex(pat);
 };
 
@@ -106,7 +105,7 @@ module JBuilderLifecycle: LIFECYCLE = {
   let getRootPath = (build: build) => build.sourcePath;
   let getAllowedToWritePaths = (_task, sourcePath) =>
     Sandbox.[
-      Subpath(Path.to_string(sourcePath / "_build")),
+      Subpath(Path.toString(sourcePath / "_build")),
       regex(sourcePath, [".*", "[^/]*\\.install"]),
       regex(sourcePath, ["[^/]*\\.install"]),
       regex(sourcePath, [".*", "[^/]*\\.opam"]),
@@ -181,7 +180,7 @@ module UnsafeLifecycle: LIFECYCLE = {
   let getRootPath = (build: build) => build.sourcePath;
 
   let getAllowedToWritePaths = (_task, sourcePath) =>
-    Sandbox.[Subpath(Path.to_string(sourcePath))];
+    Sandbox.[Subpath(Path.toString(sourcePath))];
 
   let prepare = _build => Ok();
   let finalize = _build => Ok();
@@ -245,15 +244,15 @@ let configureBuild = (~cfg: Config.t, task: Task.t) => {
       let%bind tempPath = {
         let v = Path.v(Bos.OS.Env.opt_var("TMPDIR", ~absent="/tmp"));
         let%bind v = realpath(v);
-        Ok(Path.to_string(v));
+        Ok(Path.toString(v));
       };
       Ok({
         Sandbox.allowWrite: [
           regex(sourcePath, [".*", "\\.merlin"]),
           regex(sourcePath, ["\\.merlin"]),
           regex(sourcePath, [".*\\.install"]),
-          Subpath(Path.to_string(buildPath)),
-          Subpath(Path.to_string(stagePath)),
+          Subpath(Path.toString(buildPath)),
+          Subpath(Path.toString(stagePath)),
           Subpath("/private/tmp"),
           Subpath("/tmp"),
           Subpath(tempPath),
@@ -327,7 +326,7 @@ let install = (~prefixPath, ~rootPath, ~installFilename=?, ()) => {
 };
 
 let withLock = (lockPath: Path.t, f) => {
-  let lockPath = Path.to_string(lockPath);
+  let lockPath = Path.toString(lockPath);
   let fd =
     UnixLabels.(
       openfile(
@@ -369,8 +368,8 @@ let commitBuildToStore = (config: Config.t, build: build) => {
     Bos.OS.Cmd.run(cmd);
   };
   let rewritePrefixesInFile = (~origPrefix, ~destPrefix, path) => {
-    let origPrefixString = Path.to_string(origPrefix);
-    let destPrefixString = Path.to_string(destPrefix);
+    let origPrefixString = Path.toString(origPrefix);
+    let destPrefixString = Path.toString(destPrefix);
     switch (System.Platform.host) {
     | Windows =>
       /* On Windows, the slashes could be either `/` or windows-style `\` */
@@ -400,7 +399,7 @@ let commitBuildToStore = (config: Config.t, build: build) => {
   };
   let rewriteTargetInSymlink = (~origPrefix, ~destPrefix, path) => {
     let%bind targetPath = readlink(path);
-    switch (Path.rem_prefix(origPrefix, targetPath)) {
+    switch (Path.remPrefix(origPrefix, targetPath)) {
     | Some(basePath) =>
       let nextTargetPath = Path.append(destPrefix, basePath);
       let%bind () = rm(path);
@@ -427,7 +426,7 @@ let commitBuildToStore = (config: Config.t, build: build) => {
     };
   let%bind () =
     write(
-      ~data=Path.to_string(config.storePath),
+      ~data=Path.toString(config.storePath),
       Path.(build.stagePath / "_esy" / "storePrefix"),
     );
   let%bind () = traverse(build.stagePath, relocate);
@@ -617,7 +616,7 @@ let build = (~buildOnly=true, ~force=false, ~cfg: Config.t, task: Task.t) => {
           let%bind items = Run.ls(rootPath);
           return(
             items
-            |> List.filter(name => Path.has_ext(".install", name))
+            |> List.filter(name => Path.hasExt(".install", name))
             |> List.map(name => Path.basename(name)),
           );
         };

--- a/esy-build-package/Config.re
+++ b/esy-build-package/Config.re
@@ -69,9 +69,9 @@ module Value = {
   let toString = (~cfg, v) => {
     let lookupVar =
       fun
-      | "sandbox" => Some(Path.to_string(cfg.sandboxPath))
-      | "store" => Some(Path.to_string(cfg.storePath))
-      | "localStore" => Some(Path.to_string(cfg.localStorePath))
+      | "sandbox" => Some(Path.toString(cfg.sandboxPath))
+      | "store" => Some(Path.toString(cfg.storePath))
+      | "localStore" => Some(Path.toString(cfg.localStorePath))
       | _ => None;
     PathSyntax.render(lookupVar, v);
   };

--- a/esy-build-package/Run.re
+++ b/esy-build-package/Run.re
@@ -2,6 +2,8 @@ module Result = EsyLib.Result;
 module Path = EsyLib.Path;
 module System = EsyLib.System;
 
+module Let_syntax = Result.Syntax.Let_syntax;
+
 type err('b) =
   [> | `Msg(string) | `CommandError(Cmd.t, Bos.OS.Cmd.status)] as 'b;
 
@@ -38,7 +40,20 @@ let mkdir = path =>
 
 let ls = path => Bos.OS.Dir.contents(~dotfiles=true, ~rel=true, path);
 
-let rm = path => Bos.OS.Path.delete(~must_exist=false, ~recurse=true, path);
+let rm = path =>
+  switch (Bos.OS.Path.symlink_stat(path)) {
+  | Ok({Unix.st_kind: S_DIR, _}) =>
+    Bos.OS.Path.delete(~must_exist=false, ~recurse=true, path)
+  | Ok({Unix.st_kind: S_LNK, _}) =>
+    switch (Bos.OS.U.unlink(path)) {
+    | Ok () => ok
+    | Error(`Unix(err)) =>
+      let msg = Unix.error_message(err);
+      error(msg);
+    }
+  | Ok({Unix.st_kind: _, _}) => Bos.OS.Path.delete(~must_exist=false, path)
+  | Error(_) => ok
+  };
 let stat = Bos.OS.Path.stat;
 
 let rec statOrError = p =>
@@ -88,7 +103,6 @@ let read = path => Bos.OS.File.read(path);
 let mv = Bos.OS.Path.move;
 
 let bind = Result.Syntax.Let_syntax.bind;
-module Let_syntax = Result.Syntax.Let_syntax;
 
 let rec realpath = (p: Fpath.t) => {
   let%bind p =

--- a/esy-build-package/Run.re
+++ b/esy-build-package/Run.re
@@ -169,7 +169,7 @@ let copyContents = (~from, ~ignore=[], dest) => {
       if (Path.equal(path, from)) {
         Ok();
       } else if (Path.Set.mem(
-                   Path.rem_empty_seg(Path.parent(path)),
+                   Path.remEmptySeg(Path.parent(path)),
                    excludePathsWithinSymlink^,
                  )) {
         Ok();
@@ -186,10 +186,7 @@ let copyContents = (~from, ~ignore=[], dest) => {
           Bos.OS.Path.Mode.set(nextPath, stats.Unix.st_perm);
         | Unix.S_LNK =>
           excludePathsWithinSymlink :=
-            Path.Set.add(
-              Path.rem_empty_seg(path),
-              excludePathsWithinSymlink^,
-            );
+            Path.Set.add(Path.remEmptySeg(path), excludePathsWithinSymlink^);
           let%bind targetPath = Bos.OS.Path.symlink_target(path);
           let nextTargetPath = rebasePath(targetPath);
           Bos.OS.Path.symlink(~target=nextTargetPath, nextPath);

--- a/esy-build-package/Sandbox.re
+++ b/esy-build-package/Sandbox.re
@@ -48,7 +48,7 @@ module Darwin = {
     let prepare = (~env, command) => {
       open Bos.OS.Cmd;
       let sandboxCommand =
-        Cmd.of_list(["sandbox-exec", "-f", Path.to_string(configFilename)]);
+        Cmd.of_list(["sandbox-exec", "-f", Path.toString(configFilename)]);
       let command = Cmd.(sandboxCommand %% command);
 
       let exec = (~err) => run_io(~env, ~err, command);

--- a/esy-lib/Checksum.ml
+++ b/esy-lib/Checksum.ml
@@ -69,7 +69,7 @@ let checkFile ~path (checksum : t) =
     (* On Windows, the checksum tools packaged with Cygwin require cygwin-style paths *)
     RunAsync.ofBosError (
       let open Result.Syntax in
-      let%bind path = EsyBash.normalizePathForCygwin (Path.to_string path) in
+      let%bind path = EsyBash.normalizePathForCygwin (Path.toString path) in
       let%bind out = EsyBash.runOut Cmd.(cmd % path |> toBosCmd) in
       match Astring.String.cut ~sep:" " out with
       | Some (v, _) -> return v

--- a/esy-lib/Cli.ml
+++ b/esy-lib/Cli.ml
@@ -87,7 +87,7 @@ end
 
 let pathConv =
   let open Cmdliner in
-  let parse = Path.of_string in
+  let parse = Path.ofString in
   let print = Path.pp in
   Arg.conv ~docv:"PATH" (parse, print)
 

--- a/esy-lib/Path.re
+++ b/esy-lib/Path.re
@@ -48,7 +48,7 @@ let of_yojson = (json: Yojson.Safe.json) =>
 
 let to_yojson = (path: t) => `String(to_string(path));
 
-let safeName = {
+let safeSeg = {
   let replaceAt = Str.regexp("@");
   let replaceUnderscore = Str.regexp("_+");
   let replaceSlash = Str.regexp("\\/");

--- a/esy-lib/Path.rei
+++ b/esy-lib/Path.rei
@@ -1,0 +1,50 @@
+/**
+
+  File system path.
+
+ */
+
+type t = Fpath.t;
+type ext = Fpath.ext;
+
+let v : string => t;
+let (/) : t => string => t;
+let (/\/) : t => t => t;
+
+let addSeg : (t, string) => t;
+let append : (t, t) => t;
+
+let ofString : string => result(t, [> |`Msg(string)]);
+let current : unit => Run.t(t);
+let user : unit => Run.t(t);
+
+let isPrefix : (t, t) => bool;
+let remPrefix : (t, t) => option(t);
+
+let isAbs : (t) => bool;
+let basename : t => string;
+let parent : t => t;
+let relativize : (~root:t, t) => option(t);
+
+let addExt : (ext, t) => t;
+let hasExt : (ext, t) => bool;
+let remExt : (~multi: bool=?, t) => t;
+let getExt : (~multi: bool=?, t) => ext;
+
+let dirSep : string;
+
+include Abstract.PRINTABLE with type t := t;
+include Abstract.COMPARABLE with type t := t;
+include Abstract.JSONABLE with type t := t;
+
+module Set : (module type of Fpath.Set);
+
+let safeSeg : string => string;
+let safePath : string => string;
+
+let remEmptySeg : t => t;
+let normalize : t => t;
+let normalizePathSlashes : string => string;
+let normalizeAndRemoveEmptySeg : t => t;
+
+let toPrettyString : t => Run.t(string);

--- a/esy-lib/Tarball.ml
+++ b/esy-lib/Tarball.ml
@@ -48,8 +48,8 @@ let unpackWithTar ?stripComponents ~dst filename =
   let unpack out = 
     let%bind cmd = RunAsync.ofBosError (
       let open Result.Syntax in
-      let%bind nf = EsyBash.normalizePathForCygwin (Path.to_string filename) in
-      let%bind normalizedOut = EsyBash.normalizePathForCygwin (Path.to_string out) in
+      let%bind nf = EsyBash.normalizePathForCygwin (Path.toString filename) in
+      let%bind normalizedOut = EsyBash.normalizePathForCygwin (Path.toString out) in
       return Cmd.(v "tar" % "xf" % nf % "-C" % normalizedOut)
     )
     in
@@ -77,7 +77,7 @@ let unpackWithUnzip ?stripComponents ~dst filename =
   | None -> unpack dst
 
 let unpack ?stripComponents ~dst filename =
-  let ext = Path.get_ext filename in
+  let ext = Path.getExt filename in
   begin match ext with
   | ".zip" -> unpackWithUnzip ?stripComponents ~dst filename
   | _ -> unpackWithTar ?stripComponents ~dst filename
@@ -86,8 +86,8 @@ let unpack ?stripComponents ~dst filename =
 let create ~filename src =
   RunAsync.ofBosError (
     let open Result.Syntax in
-    let%bind nf = EsyBash.normalizePathForCygwin (Path.to_string filename) in
-    let%bind ns = EsyBash.normalizePathForCygwin (Path.to_string src) in
+    let%bind nf = EsyBash.normalizePathForCygwin (Path.toString filename) in
+    let%bind ns = EsyBash.normalizePathForCygwin (Path.toString src) in
     let cmd = Cmd.(v "tar" % "czf" % nf % "-C" % ns % ".") in
     let%bind res = EsyBash.run (Cmd.toBosCmd cmd) in
     return res

--- a/esy/Config.ml
+++ b/esy/Config.ml
@@ -156,13 +156,13 @@ end = struct
 
   let toPath config p =
     let env = function
-      | "sandbox" -> Some (Path.to_string config.sandboxPath)
-      | "store" -> Some (Path.to_string config.storePath)
-      | "localStore" -> Some (Path.to_string config.localStorePath)
+      | "sandbox" -> Some (Path.toString config.sandboxPath)
+      | "store" -> Some (Path.toString config.storePath)
+      | "localStore" -> Some (Path.toString config.localStorePath)
       | _ -> None
     in
-    let path = EsyBuildPackage.PathSyntax.renderExn env (Path.to_string p) in
-    match Path.of_string path with
+    let path = EsyBuildPackage.PathSyntax.renderExn env (Path.toString p) in
+    match Path.ofString path with
     | Ok path -> path
     | Error (`Msg msg) ->
       (* FIXME: really should be fixed by ofPath returning result (validating) *)
@@ -171,7 +171,7 @@ end = struct
   let cwd = Path.v (Sys.getcwd ())
 
   let ofPath config p =
-    let p = if Path.is_abs p then p else Path.(cwd // p) in
+    let p = if Path.isAbs p then p else Path.(cwd // p) in
     let p = Path.normalize p in
     if Path.equal p config.storePath then
       store
@@ -180,11 +180,11 @@ end = struct
     else if Path.equal p config.sandboxPath then
       sandbox
     else begin
-      match Path.rem_prefix config.storePath p with
+      match Path.remPrefix config.storePath p with
       | Some suffix -> Path.(store // suffix)
-      | None -> begin match Path.rem_prefix config.localStorePath p with
+      | None -> begin match Path.remPrefix config.localStorePath p with
         | Some suffix -> Path.(localStore // suffix)
-        | None -> begin match Path.rem_prefix config.sandboxPath p with
+        | None -> begin match Path.remPrefix config.sandboxPath p with
           | Some suffix -> Path.(sandbox // suffix)
           | None -> p
         end

--- a/esy/Config.mli
+++ b/esy/Config.mli
@@ -22,7 +22,9 @@ val create :
   -> esyVersion:string
   -> prefixPath:Fpath.t option
   -> Fpath.t
-  -> t RunAsync.t
+  -> t Run.t
+
+val init : t -> unit RunAsync.t
 
 module Value : sig
   type t

--- a/esy/Environment.ml
+++ b/esy/Environment.ml
@@ -20,9 +20,9 @@ and bindingValue =
 
 let renderPath ~storePath ~localStorePath ~sandboxPath value =
   let lookup = function
-  | "store" -> Some (Path.to_string storePath)
-  | "localStore" -> Some (Path.to_string localStorePath)
-  | "sandbox" -> Some (Path.to_string sandboxPath)
+  | "store" -> Some (Path.toString storePath)
+  | "localStore" -> Some (Path.toString localStorePath)
+  | "sandbox" -> Some (Path.toString sandboxPath)
   | _ -> None
   in
   Run.ofBosError (EsyBuildPackage.PathSyntax.render lookup value)

--- a/esy/EsyRc.ml
+++ b/esy/EsyRc.ml
@@ -18,8 +18,8 @@ let ofPath path =
         match acc, item with
         | Ok { prefixPath = None }, ("esy-prefix-path", P.String value) ->
           let open Result.Syntax in
-          let%bind value = Path.of_string value in
-          let value = if Path.is_abs value
+          let%bind value = Path.ofString value in
+          let value = if Path.isAbs value
             then value
             else Path.(value |> (append path) |> normalize)
           in

--- a/esy/Manifest.ml
+++ b/esy/Manifest.ml
@@ -601,7 +601,7 @@ end = struct
 
     let%bind paths =
       let isOpamPath path =
-        Path.has_ext ".opam" path
+        Path.hasExt ".opam" path
         || Path.basename path = "opam"
       in
       let%bind paths = Fs.listDir path in
@@ -621,7 +621,7 @@ end = struct
         then return None
         else
           let opam = OpamFile.OPAM.read_from_string data in
-          let name = Path.(path |> rem_ext |> basename) in
+          let name = Path.(path |> remExt |> basename) in
           return (Some (name, opam))
       in
 
@@ -835,7 +835,7 @@ end = struct
     let%bind names = Fs.listDir path in
     let f = function
       | "esy.json" | "package.json" | "opam" -> true
-      | name -> Path.(name |> v |> has_ext ".opam")
+      | name -> Path.(name |> v |> hasExt ".opam")
     in
     return (List.exists ~f names)
 end

--- a/esy/NpmRelease.ml
+++ b/esy/NpmRelease.ml
@@ -272,7 +272,7 @@ let make ~esyInstallRelease ~outputPath ~concurrency ~cfg ~sandbox =
         let nextStorePrefix = String.make (String.length (Path.toString Config.(cfg.storePath))) '_' in
         (Config.(cfg.storePath), Path.v nextStorePrefix)
       in
-      let%bind () = Fs.writeFile ~data:(Path.to_string destPrefix) Path.(binPath / "_storePath") in
+      let%bind () = Fs.writeFile ~data:(Path.toString destPrefix) Path.(binPath / "_storePath") in
       Task.rewritePrefix ~cfg ~origPrefix ~destPrefix binPath
     in
 

--- a/esy/PackageBuilder.ml
+++ b/esy/PackageBuilder.ml
@@ -23,7 +23,7 @@ let run
         % "--prefix-path" % p cfg.prefixPath
         % "--sandbox-path" % p cfg.sandboxPath
         % "--build"
-        % Path.to_string buildJsonFilename
+        % Path.toString buildJsonFilename
         |> addArgs args
       )
     ) in
@@ -37,7 +37,7 @@ let run
     | `Log ->
       let logPath = Config.Path.toPath cfg task.paths.logPath in
       let%lwt fd = Lwt_unix.openfile
-        (Path.to_string logPath)
+        (Path.toString logPath)
         Lwt_unix.[O_WRONLY; O_CREAT]
         0o644
       in

--- a/esy/Sandbox.ml
+++ b/esy/Sandbox.ml
@@ -187,7 +187,7 @@ let ofDir (cfg : Config.t) =
         in
         let pkg = {
           Package.
-          id = Path.to_string path;
+          id = Path.toString path;
           name = Manifest.name manifest;
           version = Manifest.version manifest;
           dependencies = StringMap.values dependencies;

--- a/esy/SandboxTools.re
+++ b/esy/SandboxTools.re
@@ -17,7 +17,7 @@ let getOcamlfind = (~cfg: Config.t, task: Task.t) =>
         );
       let%bind built = Fs.exists(ocamlfindBin);
       if (built) {
-        return(Path.to_string(ocamlfindBin));
+        return(Path.toString(ocamlfindBin));
       } else {
         /* TODO Autmatically build ocamlfind instead */
         error(
@@ -39,7 +39,7 @@ let getOcamlobjinfo = (~cfg: Config.t, task: Task.t) =>
         );
       let%bind built = Fs.exists(ocamlobjinfoBin);
       if (built) {
-        return(Path.to_string(ocamlobjinfoBin));
+        return(Path.toString(ocamlobjinfoBin));
       } else {
         /* TODO Automatically build ocaml instead */
         error(
@@ -66,7 +66,7 @@ let getPackageLibraries =
     switch (task) {
     | Some((task: Task.t)) =>
       Config.Path.(task.paths.installPath / "lib" |> toPath(cfg))
-      |> Path.to_string
+      |> Path.toString
     | None => ""
     };
   let env =
@@ -97,7 +97,7 @@ let queryMeta = (~cfg: Config.t, ~ocamlfind: string, ~task: Task.t, lib) => {
   open RunAsync.Syntax;
   let ocamlpath =
     Config.Path.(task.paths.installPath / "lib" |> toPath(cfg))
-    |> Path.to_string;
+    |> Path.toString;
   let env =
     `CustomEnv(Astring.String.Map.(empty |> add("OCAMLPATH", ocamlpath)));
   let cmd =

--- a/esy/Task.ml
+++ b/esy/Task.ml
@@ -489,7 +489,7 @@ let buildId
   let id = List.fold_left ~f:updateWithDepId ~init:id dependencies in
   let hash = Digest.to_hex id in
   let hash = String.sub hash 0 8 in
-  (EsyLib.Path.safeName pkg.name ^ "-" ^ EsyLib.Path.safePath pkg.version ^ "-" ^ hash)
+  (EsyLib.Path.safeSeg pkg.name ^ "-" ^ EsyLib.Path.safePath pkg.version ^ "-" ^ hash)
 
 let getenv name =
   try Some (Sys.getenv name)

--- a/esy/Task.ml
+++ b/esy/Task.ml
@@ -1213,7 +1213,7 @@ let rewritePrefix ~(cfg : Config.t) ~origPrefix ~destPrefix rootPath =
   in
   let rewriteTargetInSymlink path =
     let%bind link = Fs.readlink path in
-    match Path.rem_prefix origPrefix link with
+    match Path.remPrefix origPrefix link with
     | Some basePath ->
       let nextTargetPath = Path.(destPrefix // basePath) in
       let%bind () = Fs.unlink path in
@@ -1265,9 +1265,9 @@ let exportBuild ~cfg ~outputPrefixPath buildPath =
 let importBuild (cfg : Config.t) buildPath =
   let open RunAsync.Syntax in
   let buildId, kind =
-    if Path.has_ext "tar.gz" buildPath
+    if Path.hasExt "tar.gz" buildPath
     then
-      (buildPath |> Path.rem_ext |> Path.rem_ext |> Path.basename, `Archive)
+      (buildPath |> Path.remExt |> Path.remExt |> Path.basename, `Archive)
     else
       (buildPath |> Path.basename, `Dir)
   in

--- a/esy/bin/SandboxInfo.ml
+++ b/esy/bin/SandboxInfo.ml
@@ -9,9 +9,9 @@ type t = {
 
 let cachePath (cfg : Config.t) =
   let hash = [
-    Path.to_string cfg.storePath;
-    Path.to_string cfg.localStorePath;
-    Path.to_string cfg.sandboxPath;
+    Path.toString cfg.storePath;
+    Path.toString cfg.localStorePath;
+    Path.toString cfg.sandboxPath;
     cfg.esyVersion
   ]
     |> String.concat "$$"
@@ -33,7 +33,7 @@ let writeCache (cfg : Config.t) (info : t) =
       in
       let cachePath = cachePath cfg in
       let%bind () = Fs.createDir (Path.parent cachePath) in
-      Lwt_io.with_file ~mode:Lwt_io.Output (Path.to_string cachePath) f
+      Lwt_io.with_file ~mode:Lwt_io.Output (Path.toString cachePath) f
     in
 
     let%bind () =
@@ -43,7 +43,7 @@ let writeCache (cfg : Config.t) (info : t) =
           let%lwt () = Lwt_io.flush oc in
           return ()
         in
-        Lwt_io.with_file ~mode:Lwt_io.Output (Path.to_string filename) f
+        Lwt_io.with_file ~mode:Lwt_io.Output (Path.toString filename) f
       in
       let sandboxBin = Path.(
           cfg.sandboxPath
@@ -107,7 +107,7 @@ let readCache (cfg : Config.t) =
       then return None
       else return (Some info)
     in
-    try%lwt Lwt_io.with_file ~mode:Lwt_io.Input (Path.to_string cachePath) f
+    try%lwt Lwt_io.with_file ~mode:Lwt_io.Input (Path.toString cachePath) f
     with | Unix.Unix_error _ -> return None
   in Esy.Perf.measureTime ~label:"reading sandbox info cache" f
 

--- a/esy/bin/esyCommand.ml
+++ b/esy/bin/esyCommand.ml
@@ -39,7 +39,7 @@ module EsyRuntime = struct
           Printf.sprintf
           "unable to resolve %s from %s"
           req
-          (Path.to_string currentDirname)
+          (Path.toString currentDirname)
         in
         RunAsync.error msg
       | Error (`Msg err) -> RunAsync.error err
@@ -104,17 +104,17 @@ end
 let esyEnvOverride (cfg : Config.t) =
   let env = Astring.String.Map.(
       empty
-      |> add "ESY__PREFIX" (Path.to_string cfg.prefixPath)
-      |> add "ESY__SANDBOX" (Path.to_string cfg.sandboxPath)
+      |> add "ESY__PREFIX" (Path.toString cfg.prefixPath)
+      |> add "ESY__SANDBOX" (Path.toString cfg.sandboxPath)
     ) in
   `CurrentEnvOverride env
 
 let resolvedPathTerm =
   let open Cmdliner in
   let parse v =
-    match Path.of_string v with
+    match Path.ofString v with
     | Ok path ->
-      if Path.is_abs path then
+      if Path.isAbs path then
         Ok path
       else
         Ok Path.(EsyRuntime.currentWorkingDir // path |> normalize)
@@ -242,7 +242,7 @@ let withBuildTaskByPath
   let open RunAsync.Syntax in
   match packagePath with
   | Some packagePath ->
-    let resolvedPath = packagePath |> Path.rem_empty_seg |> Path.to_string in
+    let resolvedPath = packagePath |> Path.remEmptySeg |> Path.toString in
     let findByPath (task : Task.t) =
       String.equal resolvedPath task.pkg.id
     in begin match Task.Graph.find ~f:findByPath info.task with
@@ -570,10 +570,10 @@ let lsModules ~libs:only cfg =
       let description = Chalk.dim(meta.description) in
       return [TermTree.Node { line=description; children=[]; }]
     else begin
-      Path.of_string (meta.location ^ Path.dir_sep ^ meta.archive) |> function
+      Path.ofString (meta.location ^ Path.dirSep ^ meta.archive) |> function
       | Ok archive ->
         if%bind Fs.exists archive then begin
-          let archive = Path.to_string archive in
+          let archive = Path.toString archive in
           let%bind lines =
             SandboxTools.queryModules ~ocamlobjinfo archive
           in

--- a/esy/bin/esyCommand.ml
+++ b/esy/bin/esyCommand.ml
@@ -202,11 +202,13 @@ let configTerm =
       return (Cmd.v cmd)
     in
     let%bind esyInstallJsCommand = EsyRuntime.esyInstallJsCommand in
-    Config.create
-      ~esyInstallJsCommand
-      ~esyBuildPackageCommand
-      ~fastreplacestringCommand
-      ~esyVersion:EsyRuntime.version ~prefixPath sandboxPath
+    RunAsync.ofRun (
+      Config.create
+        ~esyInstallJsCommand
+        ~esyBuildPackageCommand
+        ~fastreplacestringCommand
+        ~esyVersion:EsyRuntime.version ~prefixPath sandboxPath
+    )
   in
   Term.(const(parse) $ prefixPath $ sandboxPath)
 
@@ -645,6 +647,7 @@ let () =
     let open RunAsync.Syntax in
     let result =
       let%bind cfg = cfg in
+      let%bind () = Config.init cfg in
       let%lwt () = match header with
         | `Standard ->
           let commandName =
@@ -676,7 +679,7 @@ let () =
       | None ->
         let installRes =
           let f cfg = runEsyInstallCommand cfg None [] in
-            runCommandWithConfig ~info ~cfg f
+          runCommandWithConfig ~info ~cfg f
         in
         begin match installRes with
         | `Ok () ->

--- a/esyi/Package.ml
+++ b/esyi/Package.ml
@@ -499,10 +499,10 @@ module Req = struct
       });
 
       make ~name:"pkg" ~spec:"file:./some/file",
-      VersionSpec.Source (SourceSpec.LocalPath (Path.v "./some/file"));
+      VersionSpec.Source (SourceSpec.LocalPath (Path.v "some/file"));
 
       make ~name:"pkg" ~spec:"link:./some/file",
-      VersionSpec.Source (SourceSpec.LocalPathLink (Path.v "./some/file"));
+      VersionSpec.Source (SourceSpec.LocalPathLink (Path.v "some/file"));
       make ~name:"pkg" ~spec:"link:../reason-wall-demo",
       VersionSpec.Source (SourceSpec.LocalPathLink (Path.v "../reason-wall-demo"));
 
@@ -544,7 +544,8 @@ module Req = struct
 
     let%test "parsing" =
       let f passes (req, e) =
-        passes && (expectParsesTo req e)
+        let thisPasses = expectParsesTo req e in
+        passes && thisPasses
       in
       List.fold_left ~f ~init:true cases
 

--- a/esyi/Package.ml
+++ b/esyi/Package.ml
@@ -51,10 +51,12 @@ module Source = struct
       return (Archive {url; checksum})
     | "no-source", "" ->
       return NoSource
-    | "path", p ->
-      return (LocalPath (Path.v p))
-    | "link", p ->
-      return (LocalPathLink (Path.v p))
+    | "path", path ->
+      let path = Path.(normalizeAndRemoveEmptySeg (v path)) in
+      return (LocalPath path)
+    | "link", path ->
+      let path = Path.(normalizeAndRemoveEmptySeg (v path)) in
+      return (LocalPathLink path)
     | _, _ ->
       let msg = Printf.sprintf "unknown source: %s" v in
       error msg
@@ -391,11 +393,13 @@ module Req = struct
   let tryParseProto v =
     let open Result.Syntax in
     match parseProto v with
-    | Some ("link:", v) ->
-      let spec = SourceSpec.LocalPathLink (Path.v v) in
+    | Some ("link:", path) ->
+      let path = Path.(normalizeAndRemoveEmptySeg (v path)) in
+      let spec = SourceSpec.LocalPathLink path in
       return (Some (VersionSpec.Source spec))
-    | Some ("file:", v) ->
-      let spec = SourceSpec.LocalPath (Path.v v) in
+    | Some ("file:", path) ->
+      let path = Path.(normalizeAndRemoveEmptySeg (v path)) in
+      let spec = SourceSpec.LocalPath path in
       return (Some (VersionSpec.Source spec))
     | Some ("https:", _)
     | Some ("http:", _) ->

--- a/esyi/Sandbox.ml
+++ b/esyi/Sandbox.ml
@@ -31,16 +31,16 @@ let readAggregatedOpamManifest (path : Path.t) =
     let version = OpamPackage.Version.of_string "dev" in
 
     let isOpamPath path =
-      Path.has_ext ".opam" path
+      Path.hasExt ".opam" path
       || Path.basename path = "opam"
     in
 
-    let readOpam path =
+    let readOpam (path : Path.t) =
       let%bind data = Fs.readFile path in
       if String.trim data = ""
       then return None
       else 
-        let name = Path.(path |> rem_ext |> basename) in
+        let name = Path.(path |> remExt |> basename) in
         let%bind manifest =
           OpamManifest.ofPath ~name:(OpamPackage.Name.of_string name) ~version path
         in

--- a/test/Curl.ml
+++ b/test/Curl.ml
@@ -20,7 +20,7 @@ let%test "curl download simple file" =
             (* We need to normalize the path on Windows - file:///E:/.../ won't work! *)
             (* The normalize gives us a path of the form file:///cygdrive/e/.../ which does. *)
             (* This won't impact HTTP requests though - just our test using the local file system *)
-            let url = EsyBash.normalizePathForCygwin (Path.to_string(fileToCurl)) in
+            let url = EsyBash.normalizePathForCygwin (Path.toString(fileToCurl)) in
 
             match url with
             | Error _ -> Lwt.return false

--- a/test/Patch.ml
+++ b/test/Patch.ml
@@ -4,7 +4,7 @@ module Path = EsyLib.Path
 let%test "simple patch test" =
     let test () = 
         let f tempPath =
-            print_endline ("Running test: " ^ (Path.to_string tempPath));
+            print_endline ("Running test: " ^ (Path.toString tempPath));
             let fileToPatch = Path.(tempPath / "input.txt") in
             let patchFile = Path.(tempPath / "patch.txt") in
             let originalContents = "Hello OCaml\n" in


### PR DESCRIPTION


- We now always normalize paths when reading `path:` and `link:` sources.
- Fix flipping between `buildsInSource: true` and `buildsInSource: _build`.
- Add `Path.rei`, reduce its interface (only camelCased API) and update usage sides accordingly.