### PR TITLE
Windows: Fix 'uname' is not recognized error

### DIFF
--- a/esy-lib/System.ml
+++ b/esy-lib/System.ml
@@ -22,7 +22,6 @@ module Platform = struct
 
   let host =
     let uname () =
-      print_endline ("Platform.host.uname");
       let ic = Unix.open_process_in "uname" in
       let uname = input_line ic in
       let () = close_in ic in

--- a/esy-lib/System.ml
+++ b/esy-lib/System.ml
@@ -22,6 +22,7 @@ module Platform = struct
 
   let host =
     let uname () =
+      print_endline ("Platform.host.uname");
       let ic = Unix.open_process_in "uname" in
       let uname = input_line ic in
       let () = close_in ic in
@@ -64,12 +65,19 @@ module Arch = struct
 
   let host =
     let uname () =
-      let ic = Unix.open_process_in "uname -m" in
+      let cmd =
+          match Platform.host with
+          | Windows -> "echo %PROCESSOR_ARCHITECTURE%"
+          | _ -> "uname -m"
+      in
+      let ic = Unix.open_process_in cmd in
       let uname = input_line ic in
       let () = close_in ic in
-      match String.lowercase_ascii uname with
-      | "x86_32" -> X86_32
-      | "x86_64" -> X86_64
+      match String.trim (String.lowercase_ascii uname) with
+      (* Return values for Windows PROCESSOR_ARCHITECTURE environment variable *)
+      | "x86" -> X86_32
+      | "amd64" -> X86_64
+      (* Return values for uname on other platforms *)
       | "ppc32" -> Ppc32
       | "ppc64" -> Ppc64
       | "arm32" -> Arm32


### PR DESCRIPTION
__Issue:__ When running the latest master, `esy install` fails with:
```
'uname' is not recognized as an internal or external command,
operable program or batch file.
Fatal error: exception End_of_file
Raised at file "pervasives.ml", line 440, characters 14-31
Called from file "esy-lib/System.ml", line 68, characters 18-31
Called from file "esy-lib/System.ml", line 79, characters 4-12
```

__Defect:__  This looks like a regression from #351 , which may have unfortunately slipped through the cracks as we don't use `esy install` today in our Windows e2e tests (we use `legacy-install` at the moment). 

__Fix:__ Unfortunately, it doesn't seem like OCaml has a straightforward way to check the architecture (it'd be nice to have a parallel to `os.arch()` in Node!) On Windows, the `uname -m` check isn't going to work - we'd either need to defer to Cygwin (which would add some complexity to this codepath), or have another way to detect architecture. 

For Windows, I check the `PROCESSOR_ARCHITECTURE` environment variable - some more information about how this variable is populated is here: https://docs.microsoft.com/en-us/windows/desktop/WinProg64/wow64-implementation-details This environment variable seems to handle the WOW cases in the way we want (ie, running a 32-bit process in 64-bit windows would report `x86`).

cc @ulrikstrid @andreypopp 