### PR TITLE
"Promote" deps to direct deps as needed

### DIFF
--- a/esy/Manifest.ml
+++ b/esy/Manifest.ml
@@ -214,7 +214,7 @@ module Dependencies = struct
     devDependencies : string list list;
     buildTimeDependencies : string list list;
     optDependencies : string list list;
-  }
+  } [@@deriving show]
 end
 
 module Release = struct

--- a/esy/Manifest.mli
+++ b/esy/Manifest.mli
@@ -88,6 +88,7 @@ module Dependencies : sig
     buildTimeDependencies : string list list;
     optDependencies : string list list;
   }
+  val show : t -> string
 end
 
 module type MANIFEST = sig

--- a/esy/Package.ml
+++ b/esy/Package.ml
@@ -27,6 +27,7 @@ let compare_dependency a b =
   | Dependency a, Dependency b -> compare a b
   | OptDependency a, OptDependency b -> compare a b
   | BuildTimeDependency a, BuildTimeDependency b -> compare a b
+  | DevDependency a, DevDependency b -> compare a b
   | InvalidDependency a, InvalidDependency b -> String.compare a.name b.name
   | Dependency _, _ -> 1
   | OptDependency _, Dependency _ -> -1

--- a/esy/Package.ml
+++ b/esy/Package.ml
@@ -81,3 +81,8 @@ module DependencySet = Set.Make(struct
   type t = dependency
   let compare = compare_dependency
 end)
+
+module DependencyMap = Map.Make(struct
+  type t = dependency
+  let compare = compare_dependency
+end)

--- a/esy/Package.ml
+++ b/esy/Package.ml
@@ -40,6 +40,14 @@ let compare_dependency a b =
   | DevDependency _, _ -> 1
   | InvalidDependency _, _ -> -1
 
+let pp_dependency fmt dep =
+  match dep with
+  | Dependency p -> Fmt.pf fmt "Dependency %s" p.id
+  | OptDependency p -> Fmt.pf fmt "OptDependency %s" p.id
+  | DevDependency p -> Fmt.pf fmt "DevDependency %s" p.id
+  | BuildTimeDependency p -> Fmt.pf fmt "BuildTimeDependency %s" p.id
+  | InvalidDependency p -> Fmt.pf fmt "InvalidDependency %s" p.name
+
 type pkg = t
 type pkg_dependency = dependency
 

--- a/esy/Package.mli
+++ b/esy/Package.mli
@@ -21,6 +21,7 @@ and dependency =
     reason: [ | `Reason of string | `Missing ];
   }
 
+val pp_dependency : dependency Fmt.t
 val compare : t -> t -> int
 val packageOf : dependency -> t option
 

--- a/esy/Package.mli
+++ b/esy/Package.mli
@@ -25,6 +25,8 @@ val compare : t -> t -> int
 val packageOf : dependency -> t option
 
 module DependencySet : Set.S with type elt = dependency
+module DependencyMap : Map.S with type key = dependency
+
 module Graph : DependencyGraph.DependencyGraph
   with type node = t
   and type dependency := dependency

--- a/esy/Task.ml
+++ b/esy/Task.ml
@@ -26,6 +26,12 @@ and dependency =
   | DevDependency of t
   | BuildTimeDependency of t
 
+let pp_dependency fmt (dep : dependency) =
+  match dep with
+  | Dependency t -> Fmt.pf fmt "Dependency %s" t.id
+  | DevDependency t -> Fmt.pf fmt "DevDependency %s" t.id
+  | BuildTimeDependency t -> Fmt.pf fmt "BuildTimeDependency %s" t.id
+
 let compare a b =
   String.compare a.id b.id
 

--- a/esy/Task.ml
+++ b/esy/Task.ml
@@ -207,8 +207,11 @@ let ofPackage
         else
           return None
       | Package.DevDependency depPkg ->
