### PR TITLE
Windows: Don't crash on failure to delete temp folder

### DIFF
--- a/esy-lib/Fs.ml
+++ b/esy-lib/Fs.ml
@@ -330,7 +330,10 @@ let withTempDir ?tempDir f =
   let%lwt () = Lwt_unix.mkdir (Path.toString path) 0o700 in
   Lwt.finalize
     (fun () -> f path)
-    (fun () -> rmPathLwt path)
+    (fun () -> 
+       (* never fail on removing a temp folder. *)
+       try%lwt rmPathLwt path
+       with Unix.Unix_error _ -> Lwt.return ())
 
 let withTempFile ~data f =
   let path = Filename.temp_file "esy" "tmp" in


### PR DESCRIPTION
__Issue:__ `Fs.withTempDir` seems to fail intermittently. Likely related to #274 / #285 

The error is of the form:
```
E:\esy-minimal-dune-project [master ≡]> E:\esy\_release\_build\default\esy\bin\esyCommand.exe install
info esy install 0.2.7
.... fetching ocaml@github:esy-ocaml/ocaml#6aacc05esyi: internal error, uncaught exception:
      Unix.Unix_error(Unix.EACCES, "unlink", "C:\\Users\\bryph\\AppData\\Local\\Temp\\esy-bc1b2b\\_esy\\opam")
      Raised at file "src/core/lwt.ml", line 3008, characters 20-29
      Called from file "src/unix/lwt_main.ml", line 42, characters 8-18
      Called from file "esyi/bin/esyi.re.ml", line 382, characters 13-30
      Called from file "src/cmdliner_term.ml", line 27, characters 19-24
      Called from file "src/cmdliner.ml", line 27, characters 27-34
      Called from file "src/cmdliner.ml", line 106, characters 32-39
esy: error, exiting...
     error running command:
     "E:\esy\_release\_build\default\esyi\bin\esyi.exe"
```

__Fix:__ As in #285 , we don't want to crash if we were unable to clean up a temporary folder.