### PR TITLE
Windows - Development: Fix line endings for shell script files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,4 +3,4 @@
 # means that when checking out code, LF endings get converted
 # to CRLF. This causes problems for shell scripts, as bash
 # gets choked up on the extra `\r` character.
-**/*.sh text eol=LF
+*.sh text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -3,4 +3,4 @@
 # means that when checking out code, LF endings get converted
 # to CRLF. This causes problems for shell scripts, as bash
 # gets choked up on the extra `\r` character.
-*.sh text eol=LF
+**/*.sh text eol=LF


### PR DESCRIPTION
__Issue:__ Depending on gits `core.autocrlf` setting, Windows may try to normalize the line endings to `CRLF` and then send them back as `LF`. This causes problems for our bash shell scripts, as they are executed in a cygwin environment, and that environment doesn't know how to read `CRLF`, so you'll get an error like:
```
./scripts/bootstrap/build-bootstrap.sh: line 2: $'\r': command not found
```
__Fix:__ Our `.gitattributes` file should've handled this, but it seems like the line ending settings weren't properly applied. Fixing the casing of `LF` -> `lf` seemed to address this.