### PR TITLE
Include deps by default if unknown filter is found

### DIFF
--- a/esy/Manifest.ml
+++ b/esy/Manifest.ml
@@ -480,7 +480,7 @@ end = struct
   let listPackageNamesOfFormula ~build ~test ~post ~doc ~dev formula =
     let formula =
       OpamFilter.filter_deps
-        ~build ~post ~test ~doc ~dev
+        ~default:true ~build ~post ~test ~doc ~dev
         formula
     in
     let cnf = OpamFormula.to_cnf formula in

--- a/esyi/OpamManifest.ml
+++ b/esyi/OpamManifest.ml
@@ -213,7 +213,7 @@ let convertDependencies manifest =
         in
         OpamFilter.partial_filter_formula env f
       in
-      try return (OpamFilter.filter_deps ~build ~post ~test ~doc ~dev f)
+      try return (OpamFilter.filter_deps ~default:true ~build ~post ~test ~doc ~dev f)
       with Failure msg -> Error msg
     in
     convertOpamFormula f

--- a/test-e2e/build-top-100-opam.slowtest.js
+++ b/test-e2e/build-top-100-opam.slowtest.js
@@ -49,6 +49,7 @@ const cases = [
   {name: 'xmlm', toolchains: ['~4.6.0']},
   {name: 'configurator', toolchains: ['~4.6.0']},
   {name: 'bin_prot', toolchains: ['~4.6.0']},
+  {name: 'conf-libcurl', toolchains: ['~4.6.0']},
   {name: 'core_kernel', toolchains: ['~4.6.0']},
   {name: 'zed', toolchains: ['~4.6.0']},
   {name: 'lambda-term', toolchains: ['~4.6.0']},


### PR DESCRIPTION
We have a problem with dependencies filters which condition on `os` - we don't
support different lockfiles for different platforms now. Therefore we just going
to install them by default.