### PR TITLE
Add `esy gc` command

### DIFF
--- a/esy-lib/Project.ml
+++ b/esy-lib/Project.ml
@@ -73,13 +73,11 @@ let ofDir path =
   | None, false -> return None
   | Some sandbox, _ -> return (Some {path; sandbox; sandboxByName;})
 
-let initByName ~init ?name project =
-  let open RunAsync.Syntax in
+let find ~name project =
   match name with
-  | None -> init project.path project.sandbox
-  | Some "default" -> init project.path project.sandbox
-  | Some name ->
-    begin match StringMap.find name project.sandboxByName with
-    | Some sandbox -> init project.path sandbox
-    | None -> errorf "no sandbox %s found" name
-    end
+  | None
+  | Some "default" -> Some project.sandbox
+  | Some name -> StringMap.find name project.sandboxByName
+
+let sandboxes project =
+  project.sandbox::(StringMap.values project.sandboxByName)

--- a/esy-lib/Project.mli
+++ b/esy-lib/Project.mli
@@ -16,9 +16,8 @@ and sandbox =
 val ofDir : Path.t -> t option RunAsync.t
 (** Read project repr of a directory path. Returns None if no project is found. *)
 
-val initByName :
-  init:(Path.t -> sandbox -> 'sandbox RunAsync.t)
-  -> ?name:string
-  -> t
-  -> 'sandbox RunAsync.t
-(** Init project from a description. *)
+val find : name:string option -> t -> sandbox option
+(** Find a sandbox by name within the project. *)
+
+val sandboxes : t -> sandbox list
+(** List of sandboxes within the project. *)

--- a/esy/bin/esyCommand.ml
+++ b/esy/bin/esyCommand.ml
@@ -915,7 +915,6 @@ let makeLsCommand ~computeTermNode ~includeTransitive (info: SandboxInfo.t) =
       computeTermNode task children
     )
   in
-
   match%bind Task.Graph.fold ~f ~init:(return None) info.task with
   | Some tree -> return (print_endline (TermTree.toString tree))
   | None -> return ()
@@ -1356,6 +1355,63 @@ let release ({CommonOptions. cfg; project; sandbox; _} as copts) () =
     ~concurrency:EsyRuntime.concurrency
     ~sandbox:info.SandboxInfo.sandbox
 
+let gc (copts : CommonOptions.t) dryRun (roots : Path.t list) () =
+  let open RunAsync.Syntax in
+
+  let perform path =
+    if dryRun
+    then (
+      print_endline (Path.toString path);
+      return ()
+    ) else Fs.rmPath path
+  in
+
+  let%bind () =
+    let%bind () = perform Path.(copts.cfg.storePath / Store.stageTree) in
+    let%bind () = perform Path.(copts.cfg.storePath / Store.buildTree) in
+    return ()
+  in
+
+  let%bind () =
+    let%bind keep =
+      let visitSandbox project keep sandbox =
+        let%bind sandbox, _ = Sandbox.make ~cfg:copts.cfg project.Project.path sandbox in
+        let%bind task = RunAsync.ofRun (Task.ofSandbox sandbox) in
+        let f ~foldDependencies keep task =
+          let deps = foldDependencies () in
+          let f keep (_, k) = StringSet.union keep k in
+          let keep = List.fold_left ~f ~init:keep deps in
+          StringSet.add (Task.id task) keep
+        in
+        return (Task.Graph.fold ~init:keep ~f task)
+      in
+      let visitProject keep root =
+        match%lwt Project.ofDir root with
+        | Ok (Some project) ->
+          let sandboxes = Project.sandboxes project in
+          RunAsync.List.foldLeft ~f:(visitSandbox project) ~init:keep sandboxes
+        | Ok None -> errorf "no project found at %a" Path.pp root
+        | Error err -> Lwt.return (Error err)
+      in
+      RunAsync.List.foldLeft ~f:visitProject ~init:StringSet.empty roots
+    in
+
+    let queue = LwtTaskQueue.create ~concurrency:40 () in
+    let%bind buildsIds =
+      Fs.listDir Path.(copts.cfg.storePath / Store.installTree)
+    in
+    let removeBuild buildId =
+      if StringSet.mem buildId keep
+      then return ()
+      else LwtTaskQueue.submit
+        queue
+        (fun () -> perform Path.(copts.cfg.storePath / Store.installTree / buildId))
+    in
+    RunAsync.List.waitAll (List.map ~f:removeBuild buildsIds)
+  in
+
+  return ()
+
 let makeCommand
   ?(header=`Standard)
   ?(sdocs=Cmdliner.Manpage.s_common_options)
@@ -1698,6 +1754,26 @@ let () =
       Term.(
         const release
         $ CommonOptions.term
+        $ Cli.setupLogTerm
+      );
+
+    makeCommand
+      ~name:"gc"
+      ~doc:"Perform garbage collection of unused build artifacts."
+      ~header:`No
+      Term.(
+        const gc
+        $ CommonOptions.term
+        $ Arg.(
+            value
+            & flag
+            & info ["dry-run";] ~doc:"Only print directories to which should be removed."
+          )
+        $ Arg.(
+            non_empty
+            & (pos_all resolvedPathTerm [])
+            & info [] ~docv:"ROOT" ~doc:"Project roots for which built artifacts must be kept"
+          )
         $ Cli.setupLogTerm
       );
 

--- a/esy/bin/esyCommand.ml
+++ b/esy/bin/esyCommand.ml
@@ -110,10 +110,9 @@ module SandboxInfo = struct
     let makeInfo () =
       let f () =
         let%bind sandbox, info =
-          Project.initByName
-            ~init:(Sandbox.make ~cfg)
-            ?name
-            project
+          match Project.find ~name project with
+          | Some sandbox -> Sandbox.make ~cfg project.path sandbox
+          | None -> errorf "no sandbox %a found" Fmt.(option ~none:(unit "default") string) name
         in
         let%bind () = Sandbox.init sandbox in
         let%bind task, commandEnv, sandboxEnv = RunAsync.ofRun (
@@ -563,10 +562,9 @@ module CommonOptions = struct
               ?solveTimeout
               ()
           in
-          Project.initByName
-            ?name:!sandboxRef
-            ~init:(Sandbox.make ~cfg)
-            project
+          match Project.find ~name:!sandboxRef project with
+          | Some sandbox -> Sandbox.make ~cfg project.path sandbox
+          | None -> errorf "no sandbox %a found" Fmt.(option ~none:(unit "default") string) !sandboxRef
         in
         return {sandbox = !sandboxRef; project; cfg; installSandbox;}
       in


### PR DESCRIPTION
This adds a new commands `esy gc`, it requires one or more positional arguments
which point to paths with esy projects:

```
% esy gc . ~/Workspace/esy/hello-ocaml ...
```

The algo:

1. Remove `%storePath%/b`

2. Remove `%storePath%/s`

3. Clean up unused artifacts inside `%storePath%/i`

  3.1. Visits each project specified on command line (and each configured
  sandbox inside) to construct a list of builds which are currently used there.

  3.2. Remove all but found builds inside `%storePath%/i` directory.

Fixes #319