### PR TITLE
 Fix lib, libexec, share, etc, doc opam vars to include opam package name

### DIFF
--- a/esy/Task.ml
+++ b/esy/Task.ml
@@ -186,14 +186,15 @@ end = struct
     let opamOsDistribution = opamOs in
 
 
+    let opamName (scope : PackageScope.t) =
+      match Astring.String.cut ~sep:"@opam/" scope.name with
+      | Some ("", name) -> name
+      | _ -> scope.name
+    in
+
+
     let opamPackageScope ?namespace (scope : PackageScope.t) name =
-
-      let opamName =
-        match Astring.String.cut ~sep:"@opam/" scope.name with
-        | Some ("", name) -> name
-        | _ -> name
-      in
-
+      let opamName = opamName scope in
       match namespace, name with
 
       (* some specials for ocaml *)
@@ -236,7 +237,22 @@ end = struct
     | Full.Global, "make" -> Some (string "make")
     | Full.Global, "jobs" -> Some (string "4")
     | Full.Global, "pinned" -> Some (bool false)
-    | Full.Global, name -> opamPackageScope scope.self name
+
+    | Full.Global, "prefix" -> Some (configPath scope.self.install)
+    | Full.Global, "bin" -> Some (configPath scope.self.bin)
+    | Full.Global, "sbin" -> Some (configPath scope.self.sbin)
+    | Full.Global, "etc" -> Some (configPath scope.self.etc)
+    | Full.Global, "doc" -> Some (configPath scope.self.doc)
+    | Full.Global, "man" -> Some (configPath scope.self.man)
+    | Full.Global, "share" -> Some (configPath scope.self.share)
+    | Full.Global, "stublibs" -> Some (configPath scope.self.stublibs)
+    | Full.Global, "toplevel" -> Some (configPath scope.self.toplevel)
+    | Full.Global, "lib" -> Some (configPath scope.self.lib)
+    | Full.Global, "libexec" -> Some (configPath scope.self.lib)
+    | Full.Global, "version" -> Some (string scope.self.version)
+    | Full.Global, "name" -> Some (string (opamName scope.self))
+
+    | Full.Global, _ -> None
 
     | Full.Self, "enable" -> Some (bool true)
     | Full.Self, "installed" -> Some (bool true)

--- a/esy/Task.ml
+++ b/esy/Task.ml
@@ -185,13 +185,15 @@ end = struct
     let opamOsFamily = opamOs in
     let opamOsDistribution = opamOs in
 
-    let toOpamName name =
-      match Astring.String.cut ~sep:"@opam/" name with
-      | Some ("", name) -> name
-      | _ -> name
-    in
 
     let opamPackageScope ?namespace (scope : PackageScope.t) name =
+
+      let opamName =
+        match Astring.String.cut ~sep:"@opam/" scope.name with
+        | Some ("", name) -> name
+        | _ -> name
+      in
+
       match namespace, name with
 
       (* some specials for ocaml *)
@@ -207,16 +209,20 @@ end = struct
       | _, "prefix" -> Some (configPath scope.install)
       | _, "bin" -> Some (configPath scope.bin)
       | _, "sbin" -> Some (configPath scope.sbin)
-      | _, "etc" -> Some (configPath scope.etc)
-      | _, "doc" -> Some (configPath scope.doc)
+      | _, "etc" -> Some (configPath Config.Path.(scope.etc / opamName))
+      | _, "doc" -> Some (configPath Config.Path.(scope.doc / opamName))
       | _, "man" -> Some (configPath scope.man)
-      | _, "share" -> Some (configPath scope.share)
+      | _, "share" -> Some (configPath Config.Path.(scope.share / opamName))
+      | _, "share_root" -> Some (configPath scope.share)
       | _, "stublibs" -> Some (configPath scope.stublibs)
       | _, "toplevel" -> Some (configPath scope.toplevel)
