### PR TITLE
Windows - esyi: Permission denied error on install

### DIFF
--- a/esy-lib/Fs.ml
+++ b/esy-lib/Fs.ml
@@ -330,7 +330,7 @@ let withTempDir ?tempDir f =
   let%lwt () = Lwt_unix.mkdir (Path.toString path) 0o700 in
   Lwt.finalize
     (fun () -> f path)
-    (fun () -> Lwt.return ())
+    (fun () -> rmPathLwt path)
 
 let withTempFile ~data f =
   let path = Filename.temp_file "esy" "tmp" in

--- a/test/Fs.ml
+++ b/test/Fs.ml
@@ -1,0 +1,51 @@
+include EsyLib.Curl
+
+module EsyBash = EsyLib.EsyBash
+module Fs = EsyLib.Fs
+module Path = EsyLib.Path
+module RunAsync = EsyLib.RunAsync
+module Result = EsyLib.Result
+
+let%test "copyPathLwt - copy simple file" =
+    let test () = 
+        let f tempPath =
+            let src = Path.(tempPath / "src.txt") in
+            let dst = Path.(tempPath / "dst.txt") in
+            let data = "test" in
+            let%lwt _ = Fs.createDir tempPath in
+            let%lwt _ = Fs.writeFile ~data src in
+
+            (* use curl to copy the file, as opposed to hitting an external server *)
+            let%lwt _ = Fs.copyPath ~src ~dst in
+            let%lwt exists = Fs.exists dst in
+            match exists with
+            | Ok v -> Lwt.return v
+            | _ -> Lwt.return false
+        in
+        Fs.withTempDir f
+    in
+    TestLwt.runLwtTest test
+
+
+let%test "copyPathLwt - copy nested file" =
+    let test () = 
+        let f tempPath =
+            let nestedSrc = Path.(tempPath / "src_root" / "nested1") in
+            let nestedDest = Path.(tempPath / "dest_root" / "nested2") in
+            print_endline("temppath: " ^ Path.toString tempPath);
+            let src = Path.(nestedSrc / "src.txt") in
+            let dst = Path.(nestedDest / "dst.txt") in
+            let data = "test" in
+            let%lwt _ = Fs.createDir nestedSrc in
+            let%lwt _ = Fs.writeFile ~data src in
+
+            (* use curl to copy the file, as opposed to hitting an external server *)
+            let%lwt _ = Fs.copyPath ~src ~dst in
+            let%lwt exists = Fs.exists dst in
+            match exists with
+            | Ok v -> Lwt.return v
+            | _ -> Lwt.return false
+        in
+        Fs.withTempDir f
+    in
+    TestLwt.runLwtTest test

--- a/test/Fs.ml
+++ b/test/Fs.ml
@@ -1,13 +1,10 @@
 include EsyLib.Curl
 
-module EsyBash = EsyLib.EsyBash
 module Fs = EsyLib.Fs
 module Path = EsyLib.Path
-module RunAsync = EsyLib.RunAsync
-module Result = EsyLib.Result
 
 let%test "copyPathLwt - copy simple file" =
-    let test () = 
+    let test () =
         let f tempPath =
             let src = Path.(tempPath / "src.txt") in
             let dst = Path.(tempPath / "dst.txt") in
@@ -15,8 +12,8 @@ let%test "copyPathLwt - copy simple file" =
             let%lwt _ = Fs.createDir tempPath in
             let%lwt _ = Fs.writeFile ~data src in
 
-            (* use curl to copy the file, as opposed to hitting an external server *)
             let%lwt _ = Fs.copyPath ~src ~dst in
+
             let%lwt exists = Fs.exists dst in
             match exists with
             | Ok v -> Lwt.return v
@@ -28,19 +25,18 @@ let%test "copyPathLwt - copy simple file" =
 
 
 let%test "copyPathLwt - copy nested file" =
-    let test () = 
+    let test () =
         let f tempPath =
             let nestedSrc = Path.(tempPath / "src_root" / "nested1") in
             let nestedDest = Path.(tempPath / "dest_root" / "nested2") in
-            print_endline("temppath: " ^ Path.toString tempPath);
             let src = Path.(nestedSrc / "src.txt") in
             let dst = Path.(nestedDest / "dst.txt") in
             let data = "test" in
             let%lwt _ = Fs.createDir nestedSrc in
             let%lwt _ = Fs.writeFile ~data src in
 
-            (* use curl to copy the file, as opposed to hitting an external server *)
             let%lwt _ = Fs.copyPath ~src ~dst in
+
             let%lwt exists = Fs.exists dst in
             match exists with
             | Ok v -> Lwt.return v


### PR DESCRIPTION
__Issue:__ After #375, this error occurs when trying to run `esy install` against a project with a lockfile:
```
esyi: Permission denied
        fetching
      archive:https://opam.ocaml.org/archives/dune.1.0.1+opam.tar.gz#md5:bcfdd66662b5306c42ca8185deb39862****
```

__Defect:__ The error occurs when we run `Fs.copyPath` after extracting the tarball (as part of our stripComponents logic). When we attempt to `chmod` a directory, we get this permission denied error.

__Fix:__ On Windows, don't use `chmod` - the file permission model is different. At best, it is not necessary, and at worst, we get errors. See this for some difference sin the file system models: https://superuser.com/questions/106181/equivalent-of-chmod-to-change-file-permissions-in-windows

__Test Impact:__ Start adding unit tests to cover the `copyPath` code path - one for a simple file, and one for a file in a nested folder hierarchy.

cc @andreypopp @ulrikstrid 