### PR TITLE
esyi: don't require package name for the root package

### DIFF
--- a/esy/Manifest.ml
+++ b/esy/Manifest.ml
@@ -299,7 +299,7 @@ end = struct
   end
 
   type manifest = {
-    name : string;
+    name : (string [@default "root"]);
     version : string;
     description : (string option [@default None]);
     license : (Json.t option [@default None]);

--- a/esyi/Manifest.ml
+++ b/esyi/Manifest.ml
@@ -20,7 +20,7 @@ let find (path : Path.t) =
 module EsyJson = struct
   type t = {
     _dependenciesForNewEsyInstaller : (NpmDependencies.t option [@default None]);
-  } [@@deriving of_yojson { strict = false }]
+  } [@@deriving yojson { strict = false }]
 end
 
 (* This is used just to read the Json.t *)
@@ -82,7 +82,7 @@ type manifest = t
 
 let name manifest = manifest.name
 
-let ofRootPackageJson ?(source=Source.NoSource) (pkgJson : RootPackageJson.t) =
+let ofRootPackageJson (pkgJson : RootPackageJson.t) =
   let dependencies =
     match pkgJson.esy with
     | None
@@ -97,14 +97,7 @@ let ofRootPackageJson ?(source=Source.NoSource) (pkgJson : RootPackageJson.t) =
     dependencies;
     devDependencies = pkgJson.devDependencies;
     hasEsyManifest = Option.isSome pkgJson.esy;
-    source =
-      match pkgJson.dist with
-      | Some dist ->
-        Source.Archive {
-          url = dist.RootPackageJson.tarball;
-          checksum = Checksum.Sha1, dist.RootPackageJson.shasum;
-        }
-      | None -> source;
+    source = Source.NoSource
   }
 
 let ofPackageJson ?(source=Source.NoSource) (pkgJson : PackageJson.t) =

--- a/esyi/Sandbox.ml
+++ b/esyi/Sandbox.ml
@@ -27,7 +27,7 @@ let readPackageJsonManifest (path : Path.t) =
     let%bind pkgJson = RunAsync.ofRun (Json.parseJsonWith Manifest.RootPackageJson.of_yojson json) in
     let%bind resolutions = RunAsync.ofRun (Json.parseJsonWith PackageJsonWithResolutions.of_yojson json) in
     let manifest = Manifest.ofRootPackageJson pkgJson in
-    return (Some (manifest, resolutions.PackageJsonWithResolutions.resolutions))
+    return (Some (manifest, resolutions.PackageJsonWithResolutions.resolutions, Esy(filename)))
   | None -> return None
 
 let readAggregatedOpamManifest (path : Path.t) =

--- a/esyi/Sandbox.ml
+++ b/esyi/Sandbox.ml
@@ -24,10 +24,10 @@ let readPackageJsonManifest (path : Path.t) =
   match%bind Manifest.find path with
   | Some filename ->
     let%bind json = Fs.readJsonFile filename in
-    let%bind pkgJson = RunAsync.ofRun (Json.parseJsonWith Manifest.PackageJson.of_yojson json) in
+    let%bind pkgJson = RunAsync.ofRun (Json.parseJsonWith Manifest.RootPackageJson.of_yojson json) in
     let%bind resolutions = RunAsync.ofRun (Json.parseJsonWith PackageJsonWithResolutions.of_yojson json) in
-    let manifest = Manifest.ofPackageJson pkgJson in
-    return (Some (manifest, resolutions.PackageJsonWithResolutions.resolutions, Esy(filename)))
+    let manifest = Manifest.ofRootPackageJson pkgJson in
+    return (Some (manifest, resolutions.PackageJsonWithResolutions.resolutions))
   | None -> return None
 
 let readAggregatedOpamManifest (path : Path.t) =

--- a/test-e2e/complete/esy-sandbox.test.js
+++ b/test-e2e/complete/esy-sandbox.test.js
@@ -39,6 +39,33 @@ describe('complete workflow for esy sandboxes', () => {
     await p.esy('build');
   });
 
+  it('no package name, no dependencies, only ocaml devDep', async () => {
+    const fixture = [
+      packageJson({
+        version: '1.0.0',
+        esy: {
+          build: [
+            'cp root.ml #{self.target_dir/}root.ml',
+            'ocamlopt -o #{self.target_dir/}root.exe #{self.target_dir/}root.ml',
+          ],
+          install: ['cp #{self.target_dir/}root.exe #{self.bin/}root.exe'],
+        },
+        dependencies: {
+          ocaml: '*',
+        },
+        devDependencies: {
+          ocaml: '*',
+        },
+      }),
+      file('root.ml', 'print_endline "__root__"'),
+    ];
+    const p = await createTestSandbox(...fixture);
+    await p.esy('install');
+    await p.esy('build');
+    const {stdout} = await p.esy('x root.exe');
+    expect(stdout.trim()).toEqual('__root__');
+  });
+
   it('no dependencies, only ocaml devDep', async () => {
     const fixture = [
       packageJson({


### PR DESCRIPTION
This is a naive attempt at #324. The root package.json now has a default "root" package name.
Could the types of PackageJson and RootPackageJson be shared?
Should e2e tests that have the name set as "root" be changed as well?

Fixes #324 