### PR TITLE
Windows: Upgrade esy-bash from 0.1.21-> 0.1.22

### DIFF
--- a/scripts/bootstrap/build-bootstrap.sh
+++ b/scripts/bootstrap/build-bootstrap.sh
@@ -42,5 +42,7 @@ make _release/bin/fastreplacestring
 cd _release
 npm install @esy-ocaml/esy-opam
 
-echo "release: copy esy-bash"
-cp -r ../node_modules/esy-bash node_modules/esy-bash
+echo "release: link esy-bash"
+cd node_modules
+rm -rf esy-bash
+ln -s ./../../node_modules/esy-bash esy-bash

--- a/scripts/bootstrap/install-npm-dependencies.ps1
+++ b/scripts/bootstrap/install-npm-dependencies.ps1
@@ -29,7 +29,7 @@ npm install rimraf
 
 # If updating the version for this,
 # make sure to also update it in `scripts/release-postinstall.js`, too!
-npm install esy-bash@0.1.21
+npm install esy-bash@0.1.22
 
 npm install esy-ocaml/FastReplaceString.git#9450b6
 

--- a/scripts/release-postinstall.js
+++ b/scripts/release-postinstall.js
@@ -60,7 +60,7 @@ switch (platform) {
     copyPlatformBinaries('windows-x64');
 
     console.log('Installing cygwin sandbox...');
-    cp.execSync('npm install esy-bash@0.1.21');
+    cp.execSync('npm install esy-bash@0.1.22');
     console.log('Cygwin installed successfully.');
     break;
   case 'linux':


### PR DESCRIPTION
This upgrades `esy-bash` from 0.1.21 -> 0.1.22, picking up bryphe/esy-bash#11

This is a fix needed to correct symlinking behavior on Windows. 