### PR TITLE
README: Show AppVeyor status of master branch instead of latest build

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 `package.json` workflow for native development with Reason/OCaml.
 
-[![AppVeyor](https://ci.appveyor.com/api/projects/status/0x1mwqeblcgpqyc0?svg=true)](https://ci.appveyor.com/project/esy/esy)
+[![AppVeyor](https://ci.appveyor.com/api/projects/status/0x1mwqeblcgpqyc0/branch/master?svg=true)](https://ci.appveyor.com/project/esy/esy/branch/master)
 [![Travis](https://travis-ci.org/esy/esy.svg?branch=master)](https://travis-ci.org/esy/esy)
 [![npm](https://img.shields.io/npm/v/esy.svg)](https://www.npmjs.com/package/esy)
 [![npm (tag)](https://img.shields.io/npm/v/esy/next.svg)](https://www.npmjs.com/package/esy)


### PR DESCRIPTION
For the `README`, it's more useful to show the build state of `master` vs the latest build (since there can be noise from PRs) - we already do this for our travis builds, so it makes sense for AppVeyor to show the latest master build too.