### PR TITLE
[WIP] Windows - esy-build-package: Permission denied error

### DIFF
--- a/esy-build-package/Run.re
+++ b/esy-build-package/Run.re
@@ -45,12 +45,16 @@ let rm = path =>
   | Ok({Unix.st_kind: S_DIR, _}) =>
     Bos.OS.Path.delete(~must_exist=false, ~recurse=true, path)
   | Ok({Unix.st_kind: S_LNK, _}) =>
-    switch (Bos.OS.U.unlink(path)) {
-    | Ok () => ok
-    | Error(`Unix(err)) =>
-      let msg = Unix.error_message(err);
-      error(msg);
-    }
+    switch (System.Platform.host) {
+    | Windows => Bos.OS.Path.delete(~must_exist=false, ~recurse=true, path)
+    | _ =>
+        switch (Bos.OS.U.unlink(path)) {
+        | Ok () => ok
+        | Error(`Unix(err)) =>
+          let msg = Unix.error_message(err);
+          error(msg);
+        };
+    };
   | Ok({Unix.st_kind: _, _}) => Bos.OS.Path.delete(~must_exist=false, path)
   | Error(_) => ok
   };


### PR DESCRIPTION
__NOTE:__ This is on-top of #375 and requires that change first.

__Issue:__ Several of the e2e tests are failing with a `Permission Denied` error when running `esy-build-package` on Windows. An example failure looks like:
```
AIL test-e2e/build/with-linked-dep.test.js (6.662s)
  ● Build - with linked dep › package "dep" should be visible in all envs
    Error
      Error: Command failed: C:\projects\esy\_release\_build\default\esy\bin\esyCommand.exe b dep
      esy-build-package: Permission denied
  ● Build - with linked dep › should not rebuild dep with no changes
    Error
      Error: Command failed: C:\projects\esy\_release\_build\default\esy\bin\esyCommand.exe build
      info esy build 0.2.7
      esy-build-package: Permission denied
      esy: error, exiting...
           build failed
             Building with-linked-dep@1.0.0
```

__Defect:__ This is a regression from #357 , which refactored this functionality to handle links. Unfortunately, the link specific code - specifically, the `Bos.OS.U.unlink` that was introduced - doesn't seem to work the same on Windows.

__Fix:__ For the link case, revert back to the previous behavior on Windows.

With this change + #375 , the e2e tests are passing locally for me.

cc @andreypopp @ulrikstrid 