### PR TITLE
Windows: Fix another 'Permission Denied' error with 'esyi'

### DIFF
--- a/esy-lib/Fs.ml
+++ b/esy-lib/Fs.ml
@@ -178,9 +178,9 @@ let copyStatLwt ~stat path =
     let%lwt () = Lwt_unix.utimes path stat.Unix.st_atime stat.Unix.st_mtime in
     let%lwt () = Lwt_unix.chmod path stat.Unix.st_perm in
     let%lwt () = 
-      try%lwt Lwt_unix.chown path uid gid
+      try%lwt Lwt_unix.chown path stat.Unix.st_uid stat.Unix.st_gid 
       with Unix.Unix_error (Unix.EPERM, _, _) -> Lwt.return ()
-    Lwt.return ()
+    in Lwt.return ()
 
 let copyFileLwt ~src ~dst =
 

--- a/esy-lib/Fs.ml
+++ b/esy-lib/Fs.ml
@@ -170,24 +170,17 @@ let traverse ?skipTraverse ~f path =
   let f _ path stat = f path stat in
   fold ?skipTraverse ~f ~init:() path
 
-let chownOrIgnoreLwt path uid gid =
-  match System.Platform.host with
-  | Windows -> Lwt.return () (* chown is not available in Windows *)
-  | _ ->
-    try%lwt Lwt_unix.chown path uid gid
-    with Unix.Unix_error (Unix.EPERM, _, _) -> Lwt.return ()
-
-let chmodOrIgnoreLwt path uid =
-  match System.Platform.host with
-  | Windows -> Lwt.return () (* chmod is not necessary on Windows, and can cause Permission Denied errors *)
-  | _ -> Lwt_unix.chmod path uid
-
 let copyStatLwt ~stat path =
-  let path = Path.toString path in
-  let%lwt () = Lwt_unix.utimes path stat.Unix.st_atime stat.Unix.st_mtime in
-  let%lwt () = chmodOrIgnoreLwt path stat.Unix.st_perm in
-  let%lwt () = chownOrIgnoreLwt path stat.Unix.st_uid stat.Unix.st_gid in
-  Lwt.return ()
+  match System.Platform.host with
+  | Windows -> Lwt.return () (* copying these stats is not necessary on Windows, and can cause Permission Denied errors *)
+  | _ ->
+    let path = Path.toString path in
+    let%lwt () = Lwt_unix.utimes path stat.Unix.st_atime stat.Unix.st_mtime in
+    let%lwt () = Lwt_unix.chmod path stat.Unix.st_perm in
+    let%lwt () = 
+      try%lwt Lwt_unix.chown path uid gid
+      with Unix.Unix_error (Unix.EPERM, _, _) -> Lwt.return ()
+    Lwt.return ()
 
 let copyFileLwt ~src ~dst =
 


### PR DESCRIPTION
__Issue:__ When running `esy install` on a brand new cache, after #381 is fixed, the next error hit is:
```
E:\esy-minimal-dune-project [master ≡]> E:\esy\_release\_build\default\esy\bin\esyCommand.exe install
info esy install 0.2.7
esyi: Permission denied
        fetching
      archive:https://opam.ocaml.org/archives/dune.1.0.1+opam.tar.gz#md5:bcfdd66662b5306c42ca8185deb39862
esy: error, exiting...
     error running command:
     "E:\esy\_release\_build\default\esyi\bin\esyi.exe"
```

__Defect:__ Same issue as #376, but the fix was incomplete, as the `Lwt_unix.utimes` call is also problematic on Windows. 

__Fix:__ Since the `utimes` / `chmod` / `chown` are all problematic on Windows, I factored them back into `copyStatLwt`, and forked the entire function - if it's Windows, it's a no-op, otherwise we'll run through the usual codepath
