### PR TITLE
Windows: Use ~4.6.0 compiler version for e2e tests

### DIFF
--- a/test-e2e/test/jestGlobalSetup.js
+++ b/test-e2e/test/jestGlobalSetup.js
@@ -50,7 +50,7 @@ async function buildOcamlPackage() {
       name: 'root-project',
       version: '1.0.0',
       dependencies: {
-        ocaml: 'esy-ocaml/ocaml#6aacc05',
+        ocaml: '~4.6.0',
       },
       esy: {
         build: [],


### PR DESCRIPTION
We are using a forked compiler temporarily for Window in our `e2e` tests, to address pathing issues. The fixes are all in, so we no longer need to pin the ocaml compiler to a commit.