-      | _, "lib" -> Some (configPath scope.lib)
+      | _, "lib" -> Some (configPath Config.Path.(scope.lib / opamName))
+      | _, "lib_root" -> Some (configPath scope.lib)
+      | _, "libexec" -> Some (configPath Config.Path.(scope.lib / opamName))
+      | _, "libexec_root" -> Some (configPath scope.lib)
       | _, "build" -> Some (configPath scope.target_dir)
       | _, "version" -> Some (string scope.version)
-      | _, "name" -> Some (string (toOpamName scope.name))
+      | _, "name" -> Some (string opamName)
       | _ -> None
     in
 

--- a/test-e2e/build/opam-sandbox.test.js
+++ b/test-e2e/build/opam-sandbox.test.js
@@ -103,9 +103,13 @@ describe('build opam sandbox', () => {
         build: [
           ["global-prefix" prefix]
           ["global-lib" lib]
+          ["global-lib_root" lib_root]
+          ["global-libexec" libexec]
+          ["global-libexec_root" libexec_root]
           ["global-bin" bin]
           ["global-sbin" sbin]
           ["global-share" share]
+          ["global-share_root" share_root]
           ["global-doc" doc]
           ["global-etc" etc]
           ["global-man" man]
@@ -132,9 +136,13 @@ describe('build opam sandbox', () => {
           ["self-bin" _:bin]
           ["self-sbin" _:sbin]
           ["self-lib" _:lib]
+          ["self-lib_root" _:lib_root]
+          ["self-libexec" _:libexec]
+          ["self-libexec_root" _:libexec_root]
           ["self-man" _:man]
           ["self-doc" _:doc]
           ["self-share" _:share]
+          ["self-share_root" _:share_root]
           ["self-etc" _:etc]
           ["self-toplevel" _:toplevel]
           ["self-stublibs" _:stublibs]
@@ -152,9 +160,13 @@ describe('build opam sandbox', () => {
           ["scoped-bin" root:bin]
           ["scoped-sbin" root:sbin]
           ["scoped-lib" root:lib]
+          ["scoped-lib_root" root:lib_root]
+          ["scoped-libexec" root:libexec]
+          ["scoped-libexec_root" root:libexec_root]
           ["scoped-man" root:man]
           ["scoped-doc" root:doc]
           ["scoped-share" root:share]
+          ["scoped-share_root" root:share_root]
           ["scoped-etc" root:etc]
           ["scoped-toplevel" root:toplevel]
           ["scoped-stublibs" root:stublibs]
@@ -172,9 +184,13 @@ describe('build opam sandbox', () => {
           ["dep-bin" dep:bin]
           ["dep-sbin" dep:sbin]
           ["dep-lib" dep:lib]
+          ["dep-lib_root" dep:lib_root]
+          ["dep-libexec" dep:libexec]
+          ["dep-libexec_root" dep:libexec_root]
           ["dep-man" dep:man]
           ["dep-doc" dep:doc]
           ["dep-share" dep:share]
+          ["dep-share_root" dep:share_root]
           ["dep-etc" dep:etc]
           ["dep-toplevel" dep:toplevel]
           ["dep-stublibs" dep:stublibs]
@@ -186,9 +202,13 @@ describe('build opam sandbox', () => {
         install: [
           ["global-prefix" prefix]
           ["global-lib" lib]
+          ["global-lib_root" lib_root]
+          ["global-libexec" libexec]
+          ["global-libexec_root" libexec_root]
           ["global-bin" bin]
           ["global-sbin" sbin]
           ["global-share" share]
+          ["global-share_root" share_root]
           ["global-doc" doc]
           ["global-etc" etc]
           ["global-man" man]
@@ -215,9 +235,13 @@ describe('build opam sandbox', () => {
           ["self-bin" _:bin]
           ["self-sbin" _:sbin]
           ["self-lib" _:lib]
+          ["self-lib_root" _:lib_root]
+          ["self-libexec" _:libexec]
+          ["self-libexec_root" _:libexec_root]
           ["self-man" _:man]
           ["self-doc" _:doc]
           ["self-share" _:share]
+          ["self-share_root" _:share_root]
           ["self-etc" _:etc]
           ["self-toplevel" _:toplevel]
           ["self-stublibs" _:stublibs]
@@ -235,9 +259,13 @@ describe('build opam sandbox', () => {
           ["scoped-bin" root:bin]
           ["scoped-sbin" root:sbin]
           ["scoped-lib" root:lib]
+          ["scoped-lib_root" root:lib_root]
+          ["scoped-libexec" root:libexec]
+          ["scoped-libexec_root" root:libexec_root]
           ["scoped-man" root:man]
           ["scoped-doc" root:doc]
           ["scoped-share" root:share]
+          ["scoped-share_root" root:share_root]
           ["scoped-etc" root:etc]
           ["scoped-toplevel" root:toplevel]
           ["scoped-stublibs" root:stublibs]
@@ -255,9 +283,13 @@ describe('build opam sandbox', () => {
           ["dep-bin" dep:bin]
           ["dep-sbin" dep:sbin]
           ["dep-lib" dep:lib]
+          ["dep-lib_root" dep:lib_root]
+          ["dep-libexec" dep:libexec]
+          ["dep-libexec_root" dep:libexec_root]
           ["dep-man" dep:man]
           ["dep-doc" dep:doc]
           ["dep-share" dep:share]
+          ["dep-share_root" dep:share_root]
           ["dep-etc" dep:etc]
           ["dep-toplevel" dep:toplevel]
           ["dep-stublibs" dep:stublibs]
@@ -309,12 +341,16 @@ describe('build opam sandbox', () => {
 
     expect(plan.build).toEqual([
       ['global-prefix', `%{localStore}%/s/${plan.id}`],
-      ['global-lib', `%{localStore}%/s/${plan.id}/lib`],
+      ['global-lib', `%{localStore}%/s/${plan.id}/lib/root`],
+      ['global-lib_root', `%{localStore}%/s/${plan.id}/lib`],
+      ['global-libexec', `%{localStore}%/s/${plan.id}/lib/root`],
+      ['global-libexec_root', `%{localStore}%/s/${plan.id}/lib`],
       ['global-bin', `%{localStore}%/s/${plan.id}/bin`],
       ['global-sbin', `%{localStore}%/s/${plan.id}/sbin`],
-      ['global-share', `%{localStore}%/s/${plan.id}/share`],
-      ['global-doc', `%{localStore}%/s/${plan.id}/doc`],
-      ['global-etc', `%{localStore}%/s/${plan.id}/etc`],
+      ['global-share', `%{localStore}%/s/${plan.id}/share/root`],
+      ['global-share_root', `%{localStore}%/s/${plan.id}/share`],
+      ['global-doc', `%{localStore}%/s/${plan.id}/doc/root`],
+      ['global-etc', `%{localStore}%/s/${plan.id}/etc/root`],
       ['global-man', `%{localStore}%/s/${plan.id}/man`],
       ['global-toplevel', `%{localStore}%/s/${plan.id}/toplevel`],
       ['global-stublibs', `%{localStore}%/s/${plan.id}/stublibs`],
@@ -338,11 +374,15 @@ describe('build opam sandbox', () => {
       ['self-pinned', ''],
       ['self-bin', `%{localStore}%/s/${plan.id}/bin`],
       ['self-sbin', `%{localStore}%/s/${plan.id}/sbin`],
-      ['self-lib', `%{localStore}%/s/${plan.id}/lib`],
+      ['self-lib', `%{localStore}%/s/${plan.id}/lib/root`],
+      ['self-lib_root', `%{localStore}%/s/${plan.id}/lib`],
+      ['self-libexec', `%{localStore}%/s/${plan.id}/lib/root`],
+      ['self-libexec_root', `%{localStore}%/s/${plan.id}/lib`],
       ['self-man', `%{localStore}%/s/${plan.id}/man`],
-      ['self-doc', `%{localStore}%/s/${plan.id}/doc`],
-      ['self-share', `%{localStore}%/s/${plan.id}/share`],
-      ['self-etc', `%{localStore}%/s/${plan.id}/etc`],
+      ['self-doc', `%{localStore}%/s/${plan.id}/doc/root`],
+      ['self-share', `%{localStore}%/s/${plan.id}/share/root`],
+      ['self-share_root', `%{localStore}%/s/${plan.id}/share`],
+      ['self-etc', `%{localStore}%/s/${plan.id}/etc/root`],
       ['self-toplevel', `%{localStore}%/s/${plan.id}/toplevel`],
       ['self-stublibs', `%{localStore}%/s/${plan.id}/stublibs`],
       ['self-build', `%{localStore}%/b/${plan.id}`],
@@ -358,11 +398,15 @@ describe('build opam sandbox', () => {
       ['scoped-pinned', ''],
       ['scoped-bin', `%{localStore}%/s/${plan.id}/bin`],
       ['scoped-sbin', `%{localStore}%/s/${plan.id}/sbin`],
-      ['scoped-lib', `%{localStore}%/s/${plan.id}/lib`],
+      ['scoped-lib', `%{localStore}%/s/${plan.id}/lib/root`],
+      ['scoped-lib_root', `%{localStore}%/s/${plan.id}/lib`],
+      ['scoped-libexec', `%{localStore}%/s/${plan.id}/lib/root`],
+      ['scoped-libexec_root', `%{localStore}%/s/${plan.id}/lib`],
       ['scoped-man', `%{localStore}%/s/${plan.id}/man`],
-      ['scoped-doc', `%{localStore}%/s/${plan.id}/doc`],
-      ['scoped-share', `%{localStore}%/s/${plan.id}/share`],
-      ['scoped-etc', `%{localStore}%/s/${plan.id}/etc`],
+      ['scoped-doc', `%{localStore}%/s/${plan.id}/doc/root`],
+      ['scoped-share', `%{localStore}%/s/${plan.id}/share/root`],
+      ['scoped-share_root', `%{localStore}%/s/${plan.id}/share`],
+      ['scoped-etc', `%{localStore}%/s/${plan.id}/etc/root`],
       ['scoped-toplevel', `%{localStore}%/s/${plan.id}/toplevel`],
       ['scoped-stublibs', `%{localStore}%/s/${plan.id}/stublibs`],
       ['scoped-build', `%{localStore}%/b/${plan.id}`],
@@ -378,11 +422,15 @@ describe('build opam sandbox', () => {
       ['dep-pinned', ''],
       ['dep-bin', `%{store}%/i/${depPlan.id}/bin`],
       ['dep-sbin', `%{store}%/i/${depPlan.id}/sbin`],
-      ['dep-lib', `%{store}%/i/${depPlan.id}/lib`],
+      ['dep-lib', `%{store}%/i/${depPlan.id}/lib/dep`],
+      ['dep-lib_root', `%{store}%/i/${depPlan.id}/lib`],
+      ['dep-libexec', `%{store}%/i/${depPlan.id}/lib/dep`],
+      ['dep-libexec_root', `%{store}%/i/${depPlan.id}/lib`],
       ['dep-man', `%{store}%/i/${depPlan.id}/man`],
-      ['dep-doc', `%{store}%/i/${depPlan.id}/doc`],
-      ['dep-share', `%{store}%/i/${depPlan.id}/share`],
-      ['dep-etc', `%{store}%/i/${depPlan.id}/etc`],
+      ['dep-doc', `%{store}%/i/${depPlan.id}/doc/dep`],
+      ['dep-share', `%{store}%/i/${depPlan.id}/share/dep`],
+      ['dep-share_root', `%{store}%/i/${depPlan.id}/share`],
+      ['dep-etc', `%{store}%/i/${depPlan.id}/etc/dep`],
       ['dep-toplevel', `%{store}%/i/${depPlan.id}/toplevel`],
       ['dep-stublibs', `%{store}%/i/${depPlan.id}/stublibs`],
       ['dep-build', `%{store}%/b/${depPlan.id}`],
@@ -393,12 +441,16 @@ describe('build opam sandbox', () => {
 
     expect(plan.install).toEqual([
       ['global-prefix', `%{localStore}%/s/${plan.id}`],
-      ['global-lib', `%{localStore}%/s/${plan.id}/lib`],
+      ['global-lib', `%{localStore}%/s/${plan.id}/lib/root`],
+      ['global-lib_root', `%{localStore}%/s/${plan.id}/lib`],
+      ['global-libexec', `%{localStore}%/s/${plan.id}/lib/root`],
+      ['global-libexec_root', `%{localStore}%/s/${plan.id}/lib`],
       ['global-bin', `%{localStore}%/s/${plan.id}/bin`],
       ['global-sbin', `%{localStore}%/s/${plan.id}/sbin`],
-      ['global-share', `%{localStore}%/s/${plan.id}/share`],
-      ['global-doc', `%{localStore}%/s/${plan.id}/doc`],
-      ['global-etc', `%{localStore}%/s/${plan.id}/etc`],
+      ['global-share', `%{localStore}%/s/${plan.id}/share/root`],
+      ['global-share_root', `%{localStore}%/s/${plan.id}/share`],
+      ['global-doc', `%{localStore}%/s/${plan.id}/doc/root`],
+      ['global-etc', `%{localStore}%/s/${plan.id}/etc/root`],
       ['global-man', `%{localStore}%/s/${plan.id}/man`],
       ['global-toplevel', `%{localStore}%/s/${plan.id}/toplevel`],
       ['global-stublibs', `%{localStore}%/s/${plan.id}/stublibs`],
@@ -422,11 +474,15 @@ describe('build opam sandbox', () => {
       ['self-pinned', ''],
       ['self-bin', `%{localStore}%/s/${plan.id}/bin`],
       ['self-sbin', `%{localStore}%/s/${plan.id}/sbin`],
-      ['self-lib', `%{localStore}%/s/${plan.id}/lib`],
+      ['self-lib', `%{localStore}%/s/${plan.id}/lib/root`],
+      ['self-lib_root', `%{localStore}%/s/${plan.id}/lib`],
+      ['self-libexec', `%{localStore}%/s/${plan.id}/lib/root`],
+      ['self-libexec_root', `%{localStore}%/s/${plan.id}/lib`],
       ['self-man', `%{localStore}%/s/${plan.id}/man`],
-      ['self-doc', `%{localStore}%/s/${plan.id}/doc`],
-      ['self-share', `%{localStore}%/s/${plan.id}/share`],
-      ['self-etc', `%{localStore}%/s/${plan.id}/etc`],
+      ['self-doc', `%{localStore}%/s/${plan.id}/doc/root`],
+      ['self-share', `%{localStore}%/s/${plan.id}/share/root`],
+      ['self-share_root', `%{localStore}%/s/${plan.id}/share`],
+      ['self-etc', `%{localStore}%/s/${plan.id}/etc/root`],
       ['self-toplevel', `%{localStore}%/s/${plan.id}/toplevel`],
       ['self-stublibs', `%{localStore}%/s/${plan.id}/stublibs`],
       ['self-build', `%{localStore}%/b/${plan.id}`],
@@ -442,11 +498,15 @@ describe('build opam sandbox', () => {
       ['scoped-pinned', ''],
       ['scoped-bin', `%{localStore}%/s/${plan.id}/bin`],
       ['scoped-sbin', `%{localStore}%/s/${plan.id}/sbin`],
-      ['scoped-lib', `%{localStore}%/s/${plan.id}/lib`],
+      ['scoped-lib', `%{localStore}%/s/${plan.id}/lib/root`],
+      ['scoped-lib_root', `%{localStore}%/s/${plan.id}/lib`],
+      ['scoped-libexec', `%{localStore}%/s/${plan.id}/lib/root`],
+      ['scoped-libexec_root', `%{localStore}%/s/${plan.id}/lib`],
       ['scoped-man', `%{localStore}%/s/${plan.id}/man`],
-      ['scoped-doc', `%{localStore}%/s/${plan.id}/doc`],
-      ['scoped-share', `%{localStore}%/s/${plan.id}/share`],
-      ['scoped-etc', `%{localStore}%/s/${plan.id}/etc`],
+      ['scoped-doc', `%{localStore}%/s/${plan.id}/doc/root`],
+      ['scoped-share', `%{localStore}%/s/${plan.id}/share/root`],
+      ['scoped-share_root', `%{localStore}%/s/${plan.id}/share`],
+      ['scoped-etc', `%{localStore}%/s/${plan.id}/etc/root`],
       ['scoped-toplevel', `%{localStore}%/s/${plan.id}/toplevel`],
       ['scoped-stublibs', `%{localStore}%/s/${plan.id}/stublibs`],
       ['scoped-build', `%{localStore}%/b/${plan.id}`],
@@ -462,11 +522,15 @@ describe('build opam sandbox', () => {
       ['dep-pinned', ''],
       ['dep-bin', `%{store}%/i/${depPlan.id}/bin`],
       ['dep-sbin', `%{store}%/i/${depPlan.id}/sbin`],
-      ['dep-lib', `%{store}%/i/${depPlan.id}/lib`],
+      ['dep-lib', `%{store}%/i/${depPlan.id}/lib/dep`],
+      ['dep-lib_root', `%{store}%/i/${depPlan.id}/lib`],
+      ['dep-libexec', `%{store}%/i/${depPlan.id}/lib/dep`],
+      ['dep-libexec_root', `%{store}%/i/${depPlan.id}/lib`],
       ['dep-man', `%{store}%/i/${depPlan.id}/man`],
-      ['dep-doc', `%{store}%/i/${depPlan.id}/doc`],
-      ['dep-share', `%{store}%/i/${depPlan.id}/share`],
-      ['dep-etc', `%{store}%/i/${depPlan.id}/etc`],
+      ['dep-doc', `%{store}%/i/${depPlan.id}/doc/dep`],
+      ['dep-share', `%{store}%/i/${depPlan.id}/share/dep`],
+      ['dep-share_root', `%{store}%/i/${depPlan.id}/share`],
+      ['dep-etc', `%{store}%/i/${depPlan.id}/etc/dep`],
       ['dep-toplevel', `%{store}%/i/${depPlan.id}/toplevel`],
       ['dep-stublibs', `%{store}%/i/${depPlan.id}/stublibs`],
       ['dep-build', `%{store}%/b/${depPlan.id}`],

--- a/test-e2e/build/opam-sandbox.test.js
+++ b/test-e2e/build/opam-sandbox.test.js
@@ -103,13 +103,10 @@ describe('build opam sandbox', () => {
         build: [
           ["global-prefix" prefix]
           ["global-lib" lib]
-          ["global-lib_root" lib_root]
           ["global-libexec" libexec]
-          ["global-libexec_root" libexec_root]
           ["global-bin" bin]
           ["global-sbin" sbin]
           ["global-share" share]
-          ["global-share_root" share_root]
           ["global-doc" doc]
           ["global-etc" etc]
           ["global-man" man]
@@ -202,13 +199,10 @@ describe('build opam sandbox', () => {
         install: [
           ["global-prefix" prefix]
           ["global-lib" lib]
-          ["global-lib_root" lib_root]
           ["global-libexec" libexec]
-          ["global-libexec_root" libexec_root]
           ["global-bin" bin]
           ["global-sbin" sbin]
           ["global-share" share]
-          ["global-share_root" share_root]
           ["global-doc" doc]
           ["global-etc" etc]
           ["global-man" man]
@@ -341,16 +335,13 @@ describe('build opam sandbox', () => {
 
     expect(plan.build).toEqual([
       ['global-prefix', `%{localStore}%/s/${plan.id}`],
-      ['global-lib', `%{localStore}%/s/${plan.id}/lib/root`],
-      ['global-lib_root', `%{localStore}%/s/${plan.id}/lib`],
-      ['global-libexec', `%{localStore}%/s/${plan.id}/lib/root`],
-      ['global-libexec_root', `%{localStore}%/s/${plan.id}/lib`],
+      ['global-lib', `%{localStore}%/s/${plan.id}/lib`],
+      ['global-libexec', `%{localStore}%/s/${plan.id}/lib`],
       ['global-bin', `%{localStore}%/s/${plan.id}/bin`],
       ['global-sbin', `%{localStore}%/s/${plan.id}/sbin`],
-      ['global-share', `%{localStore}%/s/${plan.id}/share/root`],
-      ['global-share_root', `%{localStore}%/s/${plan.id}/share`],
-      ['global-doc', `%{localStore}%/s/${plan.id}/doc/root`],
-      ['global-etc', `%{localStore}%/s/${plan.id}/etc/root`],
+      ['global-share', `%{localStore}%/s/${plan.id}/share`],
+      ['global-doc', `%{localStore}%/s/${plan.id}/doc`],
+      ['global-etc', `%{localStore}%/s/${plan.id}/etc`],
       ['global-man', `%{localStore}%/s/${plan.id}/man`],
       ['global-toplevel', `%{localStore}%/s/${plan.id}/toplevel`],
       ['global-stublibs', `%{localStore}%/s/${plan.id}/stublibs`],
@@ -441,16 +432,13 @@ describe('build opam sandbox', () => {
 
     expect(plan.install).toEqual([
       ['global-prefix', `%{localStore}%/s/${plan.id}`],
-      ['global-lib', `%{localStore}%/s/${plan.id}/lib/root`],
-      ['global-lib_root', `%{localStore}%/s/${plan.id}/lib`],
-      ['global-libexec', `%{localStore}%/s/${plan.id}/lib/root`],
-      ['global-libexec_root', `%{localStore}%/s/${plan.id}/lib`],
+      ['global-lib', `%{localStore}%/s/${plan.id}/lib`],
+      ['global-libexec', `%{localStore}%/s/${plan.id}/lib`],
       ['global-bin', `%{localStore}%/s/${plan.id}/bin`],
       ['global-sbin', `%{localStore}%/s/${plan.id}/sbin`],
-      ['global-share', `%{localStore}%/s/${plan.id}/share/root`],
-      ['global-share_root', `%{localStore}%/s/${plan.id}/share`],
-      ['global-doc', `%{localStore}%/s/${plan.id}/doc/root`],
-      ['global-etc', `%{localStore}%/s/${plan.id}/etc/root`],
+      ['global-share', `%{localStore}%/s/${plan.id}/share`],
+      ['global-doc', `%{localStore}%/s/${plan.id}/doc`],
+      ['global-etc', `%{localStore}%/s/${plan.id}/etc`],
       ['global-man', `%{localStore}%/s/${plan.id}/man`],
       ['global-toplevel', `%{localStore}%/s/${plan.id}/toplevel`],
       ['global-stublibs', `%{localStore}%/s/${plan.id}/stublibs`],


### PR DESCRIPTION
This unbreaks odoc which expect `odoc:etc` to point to `PREFIX/etc/odoc` not `PREFIX/etc` as it was before.