-        let%bind task = taskOfPackageCached depPkg in
-        return (Some (DevDependency task))
+        if direct
+        then
+          let%bind task = taskOfPackageCached depPkg in
+          return (Some (DevDependency task))
+        else return None
       | Package.InvalidDependency { name; reason = `Missing; } ->
         Run.errorf "package %s is missing, run 'esy install' to fix that" name
       | Package.InvalidDependency { name; reason = `Reason reason; } ->

--- a/esy/Task.mli
+++ b/esy/Task.mli
@@ -10,6 +10,8 @@ type dependency =
   | DevDependency of t
   | BuildTimeDependency of t
 
+val pp_dependency : dependency Fmt.t
+
 val id : t -> string
 val pkg : t -> Package.t
 val plan : t -> EsyBuildPackage.Plan.t

--- a/test-e2e/build/same-dep-transitive-and-direct.test.js
+++ b/test-e2e/build/same-dep-transitive-and-direct.test.js
@@ -1,0 +1,113 @@
+// @flow
+
+const path = require('path');
+const {
+  createTestSandbox,
+  packageJson,
+  dir,
+  file,
+  ocamlPackage,
+  exeExtension,
+} = require('../test/helpers');
+
+function makePackage(
+  {
+    name,
+    dependencies = {},
+    devDependencies = {},
+    optDependencies = {},
+    exportedEnv = {},
+  }: {
+    name: string,
+    dependencies?: {[name: string]: string},
+    devDependencies?: {[name: string]: string},
+    optDependencies?: {[name: string]: string},
+    exportedEnv?: {[name: string]: {val: string}},
+  },
+  ...items
+) {
+  return dir(
+    name,
+    packageJson({
+      name: name,
+      version: '1.0.0',
+      license: 'MIT',
+      esy: {
+        buildsInSource: true,
+        build: 'ocamlopt -o #{self.root / self.name}.exe #{self.root / self.name}.ml',
+        install: `cp #{self.root / self.name}.exe #{self.bin / self.name}${exeExtension}`,
+        exportedEnv,
+      },
+      dependencies,
+      optDependencies,
+      devDependencies,
+      _resolved: '...',
+    }),
+    file(`${name}.ml`, `let () = print_endline "__${name}__"`),
+    ...items,
+  );
+}
+
+const fixture = [
+  packageJson({
+    name: 'withDep',
+    version: '1.0.0',
+    esy: {
+      build: 'true',
+    },
+    dependencies: {
+      dep: '*',
+      focus: '*',
+    },
+  }),
+  dir(
+    'node_modules',
+    makePackage({
+      name: 'dep',
+      dependencies: {
+        focus: '*',
+        depOfDep: '*',
+        ocaml: '*',
+      },
+    }),
+    makePackage({
+      name: 'depOfDep',
+      dependencies: {
+        ocaml: '*',
+        focus: '*',
+      },
+    }),
+    makePackage({
+      name: 'focus',
+      dependencies: {
+        ocaml: '*',
+      },
+      exportedEnv: {direct__val: {val: '__focus__', scope: 'local'}},
+    }),
+    ocamlPackage(),
+  ),
+];
+
+describe('dep exists as transitive and direct dep at once', () => {
+  it('package focus should be visible in all envs', async () => {
+    const p = await createTestSandbox(...fixture);
+    await p.esy('build');
+
+    const expecting = expect.stringMatching('__focus__');
+
+    const dep = await p.esy('focus');
+    expect(dep.stdout).toEqual(expecting);
+
+    const b = await p.esy('b focus');
+    expect(b.stdout).toEqual(expecting);
+
+    const x = await p.esy('x focus');
+    expect(x.stdout).toEqual(expecting);
+  });
+
+  it('package focus local exports should be available', async () => {
+    const p = await createTestSandbox(...fixture);
+    const env = JSON.parse((await p.esy('build-env --json')).stdout);
+    expect(env.direct__val).toBe('__focus__');
+  });
+});


### PR DESCRIPTION
The issue with logs was caused by the fact that some deps weren't marked as direct deps (and hence we won't seen their vars in scope) if they've been seen already as transitive deps.