### PR TITLE
Windows: refmterr fails with 'unable to resolve command: refmterr'

### DIFF
--- a/esy-lib/Cmd.ml
+++ b/esy-lib/Cmd.ml
@@ -79,14 +79,24 @@ let getPotentialExtensions =
     | Windows -> [""; ".exe"]
     | _ -> [""]
 
-let checkIfCommandIsAvailable fullPath =
+let checkIfExecutable path =
     let open Result.Syntax in
-    let isExecutable p = 
-        let%bind stats = Bos.OS.Path.stat p in
-        match stats.Unix.st_kind, isExecutable stats with
-        | Unix.S_REG, true -> Ok (Some p)
+    match System.Platform.host with
+    (* Windows has a different file policy model than Unix - matching with the Unix permissions won't work *)
+    | Windows -> 
+        let%bind exists = Bos.OS.Path.exists path in
+        begin match exists with
+        | true -> Ok (Some path)
         | _ -> Ok None
-    in
+        end
+    | _ ->
+        let%bind stats = Bos.OS.Path.stat path in
+        begin match stats.Unix.st_kind, isExecutable stats with
+        | Unix.S_REG, true -> Ok (Some path)
+        | _ -> Ok None
+        end
+
+let checkIfCommandIsAvailable fullPath =
     let extensions = getPotentialExtensions in
     let evaluate prev next =
         match prev with
@@ -94,7 +104,7 @@ let checkIfCommandIsAvailable fullPath =
         | _ -> 
             let pathToTest = (Fpath.to_string fullPath) ^ next in
             let p = Fpath.v pathToTest in
-            isExecutable p
+            checkIfExecutable p
     in
     List.fold_left ~f:evaluate ~init:(Ok None) extensions
 

--- a/esy-lib/Cmd.ml
+++ b/esy-lib/Cmd.ml
@@ -83,7 +83,9 @@ let checkIfExecutable path =
     let open Result.Syntax in
     match System.Platform.host with
     (* Windows has a different file policy model than Unix - matching with the Unix permissions won't work *)
-    | Windows -> 
+    (* In particular, the Unix.stat implementation emulates this on Windows by checking the extension for `exe`/`com`/`cmd`/`bat` *)
+    (* But in our case, since we're deferring to the Cygwin layer, it's possible to have executables that don't confirm to that rule *)
+    | Windows ->
         let%bind exists = Bos.OS.Path.exists path in
         begin match exists with
         | true -> Ok (Some path)


### PR DESCRIPTION
__Issue:__ When building `hello-reason`, the final build step fails with:
```
info Building @opam/lambda-term@1.13: complete
esy-build-package: unable to resolve command: refmterr
esy: error, exiting...
     build failed
       Building hello-reason@0.1.0
```

__Defect:__ Prior to running a build command, we run through a resolution step - we check for the existence of the file against all `PATH` entries, and we check if it is executable. The problem is, we are checking the isExecutable permission in the 'Windows' world, and it doesn't really make sense in this context, especially since we actually execute the command in the Cygwin shell.

The `Unix` namespace actually tries to emulate this here:
https://github.com/ocaml/ocaml/blob/617930bbd1a5edce4ed82863c40e1d499e548258/otherlibs/win32unix/stat.c#L285
simply by looking at the file extension. However, in the `refmterr` (or any script that we can execute in Cygwin that doesn't have an executable extension), this check is insufficient.

__Fix:__ For Windows, we won't bother using the stat + execution bit check, since it's really only checking the extension anyway. 

The downside is there _could_ potentially be cases where a file doesn't have `+x` permission in the Cygwin world, and we fail upon build, but the error message should be sufficient to help us debug that error w/o needing explicit intervention on our part. If desired, we could shell out to our cygwin layer and check the executable permission there, but seems overkill.