### PR TITLE
Fix #397 - Update postinstall step to install esy-bash directly in esy folder

### DIFF
--- a/scripts/release-postinstall.js
+++ b/scripts/release-postinstall.js
@@ -59,7 +59,7 @@ switch (platform) {
     copyPlatformBinaries('windows-x64');
 
     console.log('Installing cygwin sandbox...');
-    cp.execSync('npm install esy-bash@0.1.22');
+    cp.execSync(`npm install esy-bash@0.1.22 --prefix ${__dirname}`);
     console.log('Cygwin installed successfully.');
     break;
   case 'linux':


### PR DESCRIPTION
__Issue:__ Running `esy install` fails with `npm install -g esy@0.2.8` as described in #397 

__Defect:__ As part of our postinstall step, we install the `esy-bash` sandbox. This is expected to be at the root of `esy` - all our resolution logic depends on it being placed there. However, it seems that `npm` may promote this to be at the root `node_modules` folder as a sibling to `esy`, instead of installing in `esy`.

__Fix:__ Specify a `--prefix` path to force `npm` to install `esy-bash` in the `esy` folder, instead of promoting it to a global package.