### PR TITLE
Apply resolutions for non-esy packages

### DIFF
--- a/esyi/Solver.ml
+++ b/esyi/Solver.ml
@@ -559,6 +559,9 @@ let solveDependenciesNaively
   in
 
   let solveDependencies dependencies =
+    let dependencies =
+      Dependencies.applyResolutions solver.resolutions dependencies
+    in
     let reqs =
       match dependencies with
       | Dependencies.NpmFormula reqs -> reqs

--- a/test-e2e/install/resolutions.test.js
+++ b/test-e2e/install/resolutions.test.js
@@ -86,4 +86,46 @@ describe(`Installing with resolutions`, () => {
       },
     });
   });
+
+  test(`it should find resolutions for non-esy npm packages`, async () => {
+    const fixture = [
+      helpers.packageJson({
+        name: 'root',
+        version: '1.0.0',
+        dependencies: {dep: `1.0.0`},
+        resolutions: {depDep: `2.0.0`},
+      }),
+    ];
+    const p = await helpers.createTestSandbox(...fixture);
+    await p.defineNpmPackage({
+      name: 'dep',
+      version: '1.0.0',
+      dependencies: {depDep: `1.0.0`},
+    });
+    await p.defineNpmPackage({
+      name: 'depDep',
+      version: '1.0.0',
+    });
+    await p.defineNpmPackage({
+      name: 'depDep',
+      version: '2.0.0',
+    });
+
+    await p.esy(`install`);
+
+    const layout = await helpers.crawlLayout(p.projectPath);
+    expect(layout).toMatchObject({
+      name: 'root',
+      dependencies: {
+        dep: {
+          name: 'dep',
+          version: '1.0.0',
+        },
+        depDep: {
+          name: 'depDep',
+          version: '2.0.0',
+        },
+      },
+    });
+  });
 });


### PR DESCRIPTION
This PR adds a fix that allows link resolutions to be applied to non-esy packages as well. (i.e packages without `esy` section in their configs)

It also adds a fix for npm packages that has empty bin sections, like so: `"bin": ""`.

Closes #369.