### PR TITLE
Allow adding packages with constraints

### DIFF
--- a/esy.lock.json
+++ b/esy.lock.json
@@ -1,6 +1,6 @@
 {
-  "hash": "26df5507025f7c2554f4062f4fd6a6fc",
-  "root": "esy@path:.",
+  "hash": "250cc94d431bec260202a09bffb8d67d",
+  "root": "esy-test-build@path:.",
   "node": {
     "yargs-parser@9.0.2": {
       "record": {
@@ -139,7 +139,7 @@
         "name": "wrap-ansi",
         "version": "2.1.0",
         "source":
-          "archive:http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz#sha1:d8fc3d284dd05794fe84973caecdd1cf824fdd85",
+          "archive:https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz#sha1:d8fc3d284dd05794fe84973caecdd1cf824fdd85",
         "files": [],
         "opam": null
       },
@@ -2022,7 +2022,7 @@
         "name": "outdent",
         "version": "0.3.0",
         "source":
-          "archive:http://registry.npmjs.org/outdent/-/outdent-0.3.0.tgz#sha1:fad18a9c061a0938f38e8071d16c4024423f4323",
+          "archive:https://registry.npmjs.org/outdent/-/outdent-0.3.0.tgz#sha1:fad18a9c061a0938f38e8071d16c4024423f4323",
         "files": [],
         "opam": null
       },
@@ -2209,12 +2209,12 @@
       },
       "dependencies": []
     },
-    "nwsapi@2.0.9": {
+    "nwsapi@2.0.8": {
       "record": {
         "name": "nwsapi",
-        "version": "2.0.9",
+        "version": "2.0.8",
         "source":
-          "archive:https://registry.npmjs.org/nwsapi/-/nwsapi-2.0.9.tgz#sha1:77ac0cdfdcad52b6a1151a84e73254edc33ed016",
+          "archive:https://registry.npmjs.org/nwsapi/-/nwsapi-2.0.8.tgz#sha1:e3603579b7e162b3dbedae4fb24e46f771d8fa24",
         "files": [],
         "opam": null
       },
@@ -2462,7 +2462,7 @@
         "name": "minimist",
         "version": "1.2.0",
         "source":
-          "archive:http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz#sha1:a35008b20f41383eec1fb914f4cd5df79a264284",
+          "archive:https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz#sha1:a35008b20f41383eec1fb914f4cd5df79a264284",
         "files": [],
         "opam": null
       },
@@ -2473,7 +2473,7 @@
         "name": "minimist",
         "version": "0.0.10",
         "source":
-          "archive:http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz#sha1:de3f98543dbf96082be48ad1a0c7cda836301dcf",
+          "archive:https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz#sha1:de3f98543dbf96082be48ad1a0c7cda836301dcf",
         "files": [],
         "opam": null
       },
@@ -2484,7 +2484,7 @@
         "name": "minimist",
         "version": "0.0.8",
         "source":
-          "archive:http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz#sha1:857fcabfc3397d2625b8228262e86aa7a011b05d",
+          "archive:https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz#sha1:857fcabfc3397d2625b8228262e86aa7a011b05d",
         "files": [],
         "opam": null
       },
@@ -2972,7 +2972,7 @@
         "abab@2.0.0", "acorn@5.7.2", "acorn-globals@4.1.0",
         "array-equal@1.0.0", "cssom@0.3.4", "cssstyle@1.1.1",
         "data-urls@1.0.1", "domexception@1.0.1", "escodegen@1.11.0",
-        "html-encoding-sniffer@1.0.2", "left-pad@1.3.0", "nwsapi@2.0.9",
+        "html-encoding-sniffer@1.0.2", "left-pad@1.3.0", "nwsapi@2.0.8",
         "parse5@4.0.0", "pn@1.1.0", "request@2.88.0",
         "request-promise-native@1.0.5", "sax@1.2.4", "symbol-tree@3.2.2",
         "tough-cookie@2.4.3", "w3c-hr-time@1.0.1",
@@ -3498,7 +3498,7 @@
         "opam": null
       },
       "dependencies": [
-        "async@2.6.1", "compare-versions@3.4.0", "fileset@2.0.3",
+        "async@2.6.1", "compare-versions@3.3.1", "fileset@2.0.3",
         "istanbul-lib-coverage@1.2.0", "istanbul-lib-hook@1.2.1",
         "istanbul-lib-instrument@2.3.2", "istanbul-lib-report@1.1.4",
         "istanbul-lib-source-maps@1.2.5", "istanbul-reports@1.5.0",
@@ -4819,20 +4819,9 @@
       },
       "dependencies": [ "merge@1.2.0" ]
     },
-    "esy-solve-cudf@0.1.6": {
+    "esy-test-build@path:.": {
       "record": {
-        "name": "esy-solve-cudf",
-        "version": "0.1.6",
-        "source":
-          "archive:https://registry.npmjs.org/esy-solve-cudf/-/esy-solve-cudf-0.1.6.tgz#sha1:e5fe6e16be1e71964e1bfe3cdb80688e072dbe0f",
-        "files": [],
-        "opam": null
-      },
-      "dependencies": []
-    },
-    "esy@path:.": {
-      "record": {
-        "name": "esy",
+        "name": "esy-test-build",
         "version": "path:.",
         "source": "path:.",
         "files": [],
@@ -4846,13 +4835,12 @@
         "@opam/fmt@opam:0.8.5", "@opam/fpath@opam:0.7.2",
         "@opam/lambda-term@opam:1.13", "@opam/logs@opam:0.6.2",
         "@opam/lwt@opam:4.1.0", "@opam/lwt_ppx@opam:1.2.1",
-        "@opam/menhir@opam:20171013", "@opam/opam-core@opam:2.0.0",
+        "@opam/menhir@opam:20170712", "@opam/opam-core@opam:2.0.0",
         "@opam/opam-file-format@opam:2.0.0", "@opam/opam-format@opam:2.0.0",
         "@opam/opam-state@opam:2.0.0", "@opam/ppx_deriving@opam:4.2.1",
         "@opam/ppx_deriving_yojson@opam:3.1",
         "@opam/ppx_inline_test@opam:v0.11.0", "@opam/ppx_let@opam:v0.11.0",
-        "@opam/ppx_tyre@opam:0.4.0", "@opam/re@opam:1.8.0",
-        "@opam/tyre@opam:0.4.1", "@opam/utop@opam:2.2.0",
+        "@opam/re@opam:1.8.0", "@opam/utop@opam:2.2.0",
         "@opam/yojson@opam:1.4.1", "babel-preset-env@1.7.0",
         "babel-preset-flow@6.23.0", "del@3.0.0", "esy-solve-cudf@0.1.6",
         "fastreplacestring@github:esy-ocaml/FastReplaceString#95f408b",
@@ -4861,6 +4849,17 @@
         "rimraf@2.6.2", "semver@5.5.1", "super-resolve@1.0.0", "tar@4.4.6",
         "tar-fs@1.16.3", "tmp@0.0.33"
       ]
+    },
+    "esy-solve-cudf@0.1.6": {
+      "record": {
+        "name": "esy-solve-cudf",
+        "version": "0.1.6",
+        "source":
+          "archive:https://registry.npmjs.org/esy-solve-cudf/-/esy-solve-cudf-0.1.6.tgz#sha1:e5fe6e16be1e71964e1bfe3cdb80688e072dbe0f",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
     },
     "esutils@2.0.2": {
       "record": {
@@ -5350,12 +5349,12 @@
       },
       "dependencies": []
     },
-    "compare-versions@3.4.0": {
+    "compare-versions@3.3.1": {
       "record": {
         "name": "compare-versions",
-        "version": "3.4.0",
+        "version": "3.3.1",
         "source":
-          "archive:https://registry.npmjs.org/compare-versions/-/compare-versions-3.4.0.tgz#sha1:e0747df5c9cb7f054d6d3dc3e1dbc444f9e92b26",
+          "archive:https://registry.npmjs.org/compare-versions/-/compare-versions-3.3.1.tgz#sha1:1ede3172b713c15f7c7beb98cb74d2d82576dad3",
         "files": [],
         "opam": null
       },
@@ -5550,12 +5549,12 @@
       },
       "dependencies": [ "rsvp@3.6.2" ]
     },
-    "caniuse-lite@1.0.30000884": {
+    "caniuse-lite@1.0.30000882": {
       "record": {
         "name": "caniuse-lite",
-        "version": "1.0.30000884",
+        "version": "1.0.30000882",
         "source":
-          "archive:https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000884.tgz#sha1:eb82a959698745033b26a4dcd34d89dba7cc6eb3",
+          "archive:https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000882.tgz#sha1:0d5066847a11a5af0e50ffce6c062ef0665f68ea",
         "files": [],
         "opam": null
       },
@@ -5686,7 +5685,7 @@
         "opam": null
       },
       "dependencies": [
-        "caniuse-lite@1.0.30000884", "electron-to-chromium@1.3.62"
+        "caniuse-lite@1.0.30000882", "electron-to-chromium@1.3.62"
       ]
     },
     "browser-resolve@1.11.3": {
@@ -6304,7 +6303,7 @@
         "name": "babel-plugin-syntax-object-rest-spread",
         "version": "6.13.0",
         "source":
-          "archive:http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#sha1:fd6536f2bce13836ffa3a5458c4903a597bb3bf5",
+          "archive:https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#sha1:fd6536f2bce13836ffa3a5458c4903a597bb3bf5",
         "files": [],
         "opam": null
       },
@@ -6315,7 +6314,7 @@
         "name": "babel-plugin-syntax-flow",
         "version": "6.18.0",
         "source":
-          "archive:http://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz#sha1:4c3ab20a2af26aa20cd25995c398c4eb70310c8d",
+          "archive:https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz#sha1:4c3ab20a2af26aa20cd25995c398c4eb70310c8d",
         "files": [],
         "opam": null
       },
@@ -6326,7 +6325,7 @@
         "name": "babel-plugin-syntax-exponentiation-operator",
         "version": "6.13.0",
         "source":
-          "archive:http://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz#sha1:9ee7e8337290da95288201a6a57f4170317830de",
+          "archive:https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz#sha1:9ee7e8337290da95288201a6a57f4170317830de",
         "files": [],
         "opam": null
       },
@@ -6337,7 +6336,7 @@
         "name": "babel-plugin-syntax-async-functions",
         "version": "6.13.0",
         "source":
-          "archive:http://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#sha1:cad9cad1191b5ad634bf30ae0872391e0647be95",
+          "archive:https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#sha1:cad9cad1191b5ad634bf30ae0872391e0647be95",
         "files": [],
         "opam": null
       },
@@ -7159,28 +7158,6 @@
         "@esy-ocaml/substs@0.0.1", "@opam/ocamlbuild@opam:0.12.0"
       ]
     },
-    "@opam/tyre@opam:0.4.1": {
-      "record": {
-        "name": "@opam/tyre",
-        "version": "opam:0.4.1",
-        "source": [
-          "archive:https://opam.ocaml.org/archives/tyre.0.4.1+opam.tar.gz#md5:c5a3e988b7051126a389807dbdb9395b",
-          "archive:https://github.com/Drup/tyre/releases/download/0.4.1/tyre-0.4.1.tbz#md5:41923cb08a11f93d704b79f7bb078640"
-        ],
-        "files": [],
-        "opam": {
-          "name": "tyre",
-          "version": "0.4.1",
-          "opam":
-            "opam-version: \"1.2\"\nname: \"tyre\"\nversion: \"0.4.1\"\nmaintainer: \"Gabriel Radanne <drupyog@zoho.com>\"\nauthors: \"Gabriel Radanne <drupyog@zoho.com>\"\nlicense: \"ISC\"\ntags: \"regex\"\nhomepage: \"https://github.com/Drup/tyre\"\ndoc: \"https://drup.github.io/tyre/doc/0.4/tyre/Tyre/\"\nbug-reports: \"https://github.com/Drup/tyre/issues\"\ndepends: [\n  \"jbuilder\" {build}\n  \"re\" {>= \"1.8.0\"}\n  \"alcotest\" {test & >= \"0.8.0\"}\n  \"result\"\n  \"seq\"\n]\navailable: ocaml-version >= \"4.02.0\"\nbuild: [\n  [\"jbuilder\" \"subst\"] {pinned}\n  [\"jbuilder\" \"build\" \"-p\" name \"-j\" jobs]\n  [\"jbuilder\" \"runtest\" \"-p\" name] {with-test}\n]\ndev-repo: \"git+https://github.com/Drup/tyre.git\"",
-          "override": null
-        }
-      },
-      "dependencies": [
-        "@esy-ocaml/substs@0.0.1", "@opam/jbuilder@opam:transition",
-        "@opam/re@opam:1.8.0", "@opam/result@opam:1.3", "@opam/seq@opam:0.1"
-      ]
-    },
     "@opam/topkg@opam:0.9.1": {
       "record": {
         "name": "@opam/topkg",
@@ -7378,30 +7355,6 @@
         "@opam/dune@opam:1.1.1", "@opam/ocaml-compiler-libs@opam:v0.11.0",
         "@opam/ocaml-migrate-parsetree@opam:1.0.11",
         "@opam/ppx_derivers@opam:1.0", "@opam/stdio@opam:v0.11.0"
-      ]
-    },
-    "@opam/ppx_tyre@opam:0.4.0": {
-      "record": {
-        "name": "@opam/ppx_tyre",
-        "version": "opam:0.4.0",
-        "source": [
-          "archive:https://opam.ocaml.org/archives/ppx_tyre.0.4.0+opam.tar.gz#md5:b298852ce44b344afa8ad567c65686e4",
-          "archive:https://github.com/paurkedal/ppx_regexp/releases/download/v0.4.0/ppx_regexp-0.4.0.tbz#md5:44691d6e1c6c02300329a4eb769922ab"
-        ],
-        "files": [],
-        "opam": {
-          "name": "ppx_tyre",
-          "version": "0.4.0",
-          "opam":
-            "opam-version: \"1.2\"\nname: \"ppx_tyre\"\nversion: \"0.4.0\"\nmaintainer: \"Petter A. Urkedal <paurkedal@gmail.com>\"\nauthors: [\n  \"Gabriel Radanne <drupyog@zoho.com>\"\n  \"Petter A. Urkedal <paurkedal@gmail.com>\"\n]\nlicense: \"LGPL-3 with OCaml linking exception\"\nhomepage: \"https://github.com/paurkedal/ppx_regexp\"\nbug-reports: \"https://github.com/paurkedal/ppx_regexp/issues\"\ndepends: [\n  \"dune\" {build}\n  \"ocaml-migrate-parsetree\"\n  \"re\" {>= \"1.7.1\"}\n  \"ppx_tools_versioned\"\n  \"tyre\" {>= \"0.4.1\"}\n  \"qcheck\" {test}\n]\navailable: ocaml-version >= \"4.06.0\"\nbuild: [\"dune\" \"build\" \"-p\" name \"-j\" jobs]\ndev-repo: \"git+https://github.com/paurkedal/ppx_regexp.git\"",
-          "override": null
-        }
-      },
-      "dependencies": [
-        "@esy-ocaml/substs@0.0.1", "@opam/dune@opam:1.1.1",
-        "@opam/ocaml-migrate-parsetree@opam:1.0.11",
-        "@opam/ppx_tools_versioned@opam:5.2.1", "@opam/re@opam:1.8.0",
-        "@opam/tyre@opam:0.4.1"
       ]
     },
     "@opam/ppx_tools_versioned@opam:5.2.1": {
@@ -7758,7 +7711,7 @@
               "bin: [\n  \"src/findlib/ocamlfind\" {\"ocamlfind\"}\n  \"?src/findlib/ocamlfind_opt\" {\"ocamlfind\"}\n  \"?tools/safe_camlp4\"\n]\ntoplevel: [\"src/findlib/topfind\"]\n"
           },
           {
-            "name": "esy-build",
+            "name": "_esy/build",
             "content":
               "#!/bin/bash\n\nset -euo pipefail\nset -x\n\n#\n# Shim OCAMLLIB so that we can write topfind there\n#\n\nREAL_OCAMLLIB=\"$1\"\n\nmkdir -p $cur__install/lib/ocaml\ncd $cur__install/lib/ocaml\n\nfor filename in `ls -1 $REAL_OCAMLLIB`; do\n  ln -s $REAL_OCAMLLIB/$filename $filename;\ndone\n\n#\n# Build\n#\n\ncd $cur__root\n\nexport OCAMLLIB=\"$cur__install/lib/ocaml\"\n\n./configure \\\n  -bindir $cur__install/bin \\\n  -sitelib $cur__install/lib \\\n  -mandir $cur__install/man \\\n  -config $cur__install/lib/findlib.conf \\\n  -no-custom \\\n  -no-camlp4\n\nmake all\nmake opt\nmake install\n\n(opam-installer --prefix=$cur__install || true)\n"
           }
@@ -7769,7 +7722,7 @@
           "opam":
             "opam-version: \"1.2\"\nname: \"ocamlfind\"\nversion: \"1.8.0\"\nmaintainer: \"Thomas Gazagnaire <thomas@gazagnaire.org>\"\nauthors: \"Gerd Stolpmann <gerd@gerd-stolpmann.de>\"\nhomepage: \"http://projects.camlcity.org/projects/findlib.html\"\nbug-reports: \"https://gitlab.camlcity.org/gerd/lib-findlib/issues\"\ndepends: [\n  \"conf-m4\" {build}\n]\navailable: ocaml-version >= \"4.00.0\"\nbuild: [\n  [\n    \"./configure\"\n    \"-bindir\"\n    bin\n    \"-sitelib\"\n    lib\n    \"-mandir\"\n    man\n    \"-config\"\n    \"%{lib}%/findlib.conf\"\n    \"-no-custom\"\n    \"-no-topfind\" {preinstalled}\n  ]\n  [make \"all\"]\n  [make \"opt\"] {ocaml-native}\n]\ninstall: [\n  [make \"install\"]\n  [\"install\" \"-m\" \"0755\" \"ocaml-stub\" \"%{bin}%/ocaml\"] {preinstalled}\n]\nremove: [\n  [\"ocamlfind\" \"remove\" \"bytes\"]\n  [\n    \"./configure\"\n    \"-bindir\"\n    bin\n    \"-sitelib\"\n    lib\n    \"-mandir\"\n    man\n    \"-config\"\n    \"%{lib}%/findlib.conf\"\n    \"-no-topfind\" {preinstalled}\n  ]\n  [make \"uninstall\"]\n  [\"rm\" \"-f\" \"%{bin}%/ocaml\"] {preinstalled}\n]\ndev-repo: \"git+https://gitlab.camlcity.org/gerd/lib-findlib.git\"",
           "override": {
-            "build": [ [ "bash", "./esy-build", "#{ocaml.lib / 'ocaml'}" ] ],
+            "build": [ [ "bash", "./_esy/build", "#{ocaml.lib / 'ocaml'}" ] ],
             "exportedEnv": {
               "OCAMLLIB": {
                 "val": "#{@opam/ocamlfind.install / 'lib' / 'ocaml'}",
@@ -7798,13 +7751,7 @@
           "archive:https://opam.ocaml.org/archives/ocamlbuild.0.12.0+opam.tar.gz#md5:6e877d7f40c119c0c6c03f04342f2264",
           "archive:https://github.com/ocaml/ocamlbuild/archive/0.12.0.tar.gz#md5:442baa19470bd49150f153122e22907b"
         ],
-        "files": [
-          {
-            "name": "_esy/ocamlbuild-0.12.0.patch",
-            "content":
-              "--- ./Makefile\n+++ ./Makefile\n@@ -213,7 +213,7 @@\n \trm -f man/ocamlbuild.1\n \n man/options_man.byte: src/ocamlbuild_pack.cmo\n-\t$(OCAMLC) $^ -I src man/options_man.ml -o man/options_man.byte\n+\t$(OCAMLC) -I +unix unix.cma $^ -I src man/options_man.ml -o man/options_man.byte\n \n clean::\n \trm -f man/options_man.cm*\n--- ./META\n+++ ./META\n@@ -2,5 +2,6 @@\n requires = \"unix\"\n version = \"0.12.0\"\n description = \"ocamlbuild support library\"\n+directory= \"^ocamlbuild\"\n archive(byte) = \"ocamlbuildlib.cma\"\n archive(native) = \"ocamlbuildlib.cmxa\"\n--- ./src/command.ml\n+++ ./src/command.ml\n@@ -148,9 +148,10 @@\n   let self = string_of_command_spec_with_calls call_with_tags call_with_target resolve_virtuals in\n   let b = Buffer.create 256 in\n   (* The best way to prevent bash from switching to its windows-style\n-   * quote-handling is to prepend an empty string before the command name. *)\n+   * quote-handling is to prepend an empty string before the command name.\n+   * space seems to work, too - and the ouput is nicer *)\n   if Sys.os_type = \"Win32\" then\n-    Buffer.add_string b \"''\";\n+    Buffer.add_char b ' ';\n   let first = ref true in\n   let put_space () =\n     if !first then\n@@ -260,7 +261,7 @@\n \n let execute_many ?(quiet=false) ?(pretend=false) cmds =\n   add_parallel_stat (List.length cmds);\n-  let degraded = !*My_unix.is_degraded || Sys.os_type = \"Win32\" in\n+  let degraded = !*My_unix.is_degraded in\n   let jobs = !jobs in\n   if jobs < 0 then invalid_arg \"jobs < 0\";\n   let max_jobs = if jobs = 0 then None else Some jobs in\n--- ./src/findlib.ml\n+++ ./src/findlib.ml\n@@ -66,9 +66,6 @@\n     (fun command -> lexer & Lexing.from_string & run_and_read command)\n     command\n \n-let run_and_read command =\n-  Printf.ksprintf run_and_read command\n-\n let rec query name =\n   try\n     Hashtbl.find packages name\n@@ -135,7 +132,8 @@\n   with Not_found -> s\n \n let list () =\n-  List.map before_space (split_nl & run_and_read \"%s list\" ocamlfind)\n+  let cmd = Shell.quote_filename_if_needed ocamlfind ^ \" list\" in\n+  List.map before_space (split_nl & run_and_read cmd)\n \n (* The closure algorithm is easy because the dependencies are already closed\n and sorted for each package. We only have to make the union. We could also\n--- ./src/main.ml\n+++ ./src/main.ml\n@@ -162,6 +162,9 @@\n               Tags.mem \"traverse\" tags\n               || List.exists (Pathname.is_prefix path_name) !Options.include_dirs\n               || List.exists (Pathname.is_prefix path_name) target_dirs)\n+            && ((* beware: !Options.build_dir is an absolute directory *)\n+              Pathname.normalize !Options.build_dir\n+              <> Pathname.normalize (Pathname.pwd/path_name))\n           end\n         end\n       end\n--- ./src/my_std.ml\n+++ ./src/my_std.ml\n@@ -271,13 +271,107 @@\n       try Array.iter (fun x -> if x = basename then raise Exit) a; false\n       with Exit -> true\n \n+let command_plain = function\n+| [| |] -> 0\n+| margv ->\n+  let rec waitpid a b =\n+    match Unix.waitpid a b with\n+    | exception (Unix.Unix_error(Unix.EINTR,_,_)) -> waitpid a b\n+    | x -> x\n+  in\n+  let pid = Unix.(create_process margv.(0) margv stdin stdout stderr) in\n+  let pid', process_status = waitpid [] pid in\n+  assert (pid = pid');\n+  match process_status with\n+  | Unix.WEXITED n -> n\n+  | Unix.WSIGNALED _ -> 2 (* like OCaml's uncaught exceptions *)\n+  | Unix.WSTOPPED _ -> 127\n+\n+(* can't use Lexers because of circular dependency *)\n+let split_path_win str =\n+  let rec aux pos =\n+    try\n+      let i = String.index_from str pos ';' in\n+      let len = i - pos in\n+      if len = 0 then\n+        aux (succ i)\n+      else\n+        String.sub str pos (i - pos) :: aux (succ i)\n+    with Not_found | Invalid_argument _ ->\n+      let len = String.length str - pos in\n+      if len = 0 then [] else [String.sub str pos len]\n+  in\n+  aux 0\n+\n+let windows_shell = lazy begin\n+  let rec iter = function\n+  | [] -> [| \"bash.exe\" ; \"--norc\" ; \"--noprofile\" |]\n+  | hd::tl ->\n+    let dash = Filename.concat hd \"dash.exe\" in\n+    if Sys.file_exists dash then [|dash|] else\n+    let bash = Filename.concat hd \"bash.exe\" in\n+    if Sys.file_exists bash = false then iter tl else\n+    (* if sh.exe and bash.exe exist in the same dir, choose sh.exe *)\n+    let sh = Filename.concat hd \"sh.exe\" in\n+    if Sys.file_exists sh then [|sh|] else [|bash ; \"--norc\" ; \"--noprofile\"|]\n+  in\n+  split_path_win (try Sys.getenv \"PATH\" with Not_found -> \"\") |> iter\n+end\n+\n+let prep_windows_cmd cmd =\n+  (* workaround known ocaml bug, remove later *)\n+  if String.contains cmd '\\t' && String.contains cmd ' ' = false then\n+    \" \" ^ cmd\n+  else\n+    cmd\n+\n+let run_with_shell = function\n+| \"\" -> 0\n+| cmd ->\n+  let cmd = prep_windows_cmd cmd in\n+  let shell = Lazy.force windows_shell in\n+  let qlen = Filename.quote cmd |> String.length in\n+  (* old versions of dash had problems with bs *)\n+  try\n+    if qlen < 7_900 then\n+      command_plain (Array.append shell [| \"-ec\" ; cmd |])\n+    else begin\n+      (* it can still work, if the called command is a cygwin tool *)\n+      let ch_closed = ref false in\n+      let file_deleted = ref false in\n+      let fln,ch =\n+        Filename.open_temp_file\n+          ~mode:[Open_binary]\n+          \"ocamlbuildtmp\"\n+          \".sh\"\n+      in\n+      try\n+        let f_slash = String.map ( fun x -> if x = '\\\\' then '/' else x ) fln in\n+        output_string ch cmd;\n+        ch_closed:= true;\n+        close_out ch;\n+        let ret = command_plain (Array.append shell [| \"-e\" ; f_slash |]) in\n+        file_deleted:= true;\n+        Sys.remove fln;\n+        ret\n+      with\n+      | x ->\n+        if !ch_closed = false then\n+          close_out_noerr ch;\n+        if !file_deleted = false then\n+          (try Sys.remove fln with _ -> ());\n+        raise x\n+    end\n+  with\n+  | (Unix.Unix_error _) as x ->\n+    (* Sys.command doesn't raise an exception, so run_with_shell also won't\n+       raise *)\n+    Printexc.to_string x ^ \":\" ^ cmd |> prerr_endline;\n+    1\n+\n let sys_command =\n-  match Sys.os_type with\n-  | \"Win32\" -> fun cmd ->\n-      if cmd = \"\" then 0 else\n-      let cmd = \"bash --norc -c \" ^ Filename.quote cmd in\n-      Sys.command cmd\n-  | _ -> fun cmd -> if cmd = \"\" then 0 else Sys.command cmd\n+  if Sys.win32 then run_with_shell\n+  else fun cmd -> if cmd = \"\" then 0 else Sys.command cmd\n \n (* FIXME warning fix and use Filename.concat *)\n let filename_concat x y =\n--- ./src/my_std.mli\n+++ ./src/my_std.mli\n@@ -69,3 +69,6 @@\n \n val split_ocaml_version : (int * int * int * string) option\n (** (major, minor, patchlevel, rest) *)\n+\n+val windows_shell : string array Lazy.t\n+val prep_windows_cmd : string -> string\n--- ./src/ocamlbuild_executor.ml\n+++ ./src/ocamlbuild_executor.ml\n@@ -34,6 +34,8 @@\n   job_stdin   : out_channel;\n   job_stderr  : in_channel;\n   job_buffer  : Buffer.t;\n+  job_pid     : int;\n+  job_tmp_file: string option;\n   mutable job_dying : bool;\n };;\n \n@@ -76,6 +78,61 @@\n   in\n   loop 0\n ;;\n+\n+let open_process_full_win cmd env =\n+  let (in_read, in_write) = Unix.pipe () in\n+  let (out_read, out_write) = Unix.pipe () in\n+  let (err_read, err_write) = Unix.pipe () in\n+  Unix.set_close_on_exec in_read;\n+  Unix.set_close_on_exec out_write;\n+  Unix.set_close_on_exec err_read;\n+  let inchan = Unix.in_channel_of_descr in_read in\n+  let outchan = Unix.out_channel_of_descr out_write in\n+  let errchan = Unix.in_channel_of_descr err_read in\n+  let shell = Lazy.force Ocamlbuild_pack.My_std.windows_shell in\n+  let test_cmd =\n+    String.concat \" \" (List.map Filename.quote (Array.to_list shell)) ^\n+    \"-ec \" ^\n+    Filename.quote (Ocamlbuild_pack.My_std.prep_windows_cmd cmd) in\n+  let argv,tmp_file =\n+    if String.length test_cmd < 7_900 then\n+      Array.append\n+        shell\n+        [| \"-ec\" ; Ocamlbuild_pack.My_std.prep_windows_cmd cmd |],None\n+    else\n+    let fln,ch = Filename.open_temp_file ~mode:[Open_binary] \"ocamlbuild\" \".sh\" in\n+    output_string ch (Ocamlbuild_pack.My_std.prep_windows_cmd cmd);\n+    close_out ch;\n+    let fln' = String.map (function '\\\\' -> '/' | c -> c) fln in\n+    Array.append\n+      shell\n+      [| \"-c\" ; fln' |], Some fln in\n+  let pid =\n+    Unix.create_process_env argv.(0) argv env out_read in_write err_write in\n+  Unix.close out_read;\n+  Unix.close in_write;\n+  Unix.close err_write;\n+  (pid, inchan, outchan, errchan,tmp_file)\n+\n+let close_process_full_win (pid,inchan, outchan, errchan, tmp_file) =\n+  let delete tmp_file =\n+    match tmp_file with\n+    | None -> ()\n+    | Some x -> try Sys.remove x with Sys_error _ -> () in\n+  let tmp_file_deleted = ref false in\n+  try\n+    close_in inchan;\n+    close_out outchan;\n+    close_in errchan;\n+    let res = snd(Unix.waitpid [] pid) in\n+    tmp_file_deleted := true;\n+    delete tmp_file;\n+    res\n+  with\n+  | x when tmp_file <> None && !tmp_file_deleted = false ->\n+    delete tmp_file;\n+    raise x\n+\n (* ***)\n (*** execute *)\n (* XXX: Add test for non reentrancy *)\n@@ -130,10 +187,16 @@\n   (*** add_job *)\n   let add_job cmd rest result id =\n     (*display begin fun oc -> fp oc \"Job %a is %s\\n%!\" print_job_id id cmd; end;*)\n-    let (stdout', stdin', stderr') = open_process_full cmd env in\n+    let (pid,stdout', stdin', stderr', tmp_file) =\n+      if Sys.win32 then open_process_full_win cmd env else\n+      let a,b,c = open_process_full cmd env in\n+      -1,a,b,c,None\n+    in\n     incr jobs_active;\n-    set_nonblock (doi stdout');\n-    set_nonblock (doi stderr');\n+    if not Sys.win32 then (\n+      set_nonblock (doi stdout');\n+      set_nonblock (doi stderr');\n+    );\n     let job =\n       { job_id          = id;\n         job_command     = cmd;\n@@ -143,7 +206,9 @@\n         job_stdin       = stdin';\n         job_stderr      = stderr';\n         job_buffer      = Buffer.create 1024;\n-        job_dying       = false }\n+        job_dying       = false;\n+        job_tmp_file    = tmp_file;\n+        job_pid         = pid }\n     in\n     outputs := FDM.add (doi stdout') job (FDM.add (doi stderr') job !outputs);\n     jobs := JS.add job !jobs;\n@@ -199,6 +264,7 @@\n               try\n                 read fd u 0 (Bytes.length u)\n               with\n+              | Unix.Unix_error(Unix.EPIPE,_,_) when Sys.win32 -> 0\n               | Unix.Unix_error(e,_,_)  ->\n                 let msg = error_message e in\n                 display (fun oc -> fp oc\n@@ -241,14 +307,19 @@\n       decr jobs_active;\n \n       (* PR#5371: we would get EAGAIN below otherwise *)\n-      clear_nonblock (doi job.job_stdout);\n-      clear_nonblock (doi job.job_stderr);\n-\n+      if not Sys.win32 then (\n+        clear_nonblock (doi job.job_stdout);\n+        clear_nonblock (doi job.job_stderr);\n+      );\n       do_read ~loop:true (doi job.job_stdout) job;\n       do_read ~loop:true (doi job.job_stderr) job;\n       outputs := FDM.remove (doi job.job_stdout) (FDM.remove (doi job.job_stderr) !outputs);\n       jobs := JS.remove job !jobs;\n-      let status = close_process_full (job.job_stdout, job.job_stdin, job.job_stderr) in\n+      let status =\n+        if Sys.win32 then\n+          close_process_full_win (job.job_pid, job.job_stdout, job.job_stdin, job.job_stderr, job.job_tmp_file)\n+        else\n+          close_process_full (job.job_stdout, job.job_stdin, job.job_stderr) in\n \n       let shown = ref false in\n \n--- ./src/ocamlbuild_unix_plugin.ml\n+++ ./src/ocamlbuild_unix_plugin.ml\n@@ -48,12 +48,22 @@\n   end\n \n let run_and_open s kont =\n+  let s_orig = s in\n+  let s =\n+    (* Be consistent! My_unix.run_and_open uses My_std.sys_command and\n+       sys_command uses bash. *)\n+    if Sys.win32 = false then s else\n+    let l = match Lazy.force My_std.windows_shell |> Array.to_list with\n+    | hd::tl -> (Filename.quote hd)::tl\n+    | _ -> assert false in\n+    \"\\\"\" ^ (String.concat \" \" l) ^ \" -ec \" ^ Filename.quote (\" \" ^ s) ^ \"\\\"\"\n+  in\n   let ic = Unix.open_process_in s in\n   let close () =\n     match Unix.close_process_in ic with\n     | Unix.WEXITED 0 -> ()\n     | Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _ ->\n-        failwith (Printf.sprintf \"Error while running: %s\" s) in\n+        failwith (Printf.sprintf \"Error while running: %s\" s_orig) in\n   let res = try\n       kont ic\n     with e -> (close (); raise e)\n--- ./src/options.ml\n+++ ./src/options.ml\n@@ -174,11 +174,24 @@\n     build_dir := Filename.concat (Sys.getcwd ()) s\n   else\n     build_dir := s\n+\n+let slashify =\n+  if Sys.win32 then fun p -> String.map (function '\\\\' -> '/' | x -> x) p\n+  else fun p ->p\n+\n+let sb () =\n+  match Sys.os_type with\n+  | \"Win32\" ->\n+    (try set_binary_mode_out stdout true with _ -> ());\n+  | _ -> ()\n+\n+\n let spec = ref (\n     let print_version () =\n+      sb ();\n       Printf.printf \"ocamlbuild %s\\n%!\" Ocamlbuild_config.version; raise Exit_OK\n     in\n-    let print_vnum () = print_endline Ocamlbuild_config.version; raise Exit_OK in\n+    let print_vnum () = sb (); print_endline Ocamlbuild_config.version; raise Exit_OK in\n   Arg.align\n   [\n    \"-version\", Unit print_version , \" Display the version\";\n@@ -257,8 +270,8 @@\n    \"-build-dir\", String set_build_dir, \"<path> Set build directory (implies no-links)\";\n    \"-install-lib-dir\", Set_string Ocamlbuild_where.libdir, \"<path> Set the install library directory\";\n    \"-install-bin-dir\", Set_string Ocamlbuild_where.bindir, \"<path> Set the install binary directory\";\n-   \"-where\", Unit (fun () -> print_endline !Ocamlbuild_where.libdir; raise Exit_OK), \" Display the install library directory\";\n-   \"-which\", String (fun cmd -> print_endline (find_tool cmd); raise Exit_OK), \"<command> Display path to the tool command\";\n+   \"-where\", Unit (fun () -> sb (); print_endline (slashify !Ocamlbuild_where.libdir); raise Exit_OK), \" Display the install library directory\";\n+   \"-which\", String (fun cmd -> sb (); print_endline (slashify (find_tool cmd)); raise Exit_OK), \"<command> Display path to the tool command\";\n    \"-ocamlc\", set_cmd ocamlc, \"<command> Set the OCaml bytecode compiler\";\n    \"-plugin-ocamlc\", set_cmd plugin_ocamlc, \"<command> Set the OCaml bytecode compiler \\\n      used when building myocamlbuild.ml (only)\";\n--- ./src/pathname.ml\n+++ ./src/pathname.ml\n@@ -84,6 +84,26 @@\n   | x :: xs -> x :: normalize_list xs\n \n let normalize x =\n+  let x =\n+    if Sys.win32 = false then\n+      x\n+    else\n+      let len = String.length x in\n+      let b = Bytes.create len in\n+      for i = 0 to pred len do\n+        match x.[i] with\n+        | '\\\\' -> Bytes.set b i '/'\n+        | c -> Bytes.set b i c\n+      done;\n+      if len > 1 then (\n+        let c1 = Bytes.get b 0 in\n+        let c2 = Bytes.get b 1 in\n+        if c2 = ':' && c1 >= 'a' && c1 <= 'z' &&\n+           ( len = 2 || Bytes.get b 2 = '/') then\n+          Bytes.set b 0 (Char.uppercase_ascii c1)\n+      );\n+      Bytes.unsafe_to_string b\n+  in\n   if Glob.eval not_normal_form_re x then\n     let root, paths = split x in\n     join root (normalize_list paths)\n--- ./src/shell.ml\n+++ ./src/shell.ml\n@@ -24,12 +24,26 @@\n     | 'a'..'z' | 'A'..'Z' | '0'..'9' | '.' | '-' | '/' | '_' | ':' | '@' | '+' | ',' -> loop (pos + 1)\n     | _ -> false in\n   loop 0\n+\n+let generic_quote quotequote s =\n+  let l = String.length s in\n+  let b = Buffer.create (l + 20) in\n+  Buffer.add_char b '\\'';\n+  for i = 0 to l - 1 do\n+    if s.[i] = '\\''\n+    then Buffer.add_string b quotequote\n+    else Buffer.add_char b  s.[i]\n+  done;\n+  Buffer.add_char b '\\'';\n+  Buffer.contents b\n+let unix_quote = generic_quote \"'\\\\''\"\n+\n let quote_filename_if_needed s =\n   if is_simple_filename s then s\n   (* We should probably be using [Filename.unix_quote] except that function\n    * isn't exported. Users on Windows will have to live with not being able to\n    * install OCaml into c:\\o'caml. Too bad. *)\n-  else if Sys.os_type = \"Win32\" then Printf.sprintf \"'%s'\" s\n+  else if Sys.os_type = \"Win32\" then unix_quote s\n   else Filename.quote s\n let chdir dir =\n   reset_filesys_cache ();\n@@ -37,7 +51,7 @@\n let run args target =\n   reset_readdir_cache ();\n   let cmd = String.concat \" \" (List.map quote_filename_if_needed args) in\n-  if !*My_unix.is_degraded || Sys.os_type = \"Win32\" then\n+  if !*My_unix.is_degraded then\n     begin\n       Log.event cmd target Tags.empty;\n       let st = sys_command cmd in\n"
-          }
-        ],
+        "files": [],
         "opam": {
           "name": "ocamlbuild",
           "version": "0.12.0",
@@ -7812,10 +7759,6 @@
             "opam-version: \"1.2\"\nname: \"ocamlbuild\"\nversion: \"0.12.0\"\nmaintainer: \"Gabriel Scherer <gabriel.scherer@gmail.com>\"\nauthors: [\"Nicolas Pouillard\" \"Berke Durak\"]\nlicense: \"LGPL-2 with OCaml linking exception\"\nhomepage: \"https://github.com/ocaml/ocamlbuild/\"\ndoc: \"https://github.com/ocaml/ocamlbuild/blob/master/manual/manual.adoc\"\nbug-reports: \"https://github.com/ocaml/ocamlbuild/issues\"\nconflicts: [\n  \"base-ocamlbuild\"\n  \"ocamlfind\" {< \"1.6.2\"}\n]\navailable: ocaml-version >= \"4.03\"\nbuild: [\n  [\n    make\n    \"-f\"\n    \"configure.make\"\n    \"all\"\n    \"OCAMLBUILD_PREFIX=%{prefix}%\"\n    \"OCAMLBUILD_BINDIR=%{bin}%\"\n    \"OCAMLBUILD_LIBDIR=%{lib}%\"\n    \"OCAMLBUILD_MANDIR=%{man}%\"\n    \"OCAML_NATIVE=%{ocaml-native}%\"\n    \"OCAML_NATIVE_TOOLS=%{ocaml-native}%\"\n  ]\n  [make \"check-if-preinstalled\" \"all\" \"opam-install\"]\n]\ndev-repo: \"git+https://github.com/ocaml/ocamlbuild.git\"",
           "override": {
             "build": [
-              [
-                "bash", "-c",
-                "#{os == 'windows' ? 'patch -p1 < _esy/ocamlbuild-0.12.0.patch' : 'true'}"
-              ],
               [
                 "make", "-f", "configure.make", "all",
                 "OCAMLBUILD_PREFIX=#{self.install}",
@@ -7913,31 +7856,31 @@
         "@opam/ocamlfind@opam:1.8.0"
       ]
     },
-    "@opam/menhir@opam:20171013": {
+    "@opam/menhir@opam:20170712": {
       "record": {
         "name": "@opam/menhir",
-        "version": "opam:20171013",
+        "version": "opam:20170712",
         "source": [
-          "archive:https://opam.ocaml.org/archives/menhir.20171013+opam.tar.gz#md5:b361a87378407e26b9ea2dde7ddf41a0",
-          "archive:http://gallium.inria.fr/~fpottier/menhir/menhir-20171013.tar.gz#md5:620863edea40437390ee5e5bd82fba11"
+          "archive:https://opam.ocaml.org/archives/menhir.20170712+opam.tar.gz#md5:18aaf814e51aeb4fbfd8b7c1fb7ffbba",
+          "archive:http://gallium.inria.fr/~fpottier/menhir/menhir-20170712.tar.gz#md5:85a5c2aef1d3f2224dab7c53d79892e5"
         ],
         "files": [
           {
-            "name": "_esy/menhir-20171013.patch",
+            "name": "_esy/menhir-20170712.patch",
             "content":
-              "--- ./Makefile\n+++ ./Makefile\n@@ -59,13 +59,8 @@\n \n # If the compiler is MSVC, then object file names end in .obj instead of .o.\n \n-ifneq (,$(shell ocamlc -config | grep -E \"ccomp_type: msvc\"))\n-  OBJ          := obj\n-# LIBSUFFIX    := lib\n-else\n-  OBJ          := o\n-# LIBSUFFIX    := a\n-endif\n+OBJ          := $(shell ocamlc -config | awk -F '[\\t \\r]+' '/^ext_obj:/ {print $$2}' | tr -d '.')\n+#LIBSUFFIX   := $(shell ocamlc -config | awk -F '[\\t \\r]+' '/^ext_lib:/ {print $$2}' | tr -d '.')\n \n # If we are under Windows (regardless of whether we are using MSVC or mingw)\n # then the name of the executable file ends in .exe.\n@@ -91,8 +86,9 @@\n # performed if \"os_type\" is \"Win32\" or \"Win64\", and must not be performed if\n # \"os_type\" is \"Cygwin\" or \"Unix\".\n \n-ifneq (,$(shell ocamlc -config | grep -E \"os_type: (Win32|Win64)\"))\n-installation_libdir := $(shell cygpath -m $(libdir))\n+OS_TYPE:=\t$(shell ocamlc -config | awk -F '[\\t \\r]+' '/^os_type:/ {print $$2}')\n+ifeq ($(OS_TYPE),Win32)\n+installation_libdir := $(shell cygpath -m $(libdir) || echo $(libdir))\n else\n installation_libdir := $(libdir)\n endif\n--- ./src/cmly_write.ml\n+++ ./src/cmly_write.ml\n@@ -168,6 +168,6 @@\n   output_value oc (t : grammar)\n \n let write filename =\n-  let oc = open_out filename in\n+  let oc = open_out_bin filename in\n   write oc (encode());\n   close_out oc\n"
+              "--- ./Makefile\n+++ ./Makefile\n@@ -60,10 +60,11 @@\n # If the compiler is MSVC, then the name of the executable file ends in .exe,\n # and object file names end in .obj instead of .o.\n \n-ifneq (,$(shell ocamlc -config | grep -E \"ccomp_type: msvc\"))\n+OS_TYPE:=$(shell ocamlc -config | tr -d '\\15' | awk '/^os_type:/ {print $$2}')\n+ifeq ($(OS_TYPE),$(filter $(OS_TYPE),Win32 Cygwin))\n   MENHIREXE    := menhir.exe\n-  OBJ          := obj\n-# LIBSUFFIX    := lib\n+  OBJ          := $(shell ocamlc -config | tr -d '\\15' | awk '/^ext_obj:/ {print $$2}' | tr -d '.')\n+# LIBSUFFIX    := $(shell ocamlc -config | tr -d '\\15' | awk '/^ext_lib:/ {print $$2}' | tr -d '.')\n else\n   MENHIREXE    := menhir\n   OBJ          := o\n@@ -85,8 +86,8 @@\n # performed if \"os_type\" is \"Win32\" or \"Win64\", and must not be performed if\n # \"os_type\" is \"Cygwin\" or \"Unix\".\n \n-ifneq (,$(shell ocamlc -config | grep -E \"os_type: (Win32|Win64)\"))\n-installation_libdir := $(shell cygpath -m $(libdir))\n+ifeq ($(OS_TYPE),Win32)\n+installation_libdir := $(shell cygpath -m $(libdir) || echo $(libdir))\n else\n installation_libdir := $(libdir)\n endif\n--- ./src/cmly_write.ml\n+++ ./src/cmly_write.ml\n@@ -168,6 +168,6 @@\n   output_value oc (t : grammar)\n \n let write filename =\n-  let oc = open_out filename in\n+  let oc = open_out_bin filename in\n   write oc (encode());\n   close_out oc\n"
           }
         ],
         "opam": {
           "name": "menhir",
-          "version": "20171013",
+          "version": "20170712",
           "opam":
-            "opam-version: \"1.2\"\nname: \"menhir\"\nversion: \"20171013\"\nmaintainer: \"francois.pottier@inria.fr\"\nauthors: [\n  \"François Pottier <francois.pottier@inria.fr>\"\n  \"Yann Régis-Gianas <yrg@pps.univ-paris-diderot.fr>\"\n]\nhomepage: \"http://gallium.inria.fr/~fpottier/menhir/\"\nbug-reports: \"menhir@inria.fr\"\ndepends: [\n  \"ocamlfind\"\n  \"ocamlbuild\" {build}\n]\navailable: ocaml-version >= \"4.02\"\nbuild: [\n  make\n  \"-f\"\n  \"Makefile\"\n  \"PREFIX=%{prefix}%\"\n  \"USE_OCAMLFIND=true\"\n  \"docdir=%{doc}%/menhir\"\n  \"libdir=%{lib}%/menhir\"\n  \"mandir=%{man}%/man1\"\n]\ninstall: [\n  make\n  \"-f\"\n  \"Makefile\"\n  \"install\"\n  \"PREFIX=%{prefix}%\"\n  \"docdir=%{doc}%/menhir\"\n  \"libdir=%{lib}%/menhir\"\n  \"mandir=%{man}%/man1\"\n]\nremove: [\n  make\n  \"-f\"\n  \"Makefile\"\n  \"uninstall\"\n  \"PREFIX=%{prefix}%\"\n  \"docdir=%{doc}%/menhir\"\n  \"libdir=%{lib}%/menhir\"\n  \"mandir=%{man}%/man1\"\n]\ndev-repo: \"git+https://gitlab.inria.fr/fpottier/menhir.git\"",
+            "opam-version: \"1.2\"\nname: \"menhir\"\nversion: \"20170712\"\nmaintainer: \"francois.pottier@inria.fr\"\nauthors: [\n  \"François Pottier <francois.pottier@inria.fr>\"\n  \"Yann Régis-Gianas <yrg@pps.univ-paris-diderot.fr>\"\n]\nhomepage: \"http://gallium.inria.fr/~fpottier/menhir/\"\nbug-reports: \"menhir@inria.fr\"\ndepends: [\n  \"ocamlfind\"\n  \"ocamlbuild\" {build}\n]\navailable: ocaml-version >= \"4.02\"\nbuild: [\n  make\n  \"-f\"\n  \"Makefile\"\n  \"PREFIX=%{prefix}%\"\n  \"USE_OCAMLFIND=true\"\n  \"docdir=%{doc}%/menhir\"\n  \"libdir=%{lib}%/menhir\"\n  \"mandir=%{man}%/man1\"\n]\ninstall: [\n  make\n  \"-f\"\n  \"Makefile\"\n  \"install\"\n  \"PREFIX=%{prefix}%\"\n  \"docdir=%{doc}%/menhir\"\n  \"libdir=%{lib}%/menhir\"\n  \"mandir=%{man}%/man1\"\n]\nremove: [\n  make\n  \"-f\"\n  \"Makefile\"\n  \"uninstall\"\n  \"PREFIX=%{prefix}%\"\n  \"docdir=%{doc}%/menhir\"\n  \"libdir=%{lib}%/menhir\"\n  \"mandir=%{man}%/man1\"\n]\ndev-repo: \"git+https://gitlab.inria.fr/fpottier/menhir.git\"",
           "override": {
             "build": [
               [
                 "bash", "-c",
-                "#{os == 'windows' ? 'patch -p1 < _esy/menhir-20171013.patch' : 'true'}"
+                "#{os == 'windows' ? 'patch -p1 < _esy/menhir-20170712.patch' : 'true'}"
               ],
               [
                 "make", "-f", "Makefile", "PREFIX=#{self.install}",
@@ -8650,7 +8593,7 @@
       },
       "dependencies": [
         "@esy-ocaml/esy-installer@0.0.0", "@esy-ocaml/substs@0.0.1",
-        "@opam/jbuilder@opam:transition", "@opam/menhir@opam:20171013",
+        "@opam/jbuilder@opam:transition", "@opam/menhir@opam:20170712",
         "@opam/merlin-extend@opam:0.3",
         "@opam/ocaml-migrate-parsetree@opam:1.0.11",
         "@opam/ocamlfind@opam:1.8.0", "@opam/result@opam:1.3"

--- a/esy.lock.json
+++ b/esy.lock.json
@@ -1,6 +1,6 @@
 {
-  "hash": "250cc94d431bec260202a09bffb8d67d",
-  "root": "esy-test-build@path:.",
+  "hash": "439ad2b02c1cefc86bedf7e1c439b070",
+  "root": "esy@path:.",
   "node": {
     "yargs-parser@9.0.2": {
       "record": {
@@ -139,7 +139,7 @@
         "name": "wrap-ansi",
         "version": "2.1.0",
         "source":
-          "archive:https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz#sha1:d8fc3d284dd05794fe84973caecdd1cf824fdd85",
+          "archive:http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz#sha1:d8fc3d284dd05794fe84973caecdd1cf824fdd85",
         "files": [],
         "opam": null
       },
@@ -2022,7 +2022,7 @@
         "name": "outdent",
         "version": "0.3.0",
         "source":
-          "archive:https://registry.npmjs.org/outdent/-/outdent-0.3.0.tgz#sha1:fad18a9c061a0938f38e8071d16c4024423f4323",
+          "archive:http://registry.npmjs.org/outdent/-/outdent-0.3.0.tgz#sha1:fad18a9c061a0938f38e8071d16c4024423f4323",
         "files": [],
         "opam": null
       },
@@ -2209,12 +2209,12 @@
       },
       "dependencies": []
     },
-    "nwsapi@2.0.8": {
+    "nwsapi@2.0.9": {
       "record": {
         "name": "nwsapi",
-        "version": "2.0.8",
+        "version": "2.0.9",
         "source":
-          "archive:https://registry.npmjs.org/nwsapi/-/nwsapi-2.0.8.tgz#sha1:e3603579b7e162b3dbedae4fb24e46f771d8fa24",
+          "archive:https://registry.npmjs.org/nwsapi/-/nwsapi-2.0.9.tgz#sha1:77ac0cdfdcad52b6a1151a84e73254edc33ed016",
         "files": [],
         "opam": null
       },
@@ -2462,7 +2462,7 @@
         "name": "minimist",
         "version": "1.2.0",
         "source":
-          "archive:https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz#sha1:a35008b20f41383eec1fb914f4cd5df79a264284",
+          "archive:http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz#sha1:a35008b20f41383eec1fb914f4cd5df79a264284",
         "files": [],
         "opam": null
       },
@@ -2473,7 +2473,7 @@
         "name": "minimist",
         "version": "0.0.10",
         "source":
-          "archive:https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz#sha1:de3f98543dbf96082be48ad1a0c7cda836301dcf",
+          "archive:http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz#sha1:de3f98543dbf96082be48ad1a0c7cda836301dcf",
         "files": [],
         "opam": null
       },
@@ -2484,7 +2484,7 @@
         "name": "minimist",
         "version": "0.0.8",
         "source":
-          "archive:https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz#sha1:857fcabfc3397d2625b8228262e86aa7a011b05d",
+          "archive:http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz#sha1:857fcabfc3397d2625b8228262e86aa7a011b05d",
         "files": [],
         "opam": null
       },
@@ -2972,7 +2972,7 @@
         "abab@2.0.0", "acorn@5.7.2", "acorn-globals@4.1.0",
         "array-equal@1.0.0", "cssom@0.3.4", "cssstyle@1.1.1",
         "data-urls@1.0.1", "domexception@1.0.1", "escodegen@1.11.0",
-        "html-encoding-sniffer@1.0.2", "left-pad@1.3.0", "nwsapi@2.0.8",
+        "html-encoding-sniffer@1.0.2", "left-pad@1.3.0", "nwsapi@2.0.9",
         "parse5@4.0.0", "pn@1.1.0", "request@2.88.0",
         "request-promise-native@1.0.5", "sax@1.2.4", "symbol-tree@3.2.2",
         "tough-cookie@2.4.3", "w3c-hr-time@1.0.1",
@@ -3498,7 +3498,7 @@
         "opam": null
       },
       "dependencies": [
-        "async@2.6.1", "compare-versions@3.3.1", "fileset@2.0.3",
+        "async@2.6.1", "compare-versions@3.4.0", "fileset@2.0.3",
         "istanbul-lib-coverage@1.2.0", "istanbul-lib-hook@1.2.1",
         "istanbul-lib-instrument@2.3.2", "istanbul-lib-report@1.1.4",
         "istanbul-lib-source-maps@1.2.5", "istanbul-reports@1.5.0",
@@ -4819,9 +4819,20 @@
       },
       "dependencies": [ "merge@1.2.0" ]
     },
-    "esy-test-build@path:.": {
+    "esy-solve-cudf@0.1.6": {
       "record": {
-        "name": "esy-test-build",
+        "name": "esy-solve-cudf",
+        "version": "0.1.6",
+        "source":
+          "archive:https://registry.npmjs.org/esy-solve-cudf/-/esy-solve-cudf-0.1.6.tgz#sha1:e5fe6e16be1e71964e1bfe3cdb80688e072dbe0f",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "esy@path:.": {
+      "record": {
+        "name": "esy",
         "version": "path:.",
         "source": "path:.",
         "files": [],
@@ -4835,31 +4846,21 @@
         "@opam/fmt@opam:0.8.5", "@opam/fpath@opam:0.7.2",
         "@opam/lambda-term@opam:1.13", "@opam/logs@opam:0.6.2",
         "@opam/lwt@opam:4.1.0", "@opam/lwt_ppx@opam:1.2.1",
-        "@opam/menhir@opam:20170712", "@opam/opam-core@opam:2.0.0",
+        "@opam/menhir@opam:20171013", "@opam/opam-core@opam:2.0.0",
         "@opam/opam-file-format@opam:2.0.0", "@opam/opam-format@opam:2.0.0",
         "@opam/opam-state@opam:2.0.0", "@opam/ppx_deriving@opam:4.2.1",
         "@opam/ppx_deriving_yojson@opam:3.1",
         "@opam/ppx_inline_test@opam:v0.11.0", "@opam/ppx_let@opam:v0.11.0",
-        "@opam/re@opam:1.8.0", "@opam/utop@opam:2.2.0",
-        "@opam/yojson@opam:1.4.1", "babel-preset-env@1.7.0",
-        "babel-preset-flow@6.23.0", "del@3.0.0", "esy-solve-cudf@0.1.6",
+        "@opam/re@opam:1.8.0", "@opam/tyre@opam:0.4.1",
+        "@opam/utop@opam:2.2.0", "@opam/yojson@opam:1.4.1",
+        "babel-preset-env@1.7.0", "babel-preset-flow@6.23.0", "del@3.0.0",
+        "esy-solve-cudf@0.1.6",
         "fastreplacestring@github:esy-ocaml/FastReplaceString#95f408b",
         "flow-bin@0.77.0", "fs-extra@7.0.0", "jest-cli@23.5.0", "klaw@2.1.1",
         "minimatch@3.0.4", "ocaml@4.6.5", "outdent@0.3.0", "prettier@1.14.2",
         "rimraf@2.6.2", "semver@5.5.1", "super-resolve@1.0.0", "tar@4.4.6",
         "tar-fs@1.16.3", "tmp@0.0.33"
       ]
-    },
-    "esy-solve-cudf@0.1.6": {
-      "record": {
-        "name": "esy-solve-cudf",
-        "version": "0.1.6",
-        "source":
-          "archive:https://registry.npmjs.org/esy-solve-cudf/-/esy-solve-cudf-0.1.6.tgz#sha1:e5fe6e16be1e71964e1bfe3cdb80688e072dbe0f",
-        "files": [],
-        "opam": null
-      },
-      "dependencies": []
     },
     "esutils@2.0.2": {
       "record": {
@@ -5349,12 +5350,12 @@
       },
       "dependencies": []
     },
-    "compare-versions@3.3.1": {
+    "compare-versions@3.4.0": {
       "record": {
         "name": "compare-versions",
-        "version": "3.3.1",
+        "version": "3.4.0",
         "source":
-          "archive:https://registry.npmjs.org/compare-versions/-/compare-versions-3.3.1.tgz#sha1:1ede3172b713c15f7c7beb98cb74d2d82576dad3",
+          "archive:https://registry.npmjs.org/compare-versions/-/compare-versions-3.4.0.tgz#sha1:e0747df5c9cb7f054d6d3dc3e1dbc444f9e92b26",
         "files": [],
         "opam": null
       },
@@ -5549,12 +5550,12 @@
       },
       "dependencies": [ "rsvp@3.6.2" ]
     },
-    "caniuse-lite@1.0.30000882": {
+    "caniuse-lite@1.0.30000884": {
       "record": {
         "name": "caniuse-lite",
-        "version": "1.0.30000882",
+        "version": "1.0.30000884",
         "source":
-          "archive:https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000882.tgz#sha1:0d5066847a11a5af0e50ffce6c062ef0665f68ea",
+          "archive:https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000884.tgz#sha1:eb82a959698745033b26a4dcd34d89dba7cc6eb3",
         "files": [],
         "opam": null
       },
@@ -5685,7 +5686,7 @@
         "opam": null
       },
       "dependencies": [
-        "caniuse-lite@1.0.30000882", "electron-to-chromium@1.3.62"
+        "caniuse-lite@1.0.30000884", "electron-to-chromium@1.3.62"
       ]
     },
     "browser-resolve@1.11.3": {
@@ -6303,7 +6304,7 @@
         "name": "babel-plugin-syntax-object-rest-spread",
         "version": "6.13.0",
         "source":
-          "archive:https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#sha1:fd6536f2bce13836ffa3a5458c4903a597bb3bf5",
+          "archive:http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#sha1:fd6536f2bce13836ffa3a5458c4903a597bb3bf5",
         "files": [],
         "opam": null
       },
@@ -6314,7 +6315,7 @@
         "name": "babel-plugin-syntax-flow",
         "version": "6.18.0",
         "source":
-          "archive:https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz#sha1:4c3ab20a2af26aa20cd25995c398c4eb70310c8d",
+          "archive:http://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz#sha1:4c3ab20a2af26aa20cd25995c398c4eb70310c8d",
         "files": [],
         "opam": null
       },
@@ -6325,7 +6326,7 @@
         "name": "babel-plugin-syntax-exponentiation-operator",
         "version": "6.13.0",
         "source":
-          "archive:https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz#sha1:9ee7e8337290da95288201a6a57f4170317830de",
+          "archive:http://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz#sha1:9ee7e8337290da95288201a6a57f4170317830de",
         "files": [],
         "opam": null
       },
@@ -6336,7 +6337,7 @@
         "name": "babel-plugin-syntax-async-functions",
         "version": "6.13.0",
         "source":
-          "archive:https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#sha1:cad9cad1191b5ad634bf30ae0872391e0647be95",
+          "archive:http://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#sha1:cad9cad1191b5ad634bf30ae0872391e0647be95",
         "files": [],
         "opam": null
       },
@@ -7158,6 +7159,28 @@
         "@esy-ocaml/substs@0.0.1", "@opam/ocamlbuild@opam:0.12.0"
       ]
     },
+    "@opam/tyre@opam:0.4.1": {
+      "record": {
+        "name": "@opam/tyre",
+        "version": "opam:0.4.1",
+        "source": [
+          "archive:https://opam.ocaml.org/archives/tyre.0.4.1+opam.tar.gz#md5:c5a3e988b7051126a389807dbdb9395b",
+          "archive:https://github.com/Drup/tyre/releases/download/0.4.1/tyre-0.4.1.tbz#md5:41923cb08a11f93d704b79f7bb078640"
+        ],
+        "files": [],
+        "opam": {
+          "name": "tyre",
+          "version": "0.4.1",
+          "opam":
+            "opam-version: \"1.2\"\nname: \"tyre\"\nversion: \"0.4.1\"\nmaintainer: \"Gabriel Radanne <drupyog@zoho.com>\"\nauthors: \"Gabriel Radanne <drupyog@zoho.com>\"\nlicense: \"ISC\"\ntags: \"regex\"\nhomepage: \"https://github.com/Drup/tyre\"\ndoc: \"https://drup.github.io/tyre/doc/0.4/tyre/Tyre/\"\nbug-reports: \"https://github.com/Drup/tyre/issues\"\ndepends: [\n  \"jbuilder\" {build}\n  \"re\" {>= \"1.8.0\"}\n  \"alcotest\" {test & >= \"0.8.0\"}\n  \"result\"\n  \"seq\"\n]\navailable: ocaml-version >= \"4.02.0\"\nbuild: [\n  [\"jbuilder\" \"subst\"] {pinned}\n  [\"jbuilder\" \"build\" \"-p\" name \"-j\" jobs]\n  [\"jbuilder\" \"runtest\" \"-p\" name] {with-test}\n]\ndev-repo: \"git+https://github.com/Drup/tyre.git\"",
+          "override": null
+        }
+      },
+      "dependencies": [
+        "@esy-ocaml/substs@0.0.1", "@opam/jbuilder@opam:transition",
+        "@opam/re@opam:1.8.0", "@opam/result@opam:1.3", "@opam/seq@opam:0.1"
+      ]
+    },
     "@opam/topkg@opam:0.9.1": {
       "record": {
         "name": "@opam/topkg",
@@ -7711,7 +7734,7 @@
               "bin: [\n  \"src/findlib/ocamlfind\" {\"ocamlfind\"}\n  \"?src/findlib/ocamlfind_opt\" {\"ocamlfind\"}\n  \"?tools/safe_camlp4\"\n]\ntoplevel: [\"src/findlib/topfind\"]\n"
           },
           {
-            "name": "_esy/build",
+            "name": "esy-build",
             "content":
               "#!/bin/bash\n\nset -euo pipefail\nset -x\n\n#\n# Shim OCAMLLIB so that we can write topfind there\n#\n\nREAL_OCAMLLIB=\"$1\"\n\nmkdir -p $cur__install/lib/ocaml\ncd $cur__install/lib/ocaml\n\nfor filename in `ls -1 $REAL_OCAMLLIB`; do\n  ln -s $REAL_OCAMLLIB/$filename $filename;\ndone\n\n#\n# Build\n#\n\ncd $cur__root\n\nexport OCAMLLIB=\"$cur__install/lib/ocaml\"\n\n./configure \\\n  -bindir $cur__install/bin \\\n  -sitelib $cur__install/lib \\\n  -mandir $cur__install/man \\\n  -config $cur__install/lib/findlib.conf \\\n  -no-custom \\\n  -no-camlp4\n\nmake all\nmake opt\nmake install\n\n(opam-installer --prefix=$cur__install || true)\n"
           }
@@ -7722,7 +7745,7 @@
           "opam":
             "opam-version: \"1.2\"\nname: \"ocamlfind\"\nversion: \"1.8.0\"\nmaintainer: \"Thomas Gazagnaire <thomas@gazagnaire.org>\"\nauthors: \"Gerd Stolpmann <gerd@gerd-stolpmann.de>\"\nhomepage: \"http://projects.camlcity.org/projects/findlib.html\"\nbug-reports: \"https://gitlab.camlcity.org/gerd/lib-findlib/issues\"\ndepends: [\n  \"conf-m4\" {build}\n]\navailable: ocaml-version >= \"4.00.0\"\nbuild: [\n  [\n    \"./configure\"\n    \"-bindir\"\n    bin\n    \"-sitelib\"\n    lib\n    \"-mandir\"\n    man\n    \"-config\"\n    \"%{lib}%/findlib.conf\"\n    \"-no-custom\"\n    \"-no-topfind\" {preinstalled}\n  ]\n  [make \"all\"]\n  [make \"opt\"] {ocaml-native}\n]\ninstall: [\n  [make \"install\"]\n  [\"install\" \"-m\" \"0755\" \"ocaml-stub\" \"%{bin}%/ocaml\"] {preinstalled}\n]\nremove: [\n  [\"ocamlfind\" \"remove\" \"bytes\"]\n  [\n    \"./configure\"\n    \"-bindir\"\n    bin\n    \"-sitelib\"\n    lib\n    \"-mandir\"\n    man\n    \"-config\"\n    \"%{lib}%/findlib.conf\"\n    \"-no-topfind\" {preinstalled}\n  ]\n  [make \"uninstall\"]\n  [\"rm\" \"-f\" \"%{bin}%/ocaml\"] {preinstalled}\n]\ndev-repo: \"git+https://gitlab.camlcity.org/gerd/lib-findlib.git\"",
           "override": {
-            "build": [ [ "bash", "./_esy/build", "#{ocaml.lib / 'ocaml'}" ] ],
+            "build": [ [ "bash", "./esy-build", "#{ocaml.lib / 'ocaml'}" ] ],
             "exportedEnv": {
               "OCAMLLIB": {
                 "val": "#{@opam/ocamlfind.install / 'lib' / 'ocaml'}",
@@ -7751,7 +7774,13 @@
           "archive:https://opam.ocaml.org/archives/ocamlbuild.0.12.0+opam.tar.gz#md5:6e877d7f40c119c0c6c03f04342f2264",
           "archive:https://github.com/ocaml/ocamlbuild/archive/0.12.0.tar.gz#md5:442baa19470bd49150f153122e22907b"
         ],
-        "files": [],
+        "files": [
+          {
+            "name": "_esy/ocamlbuild-0.12.0.patch",
+            "content":
+              "--- ./Makefile\n+++ ./Makefile\n@@ -213,7 +213,7 @@\n \trm -f man/ocamlbuild.1\n \n man/options_man.byte: src/ocamlbuild_pack.cmo\n-\t$(OCAMLC) $^ -I src man/options_man.ml -o man/options_man.byte\n+\t$(OCAMLC) -I +unix unix.cma $^ -I src man/options_man.ml -o man/options_man.byte\n \n clean::\n \trm -f man/options_man.cm*\n--- ./META\n+++ ./META\n@@ -2,5 +2,6 @@\n requires = \"unix\"\n version = \"0.12.0\"\n description = \"ocamlbuild support library\"\n+directory= \"^ocamlbuild\"\n archive(byte) = \"ocamlbuildlib.cma\"\n archive(native) = \"ocamlbuildlib.cmxa\"\n--- ./src/command.ml\n+++ ./src/command.ml\n@@ -148,9 +148,10 @@\n   let self = string_of_command_spec_with_calls call_with_tags call_with_target resolve_virtuals in\n   let b = Buffer.create 256 in\n   (* The best way to prevent bash from switching to its windows-style\n-   * quote-handling is to prepend an empty string before the command name. *)\n+   * quote-handling is to prepend an empty string before the command name.\n+   * space seems to work, too - and the ouput is nicer *)\n   if Sys.os_type = \"Win32\" then\n-    Buffer.add_string b \"''\";\n+    Buffer.add_char b ' ';\n   let first = ref true in\n   let put_space () =\n     if !first then\n@@ -260,7 +261,7 @@\n \n let execute_many ?(quiet=false) ?(pretend=false) cmds =\n   add_parallel_stat (List.length cmds);\n-  let degraded = !*My_unix.is_degraded || Sys.os_type = \"Win32\" in\n+  let degraded = !*My_unix.is_degraded in\n   let jobs = !jobs in\n   if jobs < 0 then invalid_arg \"jobs < 0\";\n   let max_jobs = if jobs = 0 then None else Some jobs in\n--- ./src/findlib.ml\n+++ ./src/findlib.ml\n@@ -66,9 +66,6 @@\n     (fun command -> lexer & Lexing.from_string & run_and_read command)\n     command\n \n-let run_and_read command =\n-  Printf.ksprintf run_and_read command\n-\n let rec query name =\n   try\n     Hashtbl.find packages name\n@@ -135,7 +132,8 @@\n   with Not_found -> s\n \n let list () =\n-  List.map before_space (split_nl & run_and_read \"%s list\" ocamlfind)\n+  let cmd = Shell.quote_filename_if_needed ocamlfind ^ \" list\" in\n+  List.map before_space (split_nl & run_and_read cmd)\n \n (* The closure algorithm is easy because the dependencies are already closed\n and sorted for each package. We only have to make the union. We could also\n--- ./src/main.ml\n+++ ./src/main.ml\n@@ -162,6 +162,9 @@\n               Tags.mem \"traverse\" tags\n               || List.exists (Pathname.is_prefix path_name) !Options.include_dirs\n               || List.exists (Pathname.is_prefix path_name) target_dirs)\n+            && ((* beware: !Options.build_dir is an absolute directory *)\n+              Pathname.normalize !Options.build_dir\n+              <> Pathname.normalize (Pathname.pwd/path_name))\n           end\n         end\n       end\n--- ./src/my_std.ml\n+++ ./src/my_std.ml\n@@ -271,13 +271,107 @@\n       try Array.iter (fun x -> if x = basename then raise Exit) a; false\n       with Exit -> true\n \n+let command_plain = function\n+| [| |] -> 0\n+| margv ->\n+  let rec waitpid a b =\n+    match Unix.waitpid a b with\n+    | exception (Unix.Unix_error(Unix.EINTR,_,_)) -> waitpid a b\n+    | x -> x\n+  in\n+  let pid = Unix.(create_process margv.(0) margv stdin stdout stderr) in\n+  let pid', process_status = waitpid [] pid in\n+  assert (pid = pid');\n+  match process_status with\n+  | Unix.WEXITED n -> n\n+  | Unix.WSIGNALED _ -> 2 (* like OCaml's uncaught exceptions *)\n+  | Unix.WSTOPPED _ -> 127\n+\n+(* can't use Lexers because of circular dependency *)\n+let split_path_win str =\n+  let rec aux pos =\n+    try\n+      let i = String.index_from str pos ';' in\n+      let len = i - pos in\n+      if len = 0 then\n+        aux (succ i)\n+      else\n+        String.sub str pos (i - pos) :: aux (succ i)\n+    with Not_found | Invalid_argument _ ->\n+      let len = String.length str - pos in\n+      if len = 0 then [] else [String.sub str pos len]\n+  in\n+  aux 0\n+\n+let windows_shell = lazy begin\n+  let rec iter = function\n+  | [] -> [| \"bash.exe\" ; \"--norc\" ; \"--noprofile\" |]\n+  | hd::tl ->\n+    let dash = Filename.concat hd \"dash.exe\" in\n+    if Sys.file_exists dash then [|dash|] else\n+    let bash = Filename.concat hd \"bash.exe\" in\n+    if Sys.file_exists bash = false then iter tl else\n+    (* if sh.exe and bash.exe exist in the same dir, choose sh.exe *)\n+    let sh = Filename.concat hd \"sh.exe\" in\n+    if Sys.file_exists sh then [|sh|] else [|bash ; \"--norc\" ; \"--noprofile\"|]\n+  in\n+  split_path_win (try Sys.getenv \"PATH\" with Not_found -> \"\") |> iter\n+end\n+\n+let prep_windows_cmd cmd =\n+  (* workaround known ocaml bug, remove later *)\n+  if String.contains cmd '\\t' && String.contains cmd ' ' = false then\n+    \" \" ^ cmd\n+  else\n+    cmd\n+\n+let run_with_shell = function\n+| \"\" -> 0\n+| cmd ->\n+  let cmd = prep_windows_cmd cmd in\n+  let shell = Lazy.force windows_shell in\n+  let qlen = Filename.quote cmd |> String.length in\n+  (* old versions of dash had problems with bs *)\n+  try\n+    if qlen < 7_900 then\n+      command_plain (Array.append shell [| \"-ec\" ; cmd |])\n+    else begin\n+      (* it can still work, if the called command is a cygwin tool *)\n+      let ch_closed = ref false in\n+      let file_deleted = ref false in\n+      let fln,ch =\n+        Filename.open_temp_file\n+          ~mode:[Open_binary]\n+          \"ocamlbuildtmp\"\n+          \".sh\"\n+      in\n+      try\n+        let f_slash = String.map ( fun x -> if x = '\\\\' then '/' else x ) fln in\n+        output_string ch cmd;\n+        ch_closed:= true;\n+        close_out ch;\n+        let ret = command_plain (Array.append shell [| \"-e\" ; f_slash |]) in\n+        file_deleted:= true;\n+        Sys.remove fln;\n+        ret\n+      with\n+      | x ->\n+        if !ch_closed = false then\n+          close_out_noerr ch;\n+        if !file_deleted = false then\n+          (try Sys.remove fln with _ -> ());\n+        raise x\n+    end\n+  with\n+  | (Unix.Unix_error _) as x ->\n+    (* Sys.command doesn't raise an exception, so run_with_shell also won't\n+       raise *)\n+    Printexc.to_string x ^ \":\" ^ cmd |> prerr_endline;\n+    1\n+\n let sys_command =\n-  match Sys.os_type with\n-  | \"Win32\" -> fun cmd ->\n-      if cmd = \"\" then 0 else\n-      let cmd = \"bash --norc -c \" ^ Filename.quote cmd in\n-      Sys.command cmd\n-  | _ -> fun cmd -> if cmd = \"\" then 0 else Sys.command cmd\n+  if Sys.win32 then run_with_shell\n+  else fun cmd -> if cmd = \"\" then 0 else Sys.command cmd\n \n (* FIXME warning fix and use Filename.concat *)\n let filename_concat x y =\n--- ./src/my_std.mli\n+++ ./src/my_std.mli\n@@ -69,3 +69,6 @@\n \n val split_ocaml_version : (int * int * int * string) option\n (** (major, minor, patchlevel, rest) *)\n+\n+val windows_shell : string array Lazy.t\n+val prep_windows_cmd : string -> string\n--- ./src/ocamlbuild_executor.ml\n+++ ./src/ocamlbuild_executor.ml\n@@ -34,6 +34,8 @@\n   job_stdin   : out_channel;\n   job_stderr  : in_channel;\n   job_buffer  : Buffer.t;\n+  job_pid     : int;\n+  job_tmp_file: string option;\n   mutable job_dying : bool;\n };;\n \n@@ -76,6 +78,61 @@\n   in\n   loop 0\n ;;\n+\n+let open_process_full_win cmd env =\n+  let (in_read, in_write) = Unix.pipe () in\n+  let (out_read, out_write) = Unix.pipe () in\n+  let (err_read, err_write) = Unix.pipe () in\n+  Unix.set_close_on_exec in_read;\n+  Unix.set_close_on_exec out_write;\n+  Unix.set_close_on_exec err_read;\n+  let inchan = Unix.in_channel_of_descr in_read in\n+  let outchan = Unix.out_channel_of_descr out_write in\n+  let errchan = Unix.in_channel_of_descr err_read in\n+  let shell = Lazy.force Ocamlbuild_pack.My_std.windows_shell in\n+  let test_cmd =\n+    String.concat \" \" (List.map Filename.quote (Array.to_list shell)) ^\n+    \"-ec \" ^\n+    Filename.quote (Ocamlbuild_pack.My_std.prep_windows_cmd cmd) in\n+  let argv,tmp_file =\n+    if String.length test_cmd < 7_900 then\n+      Array.append\n+        shell\n+        [| \"-ec\" ; Ocamlbuild_pack.My_std.prep_windows_cmd cmd |],None\n+    else\n+    let fln,ch = Filename.open_temp_file ~mode:[Open_binary] \"ocamlbuild\" \".sh\" in\n+    output_string ch (Ocamlbuild_pack.My_std.prep_windows_cmd cmd);\n+    close_out ch;\n+    let fln' = String.map (function '\\\\' -> '/' | c -> c) fln in\n+    Array.append\n+      shell\n+      [| \"-c\" ; fln' |], Some fln in\n+  let pid =\n+    Unix.create_process_env argv.(0) argv env out_read in_write err_write in\n+  Unix.close out_read;\n+  Unix.close in_write;\n+  Unix.close err_write;\n+  (pid, inchan, outchan, errchan,tmp_file)\n+\n+let close_process_full_win (pid,inchan, outchan, errchan, tmp_file) =\n+  let delete tmp_file =\n+    match tmp_file with\n+    | None -> ()\n+    | Some x -> try Sys.remove x with Sys_error _ -> () in\n+  let tmp_file_deleted = ref false in\n+  try\n+    close_in inchan;\n+    close_out outchan;\n+    close_in errchan;\n+    let res = snd(Unix.waitpid [] pid) in\n+    tmp_file_deleted := true;\n+    delete tmp_file;\n+    res\n+  with\n+  | x when tmp_file <> None && !tmp_file_deleted = false ->\n+    delete tmp_file;\n+    raise x\n+\n (* ***)\n (*** execute *)\n (* XXX: Add test for non reentrancy *)\n@@ -130,10 +187,16 @@\n   (*** add_job *)\n   let add_job cmd rest result id =\n     (*display begin fun oc -> fp oc \"Job %a is %s\\n%!\" print_job_id id cmd; end;*)\n-    let (stdout', stdin', stderr') = open_process_full cmd env in\n+    let (pid,stdout', stdin', stderr', tmp_file) =\n+      if Sys.win32 then open_process_full_win cmd env else\n+      let a,b,c = open_process_full cmd env in\n+      -1,a,b,c,None\n+    in\n     incr jobs_active;\n-    set_nonblock (doi stdout');\n-    set_nonblock (doi stderr');\n+    if not Sys.win32 then (\n+      set_nonblock (doi stdout');\n+      set_nonblock (doi stderr');\n+    );\n     let job =\n       { job_id          = id;\n         job_command     = cmd;\n@@ -143,7 +206,9 @@\n         job_stdin       = stdin';\n         job_stderr      = stderr';\n         job_buffer      = Buffer.create 1024;\n-        job_dying       = false }\n+        job_dying       = false;\n+        job_tmp_file    = tmp_file;\n+        job_pid         = pid }\n     in\n     outputs := FDM.add (doi stdout') job (FDM.add (doi stderr') job !outputs);\n     jobs := JS.add job !jobs;\n@@ -199,6 +264,7 @@\n               try\n                 read fd u 0 (Bytes.length u)\n               with\n+              | Unix.Unix_error(Unix.EPIPE,_,_) when Sys.win32 -> 0\n               | Unix.Unix_error(e,_,_)  ->\n                 let msg = error_message e in\n                 display (fun oc -> fp oc\n@@ -241,14 +307,19 @@\n       decr jobs_active;\n \n       (* PR#5371: we would get EAGAIN below otherwise *)\n-      clear_nonblock (doi job.job_stdout);\n-      clear_nonblock (doi job.job_stderr);\n-\n+      if not Sys.win32 then (\n+        clear_nonblock (doi job.job_stdout);\n+        clear_nonblock (doi job.job_stderr);\n+      );\n       do_read ~loop:true (doi job.job_stdout) job;\n       do_read ~loop:true (doi job.job_stderr) job;\n       outputs := FDM.remove (doi job.job_stdout) (FDM.remove (doi job.job_stderr) !outputs);\n       jobs := JS.remove job !jobs;\n-      let status = close_process_full (job.job_stdout, job.job_stdin, job.job_stderr) in\n+      let status =\n+        if Sys.win32 then\n+          close_process_full_win (job.job_pid, job.job_stdout, job.job_stdin, job.job_stderr, job.job_tmp_file)\n+        else\n+          close_process_full (job.job_stdout, job.job_stdin, job.job_stderr) in\n \n       let shown = ref false in\n \n--- ./src/ocamlbuild_unix_plugin.ml\n+++ ./src/ocamlbuild_unix_plugin.ml\n@@ -48,12 +48,22 @@\n   end\n \n let run_and_open s kont =\n+  let s_orig = s in\n+  let s =\n+    (* Be consistent! My_unix.run_and_open uses My_std.sys_command and\n+       sys_command uses bash. *)\n+    if Sys.win32 = false then s else\n+    let l = match Lazy.force My_std.windows_shell |> Array.to_list with\n+    | hd::tl -> (Filename.quote hd)::tl\n+    | _ -> assert false in\n+    \"\\\"\" ^ (String.concat \" \" l) ^ \" -ec \" ^ Filename.quote (\" \" ^ s) ^ \"\\\"\"\n+  in\n   let ic = Unix.open_process_in s in\n   let close () =\n     match Unix.close_process_in ic with\n     | Unix.WEXITED 0 -> ()\n     | Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _ ->\n-        failwith (Printf.sprintf \"Error while running: %s\" s) in\n+        failwith (Printf.sprintf \"Error while running: %s\" s_orig) in\n   let res = try\n       kont ic\n     with e -> (close (); raise e)\n--- ./src/options.ml\n+++ ./src/options.ml\n@@ -174,11 +174,24 @@\n     build_dir := Filename.concat (Sys.getcwd ()) s\n   else\n     build_dir := s\n+\n+let slashify =\n+  if Sys.win32 then fun p -> String.map (function '\\\\' -> '/' | x -> x) p\n+  else fun p ->p\n+\n+let sb () =\n+  match Sys.os_type with\n+  | \"Win32\" ->\n+    (try set_binary_mode_out stdout true with _ -> ());\n+  | _ -> ()\n+\n+\n let spec = ref (\n     let print_version () =\n+      sb ();\n       Printf.printf \"ocamlbuild %s\\n%!\" Ocamlbuild_config.version; raise Exit_OK\n     in\n-    let print_vnum () = print_endline Ocamlbuild_config.version; raise Exit_OK in\n+    let print_vnum () = sb (); print_endline Ocamlbuild_config.version; raise Exit_OK in\n   Arg.align\n   [\n    \"-version\", Unit print_version , \" Display the version\";\n@@ -257,8 +270,8 @@\n    \"-build-dir\", String set_build_dir, \"<path> Set build directory (implies no-links)\";\n    \"-install-lib-dir\", Set_string Ocamlbuild_where.libdir, \"<path> Set the install library directory\";\n    \"-install-bin-dir\", Set_string Ocamlbuild_where.bindir, \"<path> Set the install binary directory\";\n-   \"-where\", Unit (fun () -> print_endline !Ocamlbuild_where.libdir; raise Exit_OK), \" Display the install library directory\";\n-   \"-which\", String (fun cmd -> print_endline (find_tool cmd); raise Exit_OK), \"<command> Display path to the tool command\";\n+   \"-where\", Unit (fun () -> sb (); print_endline (slashify !Ocamlbuild_where.libdir); raise Exit_OK), \" Display the install library directory\";\n+   \"-which\", String (fun cmd -> sb (); print_endline (slashify (find_tool cmd)); raise Exit_OK), \"<command> Display path to the tool command\";\n    \"-ocamlc\", set_cmd ocamlc, \"<command> Set the OCaml bytecode compiler\";\n    \"-plugin-ocamlc\", set_cmd plugin_ocamlc, \"<command> Set the OCaml bytecode compiler \\\n      used when building myocamlbuild.ml (only)\";\n--- ./src/pathname.ml\n+++ ./src/pathname.ml\n@@ -84,6 +84,26 @@\n   | x :: xs -> x :: normalize_list xs\n \n let normalize x =\n+  let x =\n+    if Sys.win32 = false then\n+      x\n+    else\n+      let len = String.length x in\n+      let b = Bytes.create len in\n+      for i = 0 to pred len do\n+        match x.[i] with\n+        | '\\\\' -> Bytes.set b i '/'\n+        | c -> Bytes.set b i c\n+      done;\n+      if len > 1 then (\n+        let c1 = Bytes.get b 0 in\n+        let c2 = Bytes.get b 1 in\n+        if c2 = ':' && c1 >= 'a' && c1 <= 'z' &&\n+           ( len = 2 || Bytes.get b 2 = '/') then\n+          Bytes.set b 0 (Char.uppercase_ascii c1)\n+      );\n+      Bytes.unsafe_to_string b\n+  in\n   if Glob.eval not_normal_form_re x then\n     let root, paths = split x in\n     join root (normalize_list paths)\n--- ./src/shell.ml\n+++ ./src/shell.ml\n@@ -24,12 +24,26 @@\n     | 'a'..'z' | 'A'..'Z' | '0'..'9' | '.' | '-' | '/' | '_' | ':' | '@' | '+' | ',' -> loop (pos + 1)\n     | _ -> false in\n   loop 0\n+\n+let generic_quote quotequote s =\n+  let l = String.length s in\n+  let b = Buffer.create (l + 20) in\n+  Buffer.add_char b '\\'';\n+  for i = 0 to l - 1 do\n+    if s.[i] = '\\''\n+    then Buffer.add_string b quotequote\n+    else Buffer.add_char b  s.[i]\n+  done;\n+  Buffer.add_char b '\\'';\n+  Buffer.contents b\n+let unix_quote = generic_quote \"'\\\\''\"\n+\n let quote_filename_if_needed s =\n   if is_simple_filename s then s\n   (* We should probably be using [Filename.unix_quote] except that function\n    * isn't exported. Users on Windows will have to live with not being able to\n    * install OCaml into c:\\o'caml. Too bad. *)\n-  else if Sys.os_type = \"Win32\" then Printf.sprintf \"'%s'\" s\n+  else if Sys.os_type = \"Win32\" then unix_quote s\n   else Filename.quote s\n let chdir dir =\n   reset_filesys_cache ();\n@@ -37,7 +51,7 @@\n let run args target =\n   reset_readdir_cache ();\n   let cmd = String.concat \" \" (List.map quote_filename_if_needed args) in\n-  if !*My_unix.is_degraded || Sys.os_type = \"Win32\" then\n+  if !*My_unix.is_degraded then\n     begin\n       Log.event cmd target Tags.empty;\n       let st = sys_command cmd in\n"
+          }
+        ],
         "opam": {
           "name": "ocamlbuild",
           "version": "0.12.0",
@@ -7759,6 +7788,10 @@
             "opam-version: \"1.2\"\nname: \"ocamlbuild\"\nversion: \"0.12.0\"\nmaintainer: \"Gabriel Scherer <gabriel.scherer@gmail.com>\"\nauthors: [\"Nicolas Pouillard\" \"Berke Durak\"]\nlicense: \"LGPL-2 with OCaml linking exception\"\nhomepage: \"https://github.com/ocaml/ocamlbuild/\"\ndoc: \"https://github.com/ocaml/ocamlbuild/blob/master/manual/manual.adoc\"\nbug-reports: \"https://github.com/ocaml/ocamlbuild/issues\"\nconflicts: [\n  \"base-ocamlbuild\"\n  \"ocamlfind\" {< \"1.6.2\"}\n]\navailable: ocaml-version >= \"4.03\"\nbuild: [\n  [\n    make\n    \"-f\"\n    \"configure.make\"\n    \"all\"\n    \"OCAMLBUILD_PREFIX=%{prefix}%\"\n    \"OCAMLBUILD_BINDIR=%{bin}%\"\n    \"OCAMLBUILD_LIBDIR=%{lib}%\"\n    \"OCAMLBUILD_MANDIR=%{man}%\"\n    \"OCAML_NATIVE=%{ocaml-native}%\"\n    \"OCAML_NATIVE_TOOLS=%{ocaml-native}%\"\n  ]\n  [make \"check-if-preinstalled\" \"all\" \"opam-install\"]\n]\ndev-repo: \"git+https://github.com/ocaml/ocamlbuild.git\"",
           "override": {
             "build": [
+              [
+                "bash", "-c",
+                "#{os == 'windows' ? 'patch -p1 < _esy/ocamlbuild-0.12.0.patch' : 'true'}"
+              ],
               [
                 "make", "-f", "configure.make", "all",
                 "OCAMLBUILD_PREFIX=#{self.install}",
@@ -7856,31 +7889,31 @@
         "@opam/ocamlfind@opam:1.8.0"
       ]
     },
-    "@opam/menhir@opam:20170712": {
+    "@opam/menhir@opam:20171013": {
       "record": {
         "name": "@opam/menhir",
-        "version": "opam:20170712",
+        "version": "opam:20171013",
         "source": [
-          "archive:https://opam.ocaml.org/archives/menhir.20170712+opam.tar.gz#md5:18aaf814e51aeb4fbfd8b7c1fb7ffbba",
-          "archive:http://gallium.inria.fr/~fpottier/menhir/menhir-20170712.tar.gz#md5:85a5c2aef1d3f2224dab7c53d79892e5"
+          "archive:https://opam.ocaml.org/archives/menhir.20171013+opam.tar.gz#md5:b361a87378407e26b9ea2dde7ddf41a0",
+          "archive:http://gallium.inria.fr/~fpottier/menhir/menhir-20171013.tar.gz#md5:620863edea40437390ee5e5bd82fba11"
         ],
         "files": [
           {
-            "name": "_esy/menhir-20170712.patch",
+            "name": "_esy/menhir-20171013.patch",
             "content":
-              "--- ./Makefile\n+++ ./Makefile\n@@ -60,10 +60,11 @@\n # If the compiler is MSVC, then the name of the executable file ends in .exe,\n # and object file names end in .obj instead of .o.\n \n-ifneq (,$(shell ocamlc -config | grep -E \"ccomp_type: msvc\"))\n+OS_TYPE:=$(shell ocamlc -config | tr -d '\\15' | awk '/^os_type:/ {print $$2}')\n+ifeq ($(OS_TYPE),$(filter $(OS_TYPE),Win32 Cygwin))\n   MENHIREXE    := menhir.exe\n-  OBJ          := obj\n-# LIBSUFFIX    := lib\n+  OBJ          := $(shell ocamlc -config | tr -d '\\15' | awk '/^ext_obj:/ {print $$2}' | tr -d '.')\n+# LIBSUFFIX    := $(shell ocamlc -config | tr -d '\\15' | awk '/^ext_lib:/ {print $$2}' | tr -d '.')\n else\n   MENHIREXE    := menhir\n   OBJ          := o\n@@ -85,8 +86,8 @@\n # performed if \"os_type\" is \"Win32\" or \"Win64\", and must not be performed if\n # \"os_type\" is \"Cygwin\" or \"Unix\".\n \n-ifneq (,$(shell ocamlc -config | grep -E \"os_type: (Win32|Win64)\"))\n-installation_libdir := $(shell cygpath -m $(libdir))\n+ifeq ($(OS_TYPE),Win32)\n+installation_libdir := $(shell cygpath -m $(libdir) || echo $(libdir))\n else\n installation_libdir := $(libdir)\n endif\n--- ./src/cmly_write.ml\n+++ ./src/cmly_write.ml\n@@ -168,6 +168,6 @@\n   output_value oc (t : grammar)\n \n let write filename =\n-  let oc = open_out filename in\n+  let oc = open_out_bin filename in\n   write oc (encode());\n   close_out oc\n"
+              "--- ./Makefile\n+++ ./Makefile\n@@ -59,13 +59,8 @@\n \n # If the compiler is MSVC, then object file names end in .obj instead of .o.\n \n-ifneq (,$(shell ocamlc -config | grep -E \"ccomp_type: msvc\"))\n-  OBJ          := obj\n-# LIBSUFFIX    := lib\n-else\n-  OBJ          := o\n-# LIBSUFFIX    := a\n-endif\n+OBJ          := $(shell ocamlc -config | awk -F '[\\t \\r]+' '/^ext_obj:/ {print $$2}' | tr -d '.')\n+#LIBSUFFIX   := $(shell ocamlc -config | awk -F '[\\t \\r]+' '/^ext_lib:/ {print $$2}' | tr -d '.')\n \n # If we are under Windows (regardless of whether we are using MSVC or mingw)\n # then the name of the executable file ends in .exe.\n@@ -91,8 +86,9 @@\n # performed if \"os_type\" is \"Win32\" or \"Win64\", and must not be performed if\n # \"os_type\" is \"Cygwin\" or \"Unix\".\n \n-ifneq (,$(shell ocamlc -config | grep -E \"os_type: (Win32|Win64)\"))\n-installation_libdir := $(shell cygpath -m $(libdir))\n+OS_TYPE:=\t$(shell ocamlc -config | awk -F '[\\t \\r]+' '/^os_type:/ {print $$2}')\n+ifeq ($(OS_TYPE),Win32)\n+installation_libdir := $(shell cygpath -m $(libdir) || echo $(libdir))\n else\n installation_libdir := $(libdir)\n endif\n--- ./src/cmly_write.ml\n+++ ./src/cmly_write.ml\n@@ -168,6 +168,6 @@\n   output_value oc (t : grammar)\n \n let write filename =\n-  let oc = open_out filename in\n+  let oc = open_out_bin filename in\n   write oc (encode());\n   close_out oc\n"
           }
         ],
         "opam": {
           "name": "menhir",
-          "version": "20170712",
+          "version": "20171013",
           "opam":
-            "opam-version: \"1.2\"\nname: \"menhir\"\nversion: \"20170712\"\nmaintainer: \"francois.pottier@inria.fr\"\nauthors: [\n  \"François Pottier <francois.pottier@inria.fr>\"\n  \"Yann Régis-Gianas <yrg@pps.univ-paris-diderot.fr>\"\n]\nhomepage: \"http://gallium.inria.fr/~fpottier/menhir/\"\nbug-reports: \"menhir@inria.fr\"\ndepends: [\n  \"ocamlfind\"\n  \"ocamlbuild\" {build}\n]\navailable: ocaml-version >= \"4.02\"\nbuild: [\n  make\n  \"-f\"\n  \"Makefile\"\n  \"PREFIX=%{prefix}%\"\n  \"USE_OCAMLFIND=true\"\n  \"docdir=%{doc}%/menhir\"\n  \"libdir=%{lib}%/menhir\"\n  \"mandir=%{man}%/man1\"\n]\ninstall: [\n  make\n  \"-f\"\n  \"Makefile\"\n  \"install\"\n  \"PREFIX=%{prefix}%\"\n  \"docdir=%{doc}%/menhir\"\n  \"libdir=%{lib}%/menhir\"\n  \"mandir=%{man}%/man1\"\n]\nremove: [\n  make\n  \"-f\"\n  \"Makefile\"\n  \"uninstall\"\n  \"PREFIX=%{prefix}%\"\n  \"docdir=%{doc}%/menhir\"\n  \"libdir=%{lib}%/menhir\"\n  \"mandir=%{man}%/man1\"\n]\ndev-repo: \"git+https://gitlab.inria.fr/fpottier/menhir.git\"",
+            "opam-version: \"1.2\"\nname: \"menhir\"\nversion: \"20171013\"\nmaintainer: \"francois.pottier@inria.fr\"\nauthors: [\n  \"François Pottier <francois.pottier@inria.fr>\"\n  \"Yann Régis-Gianas <yrg@pps.univ-paris-diderot.fr>\"\n]\nhomepage: \"http://gallium.inria.fr/~fpottier/menhir/\"\nbug-reports: \"menhir@inria.fr\"\ndepends: [\n  \"ocamlfind\"\n  \"ocamlbuild\" {build}\n]\navailable: ocaml-version >= \"4.02\"\nbuild: [\n  make\n  \"-f\"\n  \"Makefile\"\n  \"PREFIX=%{prefix}%\"\n  \"USE_OCAMLFIND=true\"\n  \"docdir=%{doc}%/menhir\"\n  \"libdir=%{lib}%/menhir\"\n  \"mandir=%{man}%/man1\"\n]\ninstall: [\n  make\n  \"-f\"\n  \"Makefile\"\n  \"install\"\n  \"PREFIX=%{prefix}%\"\n  \"docdir=%{doc}%/menhir\"\n  \"libdir=%{lib}%/menhir\"\n  \"mandir=%{man}%/man1\"\n]\nremove: [\n  make\n  \"-f\"\n  \"Makefile\"\n  \"uninstall\"\n  \"PREFIX=%{prefix}%\"\n  \"docdir=%{doc}%/menhir\"\n  \"libdir=%{lib}%/menhir\"\n  \"mandir=%{man}%/man1\"\n]\ndev-repo: \"git+https://gitlab.inria.fr/fpottier/menhir.git\"",
           "override": {
             "build": [
               [
                 "bash", "-c",
-                "#{os == 'windows' ? 'patch -p1 < _esy/menhir-20170712.patch' : 'true'}"
+                "#{os == 'windows' ? 'patch -p1 < _esy/menhir-20171013.patch' : 'true'}"
               ],
               [
                 "make", "-f", "Makefile", "PREFIX=#{self.install}",
@@ -8593,7 +8626,7 @@
       },
       "dependencies": [
         "@esy-ocaml/esy-installer@0.0.0", "@esy-ocaml/substs@0.0.1",
-        "@opam/jbuilder@opam:transition", "@opam/menhir@opam:20170712",
+        "@opam/jbuilder@opam:transition", "@opam/menhir@opam:20171013",
         "@opam/merlin-extend@opam:0.3",
         "@opam/ocaml-migrate-parsetree@opam:1.0.11",
         "@opam/ocamlfind@opam:1.8.0", "@opam/result@opam:1.3"

--- a/esy.lock.json
+++ b/esy.lock.json
@@ -1,6 +1,6 @@
 {
-  "hash": "250cc94d431bec260202a09bffb8d67d",
-  "root": "esy-test-build@path:.",
+  "hash": "26df5507025f7c2554f4062f4fd6a6fc",
+  "root": "esy@path:.",
   "node": {
     "yargs-parser@9.0.2": {
       "record": {
@@ -139,7 +139,7 @@
         "name": "wrap-ansi",
         "version": "2.1.0",
         "source":
-          "archive:https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz#sha1:d8fc3d284dd05794fe84973caecdd1cf824fdd85",
+          "archive:http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz#sha1:d8fc3d284dd05794fe84973caecdd1cf824fdd85",
         "files": [],
         "opam": null
       },
@@ -2022,7 +2022,7 @@
         "name": "outdent",
         "version": "0.3.0",
         "source":
-          "archive:https://registry.npmjs.org/outdent/-/outdent-0.3.0.tgz#sha1:fad18a9c061a0938f38e8071d16c4024423f4323",
+          "archive:http://registry.npmjs.org/outdent/-/outdent-0.3.0.tgz#sha1:fad18a9c061a0938f38e8071d16c4024423f4323",
         "files": [],
         "opam": null
       },
@@ -2209,12 +2209,12 @@
       },
       "dependencies": []
     },
-    "nwsapi@2.0.8": {
+    "nwsapi@2.0.9": {
       "record": {
         "name": "nwsapi",
-        "version": "2.0.8",
+        "version": "2.0.9",
         "source":
-          "archive:https://registry.npmjs.org/nwsapi/-/nwsapi-2.0.8.tgz#sha1:e3603579b7e162b3dbedae4fb24e46f771d8fa24",
+          "archive:https://registry.npmjs.org/nwsapi/-/nwsapi-2.0.9.tgz#sha1:77ac0cdfdcad52b6a1151a84e73254edc33ed016",
         "files": [],
         "opam": null
       },
@@ -2462,7 +2462,7 @@
         "name": "minimist",
         "version": "1.2.0",
         "source":
-          "archive:https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz#sha1:a35008b20f41383eec1fb914f4cd5df79a264284",
+          "archive:http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz#sha1:a35008b20f41383eec1fb914f4cd5df79a264284",
         "files": [],
         "opam": null
       },
@@ -2473,7 +2473,7 @@
         "name": "minimist",
         "version": "0.0.10",
         "source":
-          "archive:https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz#sha1:de3f98543dbf96082be48ad1a0c7cda836301dcf",
+          "archive:http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz#sha1:de3f98543dbf96082be48ad1a0c7cda836301dcf",
         "files": [],
         "opam": null
       },
@@ -2484,7 +2484,7 @@
         "name": "minimist",
         "version": "0.0.8",
         "source":
-          "archive:https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz#sha1:857fcabfc3397d2625b8228262e86aa7a011b05d",
+          "archive:http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz#sha1:857fcabfc3397d2625b8228262e86aa7a011b05d",
         "files": [],
         "opam": null
       },
@@ -2972,7 +2972,7 @@
         "abab@2.0.0", "acorn@5.7.2", "acorn-globals@4.1.0",
         "array-equal@1.0.0", "cssom@0.3.4", "cssstyle@1.1.1",
         "data-urls@1.0.1", "domexception@1.0.1", "escodegen@1.11.0",
-        "html-encoding-sniffer@1.0.2", "left-pad@1.3.0", "nwsapi@2.0.8",
+        "html-encoding-sniffer@1.0.2", "left-pad@1.3.0", "nwsapi@2.0.9",
         "parse5@4.0.0", "pn@1.1.0", "request@2.88.0",
         "request-promise-native@1.0.5", "sax@1.2.4", "symbol-tree@3.2.2",
         "tough-cookie@2.4.3", "w3c-hr-time@1.0.1",
@@ -3498,7 +3498,7 @@
         "opam": null
       },
       "dependencies": [
-        "async@2.6.1", "compare-versions@3.3.1", "fileset@2.0.3",
+        "async@2.6.1", "compare-versions@3.4.0", "fileset@2.0.3",
         "istanbul-lib-coverage@1.2.0", "istanbul-lib-hook@1.2.1",
         "istanbul-lib-instrument@2.3.2", "istanbul-lib-report@1.1.4",
         "istanbul-lib-source-maps@1.2.5", "istanbul-reports@1.5.0",
@@ -4819,9 +4819,20 @@
       },
       "dependencies": [ "merge@1.2.0" ]
     },
-    "esy-test-build@path:.": {
+    "esy-solve-cudf@0.1.6": {
       "record": {
-        "name": "esy-test-build",
+        "name": "esy-solve-cudf",
+        "version": "0.1.6",
+        "source":
+          "archive:https://registry.npmjs.org/esy-solve-cudf/-/esy-solve-cudf-0.1.6.tgz#sha1:e5fe6e16be1e71964e1bfe3cdb80688e072dbe0f",
+        "files": [],
+        "opam": null
+      },
+      "dependencies": []
+    },
+    "esy@path:.": {
+      "record": {
+        "name": "esy",
         "version": "path:.",
         "source": "path:.",
         "files": [],
@@ -4835,12 +4846,13 @@
         "@opam/fmt@opam:0.8.5", "@opam/fpath@opam:0.7.2",
         "@opam/lambda-term@opam:1.13", "@opam/logs@opam:0.6.2",
         "@opam/lwt@opam:4.1.0", "@opam/lwt_ppx@opam:1.2.1",
-        "@opam/menhir@opam:20170712", "@opam/opam-core@opam:2.0.0",
+        "@opam/menhir@opam:20171013", "@opam/opam-core@opam:2.0.0",
         "@opam/opam-file-format@opam:2.0.0", "@opam/opam-format@opam:2.0.0",
         "@opam/opam-state@opam:2.0.0", "@opam/ppx_deriving@opam:4.2.1",
         "@opam/ppx_deriving_yojson@opam:3.1",
         "@opam/ppx_inline_test@opam:v0.11.0", "@opam/ppx_let@opam:v0.11.0",
-        "@opam/re@opam:1.8.0", "@opam/utop@opam:2.2.0",
+        "@opam/ppx_tyre@opam:0.4.0", "@opam/re@opam:1.8.0",
+        "@opam/tyre@opam:0.4.1", "@opam/utop@opam:2.2.0",
         "@opam/yojson@opam:1.4.1", "babel-preset-env@1.7.0",
         "babel-preset-flow@6.23.0", "del@3.0.0", "esy-solve-cudf@0.1.6",
         "fastreplacestring@github:esy-ocaml/FastReplaceString#95f408b",
@@ -4849,17 +4861,6 @@
         "rimraf@2.6.2", "semver@5.5.1", "super-resolve@1.0.0", "tar@4.4.6",
         "tar-fs@1.16.3", "tmp@0.0.33"
       ]
-    },
-    "esy-solve-cudf@0.1.6": {
-      "record": {
-        "name": "esy-solve-cudf",
-        "version": "0.1.6",
-        "source":
-          "archive:https://registry.npmjs.org/esy-solve-cudf/-/esy-solve-cudf-0.1.6.tgz#sha1:e5fe6e16be1e71964e1bfe3cdb80688e072dbe0f",
-        "files": [],
-        "opam": null
-      },
-      "dependencies": []
     },
     "esutils@2.0.2": {
       "record": {
@@ -5349,12 +5350,12 @@
       },
       "dependencies": []
     },
-    "compare-versions@3.3.1": {
+    "compare-versions@3.4.0": {
       "record": {
         "name": "compare-versions",
-        "version": "3.3.1",
+        "version": "3.4.0",
         "source":
-          "archive:https://registry.npmjs.org/compare-versions/-/compare-versions-3.3.1.tgz#sha1:1ede3172b713c15f7c7beb98cb74d2d82576dad3",
+          "archive:https://registry.npmjs.org/compare-versions/-/compare-versions-3.4.0.tgz#sha1:e0747df5c9cb7f054d6d3dc3e1dbc444f9e92b26",
         "files": [],
         "opam": null
       },
@@ -5549,12 +5550,12 @@
       },
       "dependencies": [ "rsvp@3.6.2" ]
     },
-    "caniuse-lite@1.0.30000882": {
+    "caniuse-lite@1.0.30000884": {
       "record": {
         "name": "caniuse-lite",
-        "version": "1.0.30000882",
+        "version": "1.0.30000884",
         "source":
-          "archive:https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000882.tgz#sha1:0d5066847a11a5af0e50ffce6c062ef0665f68ea",
+          "archive:https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000884.tgz#sha1:eb82a959698745033b26a4dcd34d89dba7cc6eb3",
         "files": [],
         "opam": null
       },
@@ -5685,7 +5686,7 @@
         "opam": null
       },
       "dependencies": [
-        "caniuse-lite@1.0.30000882", "electron-to-chromium@1.3.62"
+        "caniuse-lite@1.0.30000884", "electron-to-chromium@1.3.62"
       ]
     },
     "browser-resolve@1.11.3": {
@@ -6303,7 +6304,7 @@
         "name": "babel-plugin-syntax-object-rest-spread",
         "version": "6.13.0",
         "source":
-          "archive:https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#sha1:fd6536f2bce13836ffa3a5458c4903a597bb3bf5",
+          "archive:http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#sha1:fd6536f2bce13836ffa3a5458c4903a597bb3bf5",
         "files": [],
         "opam": null
       },
@@ -6314,7 +6315,7 @@
         "name": "babel-plugin-syntax-flow",
         "version": "6.18.0",
         "source":
-          "archive:https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz#sha1:4c3ab20a2af26aa20cd25995c398c4eb70310c8d",
+          "archive:http://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz#sha1:4c3ab20a2af26aa20cd25995c398c4eb70310c8d",
         "files": [],
         "opam": null
       },
@@ -6325,7 +6326,7 @@
         "name": "babel-plugin-syntax-exponentiation-operator",
         "version": "6.13.0",
         "source":
-          "archive:https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz#sha1:9ee7e8337290da95288201a6a57f4170317830de",
+          "archive:http://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz#sha1:9ee7e8337290da95288201a6a57f4170317830de",
         "files": [],
         "opam": null
       },
@@ -6336,7 +6337,7 @@
         "name": "babel-plugin-syntax-async-functions",
         "version": "6.13.0",
         "source":
-          "archive:https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#sha1:cad9cad1191b5ad634bf30ae0872391e0647be95",
+          "archive:http://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#sha1:cad9cad1191b5ad634bf30ae0872391e0647be95",
         "files": [],
         "opam": null
       },
@@ -7158,6 +7159,28 @@
         "@esy-ocaml/substs@0.0.1", "@opam/ocamlbuild@opam:0.12.0"
       ]
     },
+    "@opam/tyre@opam:0.4.1": {
+      "record": {
+        "name": "@opam/tyre",
+        "version": "opam:0.4.1",
+        "source": [
+          "archive:https://opam.ocaml.org/archives/tyre.0.4.1+opam.tar.gz#md5:c5a3e988b7051126a389807dbdb9395b",
+          "archive:https://github.com/Drup/tyre/releases/download/0.4.1/tyre-0.4.1.tbz#md5:41923cb08a11f93d704b79f7bb078640"
+        ],
+        "files": [],
+        "opam": {
+          "name": "tyre",
+          "version": "0.4.1",
+          "opam":
+            "opam-version: \"1.2\"\nname: \"tyre\"\nversion: \"0.4.1\"\nmaintainer: \"Gabriel Radanne <drupyog@zoho.com>\"\nauthors: \"Gabriel Radanne <drupyog@zoho.com>\"\nlicense: \"ISC\"\ntags: \"regex\"\nhomepage: \"https://github.com/Drup/tyre\"\ndoc: \"https://drup.github.io/tyre/doc/0.4/tyre/Tyre/\"\nbug-reports: \"https://github.com/Drup/tyre/issues\"\ndepends: [\n  \"jbuilder\" {build}\n  \"re\" {>= \"1.8.0\"}\n  \"alcotest\" {test & >= \"0.8.0\"}\n  \"result\"\n  \"seq\"\n]\navailable: ocaml-version >= \"4.02.0\"\nbuild: [\n  [\"jbuilder\" \"subst\"] {pinned}\n  [\"jbuilder\" \"build\" \"-p\" name \"-j\" jobs]\n  [\"jbuilder\" \"runtest\" \"-p\" name] {with-test}\n]\ndev-repo: \"git+https://github.com/Drup/tyre.git\"",
+          "override": null
+        }
+      },
+      "dependencies": [
+        "@esy-ocaml/substs@0.0.1", "@opam/jbuilder@opam:transition",
+        "@opam/re@opam:1.8.0", "@opam/result@opam:1.3", "@opam/seq@opam:0.1"
+      ]
+    },
     "@opam/topkg@opam:0.9.1": {
       "record": {
         "name": "@opam/topkg",
@@ -7355,6 +7378,30 @@
         "@opam/dune@opam:1.1.1", "@opam/ocaml-compiler-libs@opam:v0.11.0",
         "@opam/ocaml-migrate-parsetree@opam:1.0.11",
         "@opam/ppx_derivers@opam:1.0", "@opam/stdio@opam:v0.11.0"
+      ]
+    },
+    "@opam/ppx_tyre@opam:0.4.0": {
+      "record": {
+        "name": "@opam/ppx_tyre",
+        "version": "opam:0.4.0",
+        "source": [
+          "archive:https://opam.ocaml.org/archives/ppx_tyre.0.4.0+opam.tar.gz#md5:b298852ce44b344afa8ad567c65686e4",
+          "archive:https://github.com/paurkedal/ppx_regexp/releases/download/v0.4.0/ppx_regexp-0.4.0.tbz#md5:44691d6e1c6c02300329a4eb769922ab"
+        ],
+        "files": [],
+        "opam": {
+          "name": "ppx_tyre",
+          "version": "0.4.0",
+          "opam":
+            "opam-version: \"1.2\"\nname: \"ppx_tyre\"\nversion: \"0.4.0\"\nmaintainer: \"Petter A. Urkedal <paurkedal@gmail.com>\"\nauthors: [\n  \"Gabriel Radanne <drupyog@zoho.com>\"\n  \"Petter A. Urkedal <paurkedal@gmail.com>\"\n]\nlicense: \"LGPL-3 with OCaml linking exception\"\nhomepage: \"https://github.com/paurkedal/ppx_regexp\"\nbug-reports: \"https://github.com/paurkedal/ppx_regexp/issues\"\ndepends: [\n  \"dune\" {build}\n  \"ocaml-migrate-parsetree\"\n  \"re\" {>= \"1.7.1\"}\n  \"ppx_tools_versioned\"\n  \"tyre\" {>= \"0.4.1\"}\n  \"qcheck\" {test}\n]\navailable: ocaml-version >= \"4.06.0\"\nbuild: [\"dune\" \"build\" \"-p\" name \"-j\" jobs]\ndev-repo: \"git+https://github.com/paurkedal/ppx_regexp.git\"",
+          "override": null
+        }
+      },
+      "dependencies": [
+        "@esy-ocaml/substs@0.0.1", "@opam/dune@opam:1.1.1",
+        "@opam/ocaml-migrate-parsetree@opam:1.0.11",
+        "@opam/ppx_tools_versioned@opam:5.2.1", "@opam/re@opam:1.8.0",
+        "@opam/tyre@opam:0.4.1"
       ]
     },
     "@opam/ppx_tools_versioned@opam:5.2.1": {
@@ -7711,7 +7758,7 @@
               "bin: [\n  \"src/findlib/ocamlfind\" {\"ocamlfind\"}\n  \"?src/findlib/ocamlfind_opt\" {\"ocamlfind\"}\n  \"?tools/safe_camlp4\"\n]\ntoplevel: [\"src/findlib/topfind\"]\n"
           },
           {
-            "name": "_esy/build",
+            "name": "esy-build",
             "content":
               "#!/bin/bash\n\nset -euo pipefail\nset -x\n\n#\n# Shim OCAMLLIB so that we can write topfind there\n#\n\nREAL_OCAMLLIB=\"$1\"\n\nmkdir -p $cur__install/lib/ocaml\ncd $cur__install/lib/ocaml\n\nfor filename in `ls -1 $REAL_OCAMLLIB`; do\n  ln -s $REAL_OCAMLLIB/$filename $filename;\ndone\n\n#\n# Build\n#\n\ncd $cur__root\n\nexport OCAMLLIB=\"$cur__install/lib/ocaml\"\n\n./configure \\\n  -bindir $cur__install/bin \\\n  -sitelib $cur__install/lib \\\n  -mandir $cur__install/man \\\n  -config $cur__install/lib/findlib.conf \\\n  -no-custom \\\n  -no-camlp4\n\nmake all\nmake opt\nmake install\n\n(opam-installer --prefix=$cur__install || true)\n"
           }
@@ -7722,7 +7769,7 @@
           "opam":
             "opam-version: \"1.2\"\nname: \"ocamlfind\"\nversion: \"1.8.0\"\nmaintainer: \"Thomas Gazagnaire <thomas@gazagnaire.org>\"\nauthors: \"Gerd Stolpmann <gerd@gerd-stolpmann.de>\"\nhomepage: \"http://projects.camlcity.org/projects/findlib.html\"\nbug-reports: \"https://gitlab.camlcity.org/gerd/lib-findlib/issues\"\ndepends: [\n  \"conf-m4\" {build}\n]\navailable: ocaml-version >= \"4.00.0\"\nbuild: [\n  [\n    \"./configure\"\n    \"-bindir\"\n    bin\n    \"-sitelib\"\n    lib\n    \"-mandir\"\n    man\n    \"-config\"\n    \"%{lib}%/findlib.conf\"\n    \"-no-custom\"\n    \"-no-topfind\" {preinstalled}\n  ]\n  [make \"all\"]\n  [make \"opt\"] {ocaml-native}\n]\ninstall: [\n  [make \"install\"]\n  [\"install\" \"-m\" \"0755\" \"ocaml-stub\" \"%{bin}%/ocaml\"] {preinstalled}\n]\nremove: [\n  [\"ocamlfind\" \"remove\" \"bytes\"]\n  [\n    \"./configure\"\n    \"-bindir\"\n    bin\n    \"-sitelib\"\n    lib\n    \"-mandir\"\n    man\n    \"-config\"\n    \"%{lib}%/findlib.conf\"\n    \"-no-topfind\" {preinstalled}\n  ]\n  [make \"uninstall\"]\n  [\"rm\" \"-f\" \"%{bin}%/ocaml\"] {preinstalled}\n]\ndev-repo: \"git+https://gitlab.camlcity.org/gerd/lib-findlib.git\"",
           "override": {
-            "build": [ [ "bash", "./_esy/build", "#{ocaml.lib / 'ocaml'}" ] ],
+            "build": [ [ "bash", "./esy-build", "#{ocaml.lib / 'ocaml'}" ] ],
             "exportedEnv": {
               "OCAMLLIB": {
                 "val": "#{@opam/ocamlfind.install / 'lib' / 'ocaml'}",
@@ -7751,7 +7798,13 @@
           "archive:https://opam.ocaml.org/archives/ocamlbuild.0.12.0+opam.tar.gz#md5:6e877d7f40c119c0c6c03f04342f2264",
           "archive:https://github.com/ocaml/ocamlbuild/archive/0.12.0.tar.gz#md5:442baa19470bd49150f153122e22907b"
         ],
-        "files": [],
+        "files": [
+          {
+            "name": "_esy/ocamlbuild-0.12.0.patch",
+            "content":
+              "--- ./Makefile\n+++ ./Makefile\n@@ -213,7 +213,7 @@\n \trm -f man/ocamlbuild.1\n \n man/options_man.byte: src/ocamlbuild_pack.cmo\n-\t$(OCAMLC) $^ -I src man/options_man.ml -o man/options_man.byte\n+\t$(OCAMLC) -I +unix unix.cma $^ -I src man/options_man.ml -o man/options_man.byte\n \n clean::\n \trm -f man/options_man.cm*\n--- ./META\n+++ ./META\n@@ -2,5 +2,6 @@\n requires = \"unix\"\n version = \"0.12.0\"\n description = \"ocamlbuild support library\"\n+directory= \"^ocamlbuild\"\n archive(byte) = \"ocamlbuildlib.cma\"\n archive(native) = \"ocamlbuildlib.cmxa\"\n--- ./src/command.ml\n+++ ./src/command.ml\n@@ -148,9 +148,10 @@\n   let self = string_of_command_spec_with_calls call_with_tags call_with_target resolve_virtuals in\n   let b = Buffer.create 256 in\n   (* The best way to prevent bash from switching to its windows-style\n-   * quote-handling is to prepend an empty string before the command name. *)\n+   * quote-handling is to prepend an empty string before the command name.\n+   * space seems to work, too - and the ouput is nicer *)\n   if Sys.os_type = \"Win32\" then\n-    Buffer.add_string b \"''\";\n+    Buffer.add_char b ' ';\n   let first = ref true in\n   let put_space () =\n     if !first then\n@@ -260,7 +261,7 @@\n \n let execute_many ?(quiet=false) ?(pretend=false) cmds =\n   add_parallel_stat (List.length cmds);\n-  let degraded = !*My_unix.is_degraded || Sys.os_type = \"Win32\" in\n+  let degraded = !*My_unix.is_degraded in\n   let jobs = !jobs in\n   if jobs < 0 then invalid_arg \"jobs < 0\";\n   let max_jobs = if jobs = 0 then None else Some jobs in\n--- ./src/findlib.ml\n+++ ./src/findlib.ml\n@@ -66,9 +66,6 @@\n     (fun command -> lexer & Lexing.from_string & run_and_read command)\n     command\n \n-let run_and_read command =\n-  Printf.ksprintf run_and_read command\n-\n let rec query name =\n   try\n     Hashtbl.find packages name\n@@ -135,7 +132,8 @@\n   with Not_found -> s\n \n let list () =\n-  List.map before_space (split_nl & run_and_read \"%s list\" ocamlfind)\n+  let cmd = Shell.quote_filename_if_needed ocamlfind ^ \" list\" in\n+  List.map before_space (split_nl & run_and_read cmd)\n \n (* The closure algorithm is easy because the dependencies are already closed\n and sorted for each package. We only have to make the union. We could also\n--- ./src/main.ml\n+++ ./src/main.ml\n@@ -162,6 +162,9 @@\n               Tags.mem \"traverse\" tags\n               || List.exists (Pathname.is_prefix path_name) !Options.include_dirs\n               || List.exists (Pathname.is_prefix path_name) target_dirs)\n+            && ((* beware: !Options.build_dir is an absolute directory *)\n+              Pathname.normalize !Options.build_dir\n+              <> Pathname.normalize (Pathname.pwd/path_name))\n           end\n         end\n       end\n--- ./src/my_std.ml\n+++ ./src/my_std.ml\n@@ -271,13 +271,107 @@\n       try Array.iter (fun x -> if x = basename then raise Exit) a; false\n       with Exit -> true\n \n+let command_plain = function\n+| [| |] -> 0\n+| margv ->\n+  let rec waitpid a b =\n+    match Unix.waitpid a b with\n+    | exception (Unix.Unix_error(Unix.EINTR,_,_)) -> waitpid a b\n+    | x -> x\n+  in\n+  let pid = Unix.(create_process margv.(0) margv stdin stdout stderr) in\n+  let pid', process_status = waitpid [] pid in\n+  assert (pid = pid');\n+  match process_status with\n+  | Unix.WEXITED n -> n\n+  | Unix.WSIGNALED _ -> 2 (* like OCaml's uncaught exceptions *)\n+  | Unix.WSTOPPED _ -> 127\n+\n+(* can't use Lexers because of circular dependency *)\n+let split_path_win str =\n+  let rec aux pos =\n+    try\n+      let i = String.index_from str pos ';' in\n+      let len = i - pos in\n+      if len = 0 then\n+        aux (succ i)\n+      else\n+        String.sub str pos (i - pos) :: aux (succ i)\n+    with Not_found | Invalid_argument _ ->\n+      let len = String.length str - pos in\n+      if len = 0 then [] else [String.sub str pos len]\n+  in\n+  aux 0\n+\n+let windows_shell = lazy begin\n+  let rec iter = function\n+  | [] -> [| \"bash.exe\" ; \"--norc\" ; \"--noprofile\" |]\n+  | hd::tl ->\n+    let dash = Filename.concat hd \"dash.exe\" in\n+    if Sys.file_exists dash then [|dash|] else\n+    let bash = Filename.concat hd \"bash.exe\" in\n+    if Sys.file_exists bash = false then iter tl else\n+    (* if sh.exe and bash.exe exist in the same dir, choose sh.exe *)\n+    let sh = Filename.concat hd \"sh.exe\" in\n+    if Sys.file_exists sh then [|sh|] else [|bash ; \"--norc\" ; \"--noprofile\"|]\n+  in\n+  split_path_win (try Sys.getenv \"PATH\" with Not_found -> \"\") |> iter\n+end\n+\n+let prep_windows_cmd cmd =\n+  (* workaround known ocaml bug, remove later *)\n+  if String.contains cmd '\\t' && String.contains cmd ' ' = false then\n+    \" \" ^ cmd\n+  else\n+    cmd\n+\n+let run_with_shell = function\n+| \"\" -> 0\n+| cmd ->\n+  let cmd = prep_windows_cmd cmd in\n+  let shell = Lazy.force windows_shell in\n+  let qlen = Filename.quote cmd |> String.length in\n+  (* old versions of dash had problems with bs *)\n+  try\n+    if qlen < 7_900 then\n+      command_plain (Array.append shell [| \"-ec\" ; cmd |])\n+    else begin\n+      (* it can still work, if the called command is a cygwin tool *)\n+      let ch_closed = ref false in\n+      let file_deleted = ref false in\n+      let fln,ch =\n+        Filename.open_temp_file\n+          ~mode:[Open_binary]\n+          \"ocamlbuildtmp\"\n+          \".sh\"\n+      in\n+      try\n+        let f_slash = String.map ( fun x -> if x = '\\\\' then '/' else x ) fln in\n+        output_string ch cmd;\n+        ch_closed:= true;\n+        close_out ch;\n+        let ret = command_plain (Array.append shell [| \"-e\" ; f_slash |]) in\n+        file_deleted:= true;\n+        Sys.remove fln;\n+        ret\n+      with\n+      | x ->\n+        if !ch_closed = false then\n+          close_out_noerr ch;\n+        if !file_deleted = false then\n+          (try Sys.remove fln with _ -> ());\n+        raise x\n+    end\n+  with\n+  | (Unix.Unix_error _) as x ->\n+    (* Sys.command doesn't raise an exception, so run_with_shell also won't\n+       raise *)\n+    Printexc.to_string x ^ \":\" ^ cmd |> prerr_endline;\n+    1\n+\n let sys_command =\n-  match Sys.os_type with\n-  | \"Win32\" -> fun cmd ->\n-      if cmd = \"\" then 0 else\n-      let cmd = \"bash --norc -c \" ^ Filename.quote cmd in\n-      Sys.command cmd\n-  | _ -> fun cmd -> if cmd = \"\" then 0 else Sys.command cmd\n+  if Sys.win32 then run_with_shell\n+  else fun cmd -> if cmd = \"\" then 0 else Sys.command cmd\n \n (* FIXME warning fix and use Filename.concat *)\n let filename_concat x y =\n--- ./src/my_std.mli\n+++ ./src/my_std.mli\n@@ -69,3 +69,6 @@\n \n val split_ocaml_version : (int * int * int * string) option\n (** (major, minor, patchlevel, rest) *)\n+\n+val windows_shell : string array Lazy.t\n+val prep_windows_cmd : string -> string\n--- ./src/ocamlbuild_executor.ml\n+++ ./src/ocamlbuild_executor.ml\n@@ -34,6 +34,8 @@\n   job_stdin   : out_channel;\n   job_stderr  : in_channel;\n   job_buffer  : Buffer.t;\n+  job_pid     : int;\n+  job_tmp_file: string option;\n   mutable job_dying : bool;\n };;\n \n@@ -76,6 +78,61 @@\n   in\n   loop 0\n ;;\n+\n+let open_process_full_win cmd env =\n+  let (in_read, in_write) = Unix.pipe () in\n+  let (out_read, out_write) = Unix.pipe () in\n+  let (err_read, err_write) = Unix.pipe () in\n+  Unix.set_close_on_exec in_read;\n+  Unix.set_close_on_exec out_write;\n+  Unix.set_close_on_exec err_read;\n+  let inchan = Unix.in_channel_of_descr in_read in\n+  let outchan = Unix.out_channel_of_descr out_write in\n+  let errchan = Unix.in_channel_of_descr err_read in\n+  let shell = Lazy.force Ocamlbuild_pack.My_std.windows_shell in\n+  let test_cmd =\n+    String.concat \" \" (List.map Filename.quote (Array.to_list shell)) ^\n+    \"-ec \" ^\n+    Filename.quote (Ocamlbuild_pack.My_std.prep_windows_cmd cmd) in\n+  let argv,tmp_file =\n+    if String.length test_cmd < 7_900 then\n+      Array.append\n+        shell\n+        [| \"-ec\" ; Ocamlbuild_pack.My_std.prep_windows_cmd cmd |],None\n+    else\n+    let fln,ch = Filename.open_temp_file ~mode:[Open_binary] \"ocamlbuild\" \".sh\" in\n+    output_string ch (Ocamlbuild_pack.My_std.prep_windows_cmd cmd);\n+    close_out ch;\n+    let fln' = String.map (function '\\\\' -> '/' | c -> c) fln in\n+    Array.append\n+      shell\n+      [| \"-c\" ; fln' |], Some fln in\n+  let pid =\n+    Unix.create_process_env argv.(0) argv env out_read in_write err_write in\n+  Unix.close out_read;\n+  Unix.close in_write;\n+  Unix.close err_write;\n+  (pid, inchan, outchan, errchan,tmp_file)\n+\n+let close_process_full_win (pid,inchan, outchan, errchan, tmp_file) =\n+  let delete tmp_file =\n+    match tmp_file with\n+    | None -> ()\n+    | Some x -> try Sys.remove x with Sys_error _ -> () in\n+  let tmp_file_deleted = ref false in\n+  try\n+    close_in inchan;\n+    close_out outchan;\n+    close_in errchan;\n+    let res = snd(Unix.waitpid [] pid) in\n+    tmp_file_deleted := true;\n+    delete tmp_file;\n+    res\n+  with\n+  | x when tmp_file <> None && !tmp_file_deleted = false ->\n+    delete tmp_file;\n+    raise x\n+\n (* ***)\n (*** execute *)\n (* XXX: Add test for non reentrancy *)\n@@ -130,10 +187,16 @@\n   (*** add_job *)\n   let add_job cmd rest result id =\n     (*display begin fun oc -> fp oc \"Job %a is %s\\n%!\" print_job_id id cmd; end;*)\n-    let (stdout', stdin', stderr') = open_process_full cmd env in\n+    let (pid,stdout', stdin', stderr', tmp_file) =\n+      if Sys.win32 then open_process_full_win cmd env else\n+      let a,b,c = open_process_full cmd env in\n+      -1,a,b,c,None\n+    in\n     incr jobs_active;\n-    set_nonblock (doi stdout');\n-    set_nonblock (doi stderr');\n+    if not Sys.win32 then (\n+      set_nonblock (doi stdout');\n+      set_nonblock (doi stderr');\n+    );\n     let job =\n       { job_id          = id;\n         job_command     = cmd;\n@@ -143,7 +206,9 @@\n         job_stdin       = stdin';\n         job_stderr      = stderr';\n         job_buffer      = Buffer.create 1024;\n-        job_dying       = false }\n+        job_dying       = false;\n+        job_tmp_file    = tmp_file;\n+        job_pid         = pid }\n     in\n     outputs := FDM.add (doi stdout') job (FDM.add (doi stderr') job !outputs);\n     jobs := JS.add job !jobs;\n@@ -199,6 +264,7 @@\n               try\n                 read fd u 0 (Bytes.length u)\n               with\n+              | Unix.Unix_error(Unix.EPIPE,_,_) when Sys.win32 -> 0\n               | Unix.Unix_error(e,_,_)  ->\n                 let msg = error_message e in\n                 display (fun oc -> fp oc\n@@ -241,14 +307,19 @@\n       decr jobs_active;\n \n       (* PR#5371: we would get EAGAIN below otherwise *)\n-      clear_nonblock (doi job.job_stdout);\n-      clear_nonblock (doi job.job_stderr);\n-\n+      if not Sys.win32 then (\n+        clear_nonblock (doi job.job_stdout);\n+        clear_nonblock (doi job.job_stderr);\n+      );\n       do_read ~loop:true (doi job.job_stdout) job;\n       do_read ~loop:true (doi job.job_stderr) job;\n       outputs := FDM.remove (doi job.job_stdout) (FDM.remove (doi job.job_stderr) !outputs);\n       jobs := JS.remove job !jobs;\n-      let status = close_process_full (job.job_stdout, job.job_stdin, job.job_stderr) in\n+      let status =\n+        if Sys.win32 then\n+          close_process_full_win (job.job_pid, job.job_stdout, job.job_stdin, job.job_stderr, job.job_tmp_file)\n+        else\n+          close_process_full (job.job_stdout, job.job_stdin, job.job_stderr) in\n \n       let shown = ref false in\n \n--- ./src/ocamlbuild_unix_plugin.ml\n+++ ./src/ocamlbuild_unix_plugin.ml\n@@ -48,12 +48,22 @@\n   end\n \n let run_and_open s kont =\n+  let s_orig = s in\n+  let s =\n+    (* Be consistent! My_unix.run_and_open uses My_std.sys_command and\n+       sys_command uses bash. *)\n+    if Sys.win32 = false then s else\n+    let l = match Lazy.force My_std.windows_shell |> Array.to_list with\n+    | hd::tl -> (Filename.quote hd)::tl\n+    | _ -> assert false in\n+    \"\\\"\" ^ (String.concat \" \" l) ^ \" -ec \" ^ Filename.quote (\" \" ^ s) ^ \"\\\"\"\n+  in\n   let ic = Unix.open_process_in s in\n   let close () =\n     match Unix.close_process_in ic with\n     | Unix.WEXITED 0 -> ()\n     | Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _ ->\n-        failwith (Printf.sprintf \"Error while running: %s\" s) in\n+        failwith (Printf.sprintf \"Error while running: %s\" s_orig) in\n   let res = try\n       kont ic\n     with e -> (close (); raise e)\n--- ./src/options.ml\n+++ ./src/options.ml\n@@ -174,11 +174,24 @@\n     build_dir := Filename.concat (Sys.getcwd ()) s\n   else\n     build_dir := s\n+\n+let slashify =\n+  if Sys.win32 then fun p -> String.map (function '\\\\' -> '/' | x -> x) p\n+  else fun p ->p\n+\n+let sb () =\n+  match Sys.os_type with\n+  | \"Win32\" ->\n+    (try set_binary_mode_out stdout true with _ -> ());\n+  | _ -> ()\n+\n+\n let spec = ref (\n     let print_version () =\n+      sb ();\n       Printf.printf \"ocamlbuild %s\\n%!\" Ocamlbuild_config.version; raise Exit_OK\n     in\n-    let print_vnum () = print_endline Ocamlbuild_config.version; raise Exit_OK in\n+    let print_vnum () = sb (); print_endline Ocamlbuild_config.version; raise Exit_OK in\n   Arg.align\n   [\n    \"-version\", Unit print_version , \" Display the version\";\n@@ -257,8 +270,8 @@\n    \"-build-dir\", String set_build_dir, \"<path> Set build directory (implies no-links)\";\n    \"-install-lib-dir\", Set_string Ocamlbuild_where.libdir, \"<path> Set the install library directory\";\n    \"-install-bin-dir\", Set_string Ocamlbuild_where.bindir, \"<path> Set the install binary directory\";\n-   \"-where\", Unit (fun () -> print_endline !Ocamlbuild_where.libdir; raise Exit_OK), \" Display the install library directory\";\n-   \"-which\", String (fun cmd -> print_endline (find_tool cmd); raise Exit_OK), \"<command> Display path to the tool command\";\n+   \"-where\", Unit (fun () -> sb (); print_endline (slashify !Ocamlbuild_where.libdir); raise Exit_OK), \" Display the install library directory\";\n+   \"-which\", String (fun cmd -> sb (); print_endline (slashify (find_tool cmd)); raise Exit_OK), \"<command> Display path to the tool command\";\n    \"-ocamlc\", set_cmd ocamlc, \"<command> Set the OCaml bytecode compiler\";\n    \"-plugin-ocamlc\", set_cmd plugin_ocamlc, \"<command> Set the OCaml bytecode compiler \\\n      used when building myocamlbuild.ml (only)\";\n--- ./src/pathname.ml\n+++ ./src/pathname.ml\n@@ -84,6 +84,26 @@\n   | x :: xs -> x :: normalize_list xs\n \n let normalize x =\n+  let x =\n+    if Sys.win32 = false then\n+      x\n+    else\n+      let len = String.length x in\n+      let b = Bytes.create len in\n+      for i = 0 to pred len do\n+        match x.[i] with\n+        | '\\\\' -> Bytes.set b i '/'\n+        | c -> Bytes.set b i c\n+      done;\n+      if len > 1 then (\n+        let c1 = Bytes.get b 0 in\n+        let c2 = Bytes.get b 1 in\n+        if c2 = ':' && c1 >= 'a' && c1 <= 'z' &&\n+           ( len = 2 || Bytes.get b 2 = '/') then\n+          Bytes.set b 0 (Char.uppercase_ascii c1)\n+      );\n+      Bytes.unsafe_to_string b\n+  in\n   if Glob.eval not_normal_form_re x then\n     let root, paths = split x in\n     join root (normalize_list paths)\n--- ./src/shell.ml\n+++ ./src/shell.ml\n@@ -24,12 +24,26 @@\n     | 'a'..'z' | 'A'..'Z' | '0'..'9' | '.' | '-' | '/' | '_' | ':' | '@' | '+' | ',' -> loop (pos + 1)\n     | _ -> false in\n   loop 0\n+\n+let generic_quote quotequote s =\n+  let l = String.length s in\n+  let b = Buffer.create (l + 20) in\n+  Buffer.add_char b '\\'';\n+  for i = 0 to l - 1 do\n+    if s.[i] = '\\''\n+    then Buffer.add_string b quotequote\n+    else Buffer.add_char b  s.[i]\n+  done;\n+  Buffer.add_char b '\\'';\n+  Buffer.contents b\n+let unix_quote = generic_quote \"'\\\\''\"\n+\n let quote_filename_if_needed s =\n   if is_simple_filename s then s\n   (* We should probably be using [Filename.unix_quote] except that function\n    * isn't exported. Users on Windows will have to live with not being able to\n    * install OCaml into c:\\o'caml. Too bad. *)\n-  else if Sys.os_type = \"Win32\" then Printf.sprintf \"'%s'\" s\n+  else if Sys.os_type = \"Win32\" then unix_quote s\n   else Filename.quote s\n let chdir dir =\n   reset_filesys_cache ();\n@@ -37,7 +51,7 @@\n let run args target =\n   reset_readdir_cache ();\n   let cmd = String.concat \" \" (List.map quote_filename_if_needed args) in\n-  if !*My_unix.is_degraded || Sys.os_type = \"Win32\" then\n+  if !*My_unix.is_degraded then\n     begin\n       Log.event cmd target Tags.empty;\n       let st = sys_command cmd in\n"
+          }
+        ],
         "opam": {
           "name": "ocamlbuild",
           "version": "0.12.0",
@@ -7759,6 +7812,10 @@
             "opam-version: \"1.2\"\nname: \"ocamlbuild\"\nversion: \"0.12.0\"\nmaintainer: \"Gabriel Scherer <gabriel.scherer@gmail.com>\"\nauthors: [\"Nicolas Pouillard\" \"Berke Durak\"]\nlicense: \"LGPL-2 with OCaml linking exception\"\nhomepage: \"https://github.com/ocaml/ocamlbuild/\"\ndoc: \"https://github.com/ocaml/ocamlbuild/blob/master/manual/manual.adoc\"\nbug-reports: \"https://github.com/ocaml/ocamlbuild/issues\"\nconflicts: [\n  \"base-ocamlbuild\"\n  \"ocamlfind\" {< \"1.6.2\"}\n]\navailable: ocaml-version >= \"4.03\"\nbuild: [\n  [\n    make\n    \"-f\"\n    \"configure.make\"\n    \"all\"\n    \"OCAMLBUILD_PREFIX=%{prefix}%\"\n    \"OCAMLBUILD_BINDIR=%{bin}%\"\n    \"OCAMLBUILD_LIBDIR=%{lib}%\"\n    \"OCAMLBUILD_MANDIR=%{man}%\"\n    \"OCAML_NATIVE=%{ocaml-native}%\"\n    \"OCAML_NATIVE_TOOLS=%{ocaml-native}%\"\n  ]\n  [make \"check-if-preinstalled\" \"all\" \"opam-install\"]\n]\ndev-repo: \"git+https://github.com/ocaml/ocamlbuild.git\"",
           "override": {
             "build": [
+              [
+                "bash", "-c",
+                "#{os == 'windows' ? 'patch -p1 < _esy/ocamlbuild-0.12.0.patch' : 'true'}"
+              ],
               [
                 "make", "-f", "configure.make", "all",
                 "OCAMLBUILD_PREFIX=#{self.install}",
@@ -7856,31 +7913,31 @@
         "@opam/ocamlfind@opam:1.8.0"
       ]
     },
-    "@opam/menhir@opam:20170712": {
+    "@opam/menhir@opam:20171013": {
       "record": {
         "name": "@opam/menhir",
-        "version": "opam:20170712",
+        "version": "opam:20171013",
         "source": [
-          "archive:https://opam.ocaml.org/archives/menhir.20170712+opam.tar.gz#md5:18aaf814e51aeb4fbfd8b7c1fb7ffbba",
-          "archive:http://gallium.inria.fr/~fpottier/menhir/menhir-20170712.tar.gz#md5:85a5c2aef1d3f2224dab7c53d79892e5"
+          "archive:https://opam.ocaml.org/archives/menhir.20171013+opam.tar.gz#md5:b361a87378407e26b9ea2dde7ddf41a0",
+          "archive:http://gallium.inria.fr/~fpottier/menhir/menhir-20171013.tar.gz#md5:620863edea40437390ee5e5bd82fba11"
         ],
         "files": [
           {
-            "name": "_esy/menhir-20170712.patch",
+            "name": "_esy/menhir-20171013.patch",
             "content":
-              "--- ./Makefile\n+++ ./Makefile\n@@ -60,10 +60,11 @@\n # If the compiler is MSVC, then the name of the executable file ends in .exe,\n # and object file names end in .obj instead of .o.\n \n-ifneq (,$(shell ocamlc -config | grep -E \"ccomp_type: msvc\"))\n+OS_TYPE:=$(shell ocamlc -config | tr -d '\\15' | awk '/^os_type:/ {print $$2}')\n+ifeq ($(OS_TYPE),$(filter $(OS_TYPE),Win32 Cygwin))\n   MENHIREXE    := menhir.exe\n-  OBJ          := obj\n-# LIBSUFFIX    := lib\n+  OBJ          := $(shell ocamlc -config | tr -d '\\15' | awk '/^ext_obj:/ {print $$2}' | tr -d '.')\n+# LIBSUFFIX    := $(shell ocamlc -config | tr -d '\\15' | awk '/^ext_lib:/ {print $$2}' | tr -d '.')\n else\n   MENHIREXE    := menhir\n   OBJ          := o\n@@ -85,8 +86,8 @@\n # performed if \"os_type\" is \"Win32\" or \"Win64\", and must not be performed if\n # \"os_type\" is \"Cygwin\" or \"Unix\".\n \n-ifneq (,$(shell ocamlc -config | grep -E \"os_type: (Win32|Win64)\"))\n-installation_libdir := $(shell cygpath -m $(libdir))\n+ifeq ($(OS_TYPE),Win32)\n+installation_libdir := $(shell cygpath -m $(libdir) || echo $(libdir))\n else\n installation_libdir := $(libdir)\n endif\n--- ./src/cmly_write.ml\n+++ ./src/cmly_write.ml\n@@ -168,6 +168,6 @@\n   output_value oc (t : grammar)\n \n let write filename =\n-  let oc = open_out filename in\n+  let oc = open_out_bin filename in\n   write oc (encode());\n   close_out oc\n"
+              "--- ./Makefile\n+++ ./Makefile\n@@ -59,13 +59,8 @@\n \n # If the compiler is MSVC, then object file names end in .obj instead of .o.\n \n-ifneq (,$(shell ocamlc -config | grep -E \"ccomp_type: msvc\"))\n-  OBJ          := obj\n-# LIBSUFFIX    := lib\n-else\n-  OBJ          := o\n-# LIBSUFFIX    := a\n-endif\n+OBJ          := $(shell ocamlc -config | awk -F '[\\t \\r]+' '/^ext_obj:/ {print $$2}' | tr -d '.')\n+#LIBSUFFIX   := $(shell ocamlc -config | awk -F '[\\t \\r]+' '/^ext_lib:/ {print $$2}' | tr -d '.')\n \n # If we are under Windows (regardless of whether we are using MSVC or mingw)\n # then the name of the executable file ends in .exe.\n@@ -91,8 +86,9 @@\n # performed if \"os_type\" is \"Win32\" or \"Win64\", and must not be performed if\n # \"os_type\" is \"Cygwin\" or \"Unix\".\n \n-ifneq (,$(shell ocamlc -config | grep -E \"os_type: (Win32|Win64)\"))\n-installation_libdir := $(shell cygpath -m $(libdir))\n+OS_TYPE:=\t$(shell ocamlc -config | awk -F '[\\t \\r]+' '/^os_type:/ {print $$2}')\n+ifeq ($(OS_TYPE),Win32)\n+installation_libdir := $(shell cygpath -m $(libdir) || echo $(libdir))\n else\n installation_libdir := $(libdir)\n endif\n--- ./src/cmly_write.ml\n+++ ./src/cmly_write.ml\n@@ -168,6 +168,6 @@\n   output_value oc (t : grammar)\n \n let write filename =\n-  let oc = open_out filename in\n+  let oc = open_out_bin filename in\n   write oc (encode());\n   close_out oc\n"
           }
         ],
         "opam": {
           "name": "menhir",
-          "version": "20170712",
+          "version": "20171013",
           "opam":
-            "opam-version: \"1.2\"\nname: \"menhir\"\nversion: \"20170712\"\nmaintainer: \"francois.pottier@inria.fr\"\nauthors: [\n  \"François Pottier <francois.pottier@inria.fr>\"\n  \"Yann Régis-Gianas <yrg@pps.univ-paris-diderot.fr>\"\n]\nhomepage: \"http://gallium.inria.fr/~fpottier/menhir/\"\nbug-reports: \"menhir@inria.fr\"\ndepends: [\n  \"ocamlfind\"\n  \"ocamlbuild\" {build}\n]\navailable: ocaml-version >= \"4.02\"\nbuild: [\n  make\n  \"-f\"\n  \"Makefile\"\n  \"PREFIX=%{prefix}%\"\n  \"USE_OCAMLFIND=true\"\n  \"docdir=%{doc}%/menhir\"\n  \"libdir=%{lib}%/menhir\"\n  \"mandir=%{man}%/man1\"\n]\ninstall: [\n  make\n  \"-f\"\n  \"Makefile\"\n  \"install\"\n  \"PREFIX=%{prefix}%\"\n  \"docdir=%{doc}%/menhir\"\n  \"libdir=%{lib}%/menhir\"\n  \"mandir=%{man}%/man1\"\n]\nremove: [\n  make\n  \"-f\"\n  \"Makefile\"\n  \"uninstall\"\n  \"PREFIX=%{prefix}%\"\n  \"docdir=%{doc}%/menhir\"\n  \"libdir=%{lib}%/menhir\"\n  \"mandir=%{man}%/man1\"\n]\ndev-repo: \"git+https://gitlab.inria.fr/fpottier/menhir.git\"",
+            "opam-version: \"1.2\"\nname: \"menhir\"\nversion: \"20171013\"\nmaintainer: \"francois.pottier@inria.fr\"\nauthors: [\n  \"François Pottier <francois.pottier@inria.fr>\"\n  \"Yann Régis-Gianas <yrg@pps.univ-paris-diderot.fr>\"\n]\nhomepage: \"http://gallium.inria.fr/~fpottier/menhir/\"\nbug-reports: \"menhir@inria.fr\"\ndepends: [\n  \"ocamlfind\"\n  \"ocamlbuild\" {build}\n]\navailable: ocaml-version >= \"4.02\"\nbuild: [\n  make\n  \"-f\"\n  \"Makefile\"\n  \"PREFIX=%{prefix}%\"\n  \"USE_OCAMLFIND=true\"\n  \"docdir=%{doc}%/menhir\"\n  \"libdir=%{lib}%/menhir\"\n  \"mandir=%{man}%/man1\"\n]\ninstall: [\n  make\n  \"-f\"\n  \"Makefile\"\n  \"install\"\n  \"PREFIX=%{prefix}%\"\n  \"docdir=%{doc}%/menhir\"\n  \"libdir=%{lib}%/menhir\"\n  \"mandir=%{man}%/man1\"\n]\nremove: [\n  make\n  \"-f\"\n  \"Makefile\"\n  \"uninstall\"\n  \"PREFIX=%{prefix}%\"\n  \"docdir=%{doc}%/menhir\"\n  \"libdir=%{lib}%/menhir\"\n  \"mandir=%{man}%/man1\"\n]\ndev-repo: \"git+https://gitlab.inria.fr/fpottier/menhir.git\"",
           "override": {
             "build": [
               [
                 "bash", "-c",
-                "#{os == 'windows' ? 'patch -p1 < _esy/menhir-20170712.patch' : 'true'}"
+                "#{os == 'windows' ? 'patch -p1 < _esy/menhir-20171013.patch' : 'true'}"
               ],
               [
                 "make", "-f", "Makefile", "PREFIX=#{self.install}",
@@ -8593,7 +8650,7 @@
       },
       "dependencies": [
         "@esy-ocaml/esy-installer@0.0.0", "@esy-ocaml/substs@0.0.1",
-        "@opam/jbuilder@opam:transition", "@opam/menhir@opam:20170712",
+        "@opam/jbuilder@opam:transition", "@opam/menhir@opam:20171013",
         "@opam/merlin-extend@opam:0.3",
         "@opam/ocaml-migrate-parsetree@opam:1.0.11",
         "@opam/ocamlfind@opam:1.8.0", "@opam/result@opam:1.3"

--- a/esyi/Package.mli
+++ b/esyi/Package.mli
@@ -75,6 +75,9 @@ module VersionSpec : sig
   val toString : t -> string
   val to_yojson : t -> [> `String of string ]
 
+  val parseAsNpm : string -> (t, string) result
+  val parseAsOpam : string -> (t, string) result
+
   val matches : version:Version.t -> t -> bool
   val ofVersion : Version.t -> t
 end
@@ -85,13 +88,11 @@ module Req : sig
   val pp : Format.formatter -> t -> unit
 
   val toString : t -> string
-  val to_yojson : t -> [> `String of string ]
+  val to_yojson : t Json.encoder
 
-  val make : name:string -> spec:string -> (t, string) result
-  val ofSpec : name:string -> spec:VersionSpec.t -> t
+  val parse : string -> (t, string) result
 
-  val name : t -> string
-  val spec : t -> VersionSpec.t
+  val make : name:string -> spec:VersionSpec.t -> t
 
   val matches : name:string -> version:Version.t -> t -> bool
 end

--- a/esyi/Sandbox.ml
+++ b/esyi/Sandbox.ml
@@ -22,7 +22,7 @@ end
 
 let ocamlReqAny =
   let spec = Package.VersionSpec.Npm SemverVersion.Formula.any in
-  Package.Req.ofSpec ~name:"ocaml" ~spec
+  Package.Req.make ~name:"ocaml" ~spec
 
 let makeOpamSandbox ~cfg projectPath (paths : Path.t list) =
   let open RunAsync.Syntax in

--- a/esyi/Solution.ml
+++ b/esyi/Solution.ml
@@ -265,9 +265,7 @@ module LockfileV1 = struct
             Fmt.pf fmt "%a" Package.SourceSpec.pp src
         in
         let ppReq fmt req =
-          let name = Package.Req.name req in
-          let spec = Package.Req.spec req in
-          Fmt.fmt "%s@%a" fmt name ppVersionSpec spec
+          Fmt.fmt "%s@%a" fmt req.Package.Req.name ppVersionSpec req.spec
         in
         Fmt.pf fmt "@[<hov>[@;%a@;]@]" (Fmt.list ~sep:(Fmt.unit ", ") ppReq) deps
       in

--- a/esyi/Solver.ml
+++ b/esyi/Solver.ml
@@ -342,7 +342,7 @@ let add ~(dependencies : Dependencies.t) solver =
 
     return (
       match spec with
-      | Some spec -> Req.ofSpec ~name:req.name ~spec
+      | Some spec -> Req.make ~name:req.name ~spec
       | None -> req
     )
   in
@@ -703,7 +703,7 @@ let solve (sandbox : Sandbox.t) =
         match ocamlVersion, sandbox.dependencies with
         | Some ocamlVersion, Package.Dependencies.NpmFormula reqs ->
           let ocamlSpec = Package.VersionSpec.ofVersion ocamlVersion in
-          let ocamlReq = Req.ofSpec ~name:"ocaml" ~spec:ocamlSpec in
+          let ocamlReq = Req.make ~name:"ocaml" ~spec:ocamlSpec in
           let reqs = Package.NpmDependencies.override reqs [ocamlReq] in
           Package.Dependencies.NpmFormula reqs
         | Some ocamlVersion, Package.Dependencies.OpamFormula deps ->

--- a/esyi/dune
+++ b/esyi/dune
@@ -5,7 +5,6 @@
                   ppx_deriving.std
                   ppx_deriving_yojson
                   ppxlib
-                  ppx_tyre
                   ppx_inline_test))
   (inline_tests)
   (flags (:standard (-w -39) "-open" "EsyLib"))

--- a/esyi/dune
+++ b/esyi/dune
@@ -5,11 +5,13 @@
                   ppx_deriving.std
                   ppx_deriving_yojson
                   ppxlib
+                  ppx_tyre
                   ppx_inline_test))
   (inline_tests)
   (flags (:standard (-w -39) "-open" "EsyLib"))
   (libraries
             EsyLib
+            tyre
             str
             cudf
             ppx_deriving_yojson.runtime

--- a/package.json
+++ b/package.json
@@ -5,42 +5,30 @@
   "license": "MIT",
   "esy": {
     "build": [
+      [ "dune", "build", "-j", "4" ],
       [
-        "dune",
-        "build",
-        "-j",
-        "4"
-      ],
-      [
-        "dune",
-        "build",
-        "esy/bin/esyCommand.exe",
+        "dune", "build", "esy/bin/esyCommand.exe",
         "esy-build-package/bin/esyBuildPackageCommand.exe"
       ]
     ],
     "install": [
-      [
-        "esy-installer",
-        "./esy-build-package.install"
-      ],
-      [
-        "esy-installer",
-        "./esy.install"
-      ]
+      [ "esy-installer", "./esy-build-package.install" ],
+      [ "esy-installer", "./esy.install" ]
     ],
     "buildsInSource": "_build"
   },
   "scripts": {
-    "bootstrap:install-opam": "esy-bash ./scripts/bootstrap/install-opam-windows.sh",
-    "bootstrap:install-dependencies": "esy-bash ./scripts/bootstrap/install-opam-dependencies.sh",
+    "bootstrap:install-opam":
+      "esy-bash ./scripts/bootstrap/install-opam-windows.sh",
+    "bootstrap:install-dependencies":
+      "esy-bash ./scripts/bootstrap/install-opam-dependencies.sh",
     "bootstrap:build": "esy-bash ./scripts/bootstrap/build-bootstrap.sh",
-    "bootstrap:make-release-package": "node ./scripts/bootstrap/make-release-package.js",
+    "bootstrap:make-release-package":
+      "node ./scripts/bootstrap/make-release-package.js",
     "bootstrap:unit-test": "esy-bash dune runtest test",
     "test-e2e": "jest --runInBand test-e2e"
   },
-  "resolutions": {
-    "@opam/merlin-extend": "0.3"
-  },
+  "resolutions": { "@opam/merlin-extend": "0.3" },
   "dependencies": {
     "@esy-ocaml/esy-installer": "^0.0.0",
     "@esy-ocaml/reason": "~3.2.0",
@@ -48,30 +36,29 @@
     "@opam/cmdliner": "^1.0.2",
     "@opam/cudf": "0.9",
     "@opam/dose3": "*",
+    "@opam/dune": "*",
     "@opam/fmt": "^0.8.4",
     "@opam/fpath": "^0.7.2",
-    "@opam/dune": "*",
     "@opam/lambda-term": "^1.11.0",
     "@opam/logs": "^0.6.2",
     "@opam/lwt": "^4.0.0",
     "@opam/lwt_ppx": "^1.1.0",
     "@opam/menhir": "*",
+    "@opam/opam-core": "*",
     "@opam/opam-file-format": "*",
     "@opam/opam-format": "*",
-    "@opam/opam-core": "*",
     "@opam/opam-state": "*",
     "@opam/ppx_deriving": "*",
     "@opam/ppx_deriving_yojson": "*",
     "@opam/ppx_inline_test": "*",
     "@opam/ppx_let": "*",
     "@opam/re": "^1.7.1",
+    "@opam/tyre": "0.4.1",
     "@opam/yojson": "*",
     "esy-solve-cudf": "^0.1.6",
     "fastreplacestring": "esy-ocaml/FastReplaceString#95f408b"
   },
-  "peerDependencies": {
-    "ocaml": "~4.6.0"
-  },
+  "peerDependencies": { "ocaml": "~4.6.0" },
   "devDependencies": {
     "@opam/utop": "*",
     "@esy-ocaml/merlin": "*",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,12 @@
   "license": "MIT",
   "esy": {
     "build": [
-      ["dune", "build", "-j", "4"],
+      [
+        "dune",
+        "build",
+        "-j",
+        "4"
+      ],
       [
         "dune",
         "build",
@@ -14,8 +19,14 @@
       ]
     ],
     "install": [
-      ["esy-installer", "./esy-build-package.install"],
-      ["esy-installer", "./esy.install"]
+      [
+        "esy-installer",
+        "./esy-build-package.install"
+      ],
+      [
+        "esy-installer",
+        "./esy.install"
+      ]
     ],
     "buildsInSource": "_build"
   },
@@ -33,8 +44,6 @@
   "dependencies": {
     "@esy-ocaml/esy-installer": "^0.0.0",
     "@esy-ocaml/reason": "~3.2.0",
-    "@opam/tyre": "*",
-    "@opam/ppx_tyre": "*",
     "@opam/bos": "^0.2.0",
     "@opam/cmdliner": "^1.0.2",
     "@opam/cudf": "0.9",

--- a/package.json
+++ b/package.json
@@ -5,12 +5,7 @@
   "license": "MIT",
   "esy": {
     "build": [
-      [
-        "dune",
-        "build",
-        "-j",
-        "4"
-      ],
+      ["dune", "build", "-j", "4"],
       [
         "dune",
         "build",
@@ -19,14 +14,8 @@
       ]
     ],
     "install": [
-      [
-        "esy-installer",
-        "./esy-build-package.install"
-      ],
-      [
-        "esy-installer",
-        "./esy.install"
-      ]
+      ["esy-installer", "./esy-build-package.install"],
+      ["esy-installer", "./esy.install"]
     ],
     "buildsInSource": "_build"
   },
@@ -44,6 +33,8 @@
   "dependencies": {
     "@esy-ocaml/esy-installer": "^0.0.0",
     "@esy-ocaml/reason": "~3.2.0",
+    "@opam/tyre": "*",
+    "@opam/ppx_tyre": "*",
     "@opam/bos": "^0.2.0",
     "@opam/cmdliner": "^1.0.2",
     "@opam/cudf": "0.9",

--- a/scripts/bootstrap/install-opam-dependencies.sh
+++ b/scripts/bootstrap/install-opam-dependencies.sh
@@ -20,6 +20,7 @@ opam install --yes ppx_deriving_yojson
 opam install --yes yojson
 opam install --yes bos
 opam install --yes re
+opam install --yes tyre
 opam install --yes opam-format
 opam install --yes opam-state
 opam install --yes cudf

--- a/test-e2e/install/add.test.js
+++ b/test-e2e/install/add.test.js
@@ -48,6 +48,48 @@ describe('adding dependencies', function() {
     expect(packageJson.dependencies['new-dep']).toEqual('^2.0.0');
   });
 
+  test(`simply add a new dep with constraint`, async () => {
+    const fixture = [
+      helpers.packageJson({
+        name: 'root',
+        version: '1.0.0',
+        esy: {},
+        dependencies: {},
+      }),
+    ];
+    const p = await helpers.createTestSandbox(...fixture);
+    await p.defineNpmPackage({
+      name: 'new-dep',
+      version: '1.0.0',
+      esy: {},
+      dependencies: {},
+    });
+    await p.defineNpmPackage({
+      name: 'new-dep',
+      version: '2.0.0',
+      esy: {},
+      dependencies: {},
+    });
+
+    await p.esy(`add new-dep@^1.0.0`);
+
+    await expect(helpers.crawlLayout(p.projectPath)).resolves.toMatchObject({
+      dependencies: {
+        'new-dep': {
+          name: 'new-dep',
+          version: '1.0.0',
+        },
+      },
+    });
+
+    const packageJsonData = await helpers.readFile(
+      path.join(p.projectPath, 'package.json'),
+      'utf8',
+    );
+    const packageJson = JSON.parse(packageJsonData);
+    expect(packageJson.dependencies['new-dep']).toEqual('^1.0.0');
+  });
+
   test(`adding multiple deps`, async () => {
     const fixture = [
       helpers.packageJson({


### PR DESCRIPTION
Currently it is only possible to ru `esy add` command with package names to add:

```
% esy add @opam/merlin
```

This PR makes it possible to specify constraints:

```
% esy add @opam/merlin@3.5.1
```

It also refactors version spec parsing and starts using `tyre` instead of raw `re`.