### PR TITLE
Windows - Dependency: Update fastreplacestring to commit 95f408b

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@opam/re": "^1.7.1",
     "@opam/yojson": "*",
     "esy-solve-cudf": "^0.1.6",
-    "fastreplacestring": "esy-ocaml/FastReplaceString#3c81520"
+    "fastreplacestring": "esy-ocaml/FastReplaceString#95f408b"
   },
   "peerDependencies": {
     "ocaml": "~4.6.0"

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@opam/re": "^1.7.1",
     "@opam/yojson": "*",
     "esy-solve-cudf": "^0.1.6",
-    "fastreplacestring": "esy-ocaml/FastReplaceString#9450b6"
+    "fastreplacestring": "esy-ocaml/FastReplaceString#3c81520"
   },
   "peerDependencies": {
     "ocaml": "~4.6.0"


### PR DESCRIPTION
This change pulls in [95f408b](https://github.com/esy-ocaml/FastReplaceString/commit/3c81520f9503eedfab922b3273cd1831dbbf9265) for `FastReplaceString`, so that it is buildable on Windows with the `MingW` toolchain.