### PR TITLE
Remove toString from PRINTABLE signature

### DIFF
--- a/esy-build-package/Build.re
+++ b/esy-build-package/Build.re
@@ -25,7 +25,7 @@ let isRoot = (build: t) =>
   Config.Value.equal(build.plan.sourcePath, Config.Value.project);
 
 let regex = (base, segments) => {
-  let pat = String.concat(Path.dirSep, [Path.toString(base), ...segments]);
+  let pat = String.concat(Path.dirSep, [Path.show(base), ...segments]);
   Sandbox.Regex(pat);
 };
 
@@ -114,7 +114,7 @@ module JBuilderLifecycle: LIFECYCLE = {
   let getRootPath = (build: build) => build.sourcePath;
   let getAllowedToWritePaths = (_task, sourcePath) =>
     Sandbox.[
-      Subpath(Path.toString(sourcePath / "_build")),
+      Subpath(Path.show(sourcePath / "_build")),
       regex(sourcePath, [".*", "[^/]*\\.install"]),
       regex(sourcePath, ["[^/]*\\.install"]),
       regex(sourcePath, [".*", "[^/]*\\.opam"]),
@@ -196,7 +196,7 @@ module UnsafeLifecycle: LIFECYCLE = {
   let getRootPath = (build: build) => build.sourcePath;
 
   let getAllowedToWritePaths = (_task, sourcePath) =>
-    Sandbox.[Subpath(Path.toString(sourcePath))];
+    Sandbox.[Subpath(Path.show(sourcePath))];
 
   let prepare = (~cfg as _, _build) => Ok();
   let finalize = (~cfg as _, _build) => Ok();
@@ -259,15 +259,15 @@ let configureBuild = (~cfg: Config.t, plan: Plan.t) => {
       let%bind tempPath = {
         let v = Path.v(Bos.OS.Env.opt_var("TMPDIR", ~absent="/tmp"));
         let%bind v = realpath(v);
-        Ok(Path.toString(v));
+        Ok(Path.show(v));
       };
       Ok({
         Sandbox.allowWrite: [
           regex(sourcePath, [".*", "\\.merlin"]),
           regex(sourcePath, ["\\.merlin"]),
           regex(sourcePath, [".*\\.install"]),
-          Subpath(Path.toString(buildPath)),
-          Subpath(Path.toString(stagePath)),
+          Subpath(Path.show(buildPath)),
+          Subpath(Path.show(stagePath)),
           Subpath("/private/tmp"),
           Subpath("/tmp"),
           Subpath(tempPath),
@@ -341,7 +341,7 @@ let install = (~prefixPath, ~rootPath, ~installFilename=?, ()) => {
 };
 
 let withLock = (lockPath: Path.t, f) => {
-  let lockPath = Path.toString(lockPath);
+  let lockPath = Path.show(lockPath);
   let fd =
     UnixLabels.(
       openfile(
@@ -383,8 +383,8 @@ let commitBuildToStore = (config: Config.t, build: build) => {
     Bos.OS.Cmd.run(cmd);
   };
   let rewritePrefixesInFile = (~origPrefix, ~destPrefix, path) => {
-    let origPrefixString = Path.toString(origPrefix);
-    let destPrefixString = Path.toString(destPrefix);
+    let origPrefixString = Path.show(origPrefix);
+    let destPrefixString = Path.show(destPrefix);
     switch (System.Platform.host) {
     | Windows =>
       /* On Windows, the slashes could be either `/` or windows-style `\`, or even escaped like `\\` */
@@ -462,7 +462,7 @@ let commitBuildToStore = (config: Config.t, build: build) => {
     };
   let%bind () =
     write(
-      ~data=Path.toString(config.storePath),
+      ~data=Path.show(config.storePath),
       Path.(build.stagePath / "_esy" / "storePrefix"),
     );
   let%bind () = traverse(build.stagePath, relocate);

--- a/esy-build-package/Config.re
+++ b/esy-build-package/Config.re
@@ -48,8 +48,7 @@ let make =
   );
 
 let render = (cfg, v) => {
-  let path = v =>
-    v |> EsyLib.Path.toString |> EsyLib.Path.normalizePathSlashes;
+  let path = v => v |> EsyLib.Path.show |> EsyLib.Path.normalizePathSlashes;
   let projectPath = path(cfg.projectPath);
   let storePath = path(cfg.storePath);
   let localStorePath = path(cfg.localStorePath);
@@ -88,9 +87,9 @@ module Path: {
   let localStore = v("%{localStore}%");
 
   let toValue = path =>
-    path |> toString |> EsyLib.Path.normalizePathSlashes |> Value.v;
+    path |> show |> EsyLib.Path.normalizePathSlashes |> Value.v;
 
-  let toPath = (cfg, path) => path |> toString |> render(cfg) |> v;
+  let toPath = (cfg, path) => path |> show |> render(cfg) |> v;
 
   let ofPath = (cfg, p) => {
     let p =

--- a/esy-build-package/Sandbox.re
+++ b/esy-build-package/Sandbox.re
@@ -48,7 +48,7 @@ module Darwin = {
     let prepare = (~env, command) => {
       open Bos.OS.Cmd;
       let sandboxCommand =
-        Cmd.of_list(["sandbox-exec", "-f", Path.toString(configFilename)]);
+        Cmd.of_list(["sandbox-exec", "-f", Path.show(configFilename)]);
       let command = Cmd.(sandboxCommand %% command);
 
       let exec = (~err) => run_io(~env, ~err, command);

--- a/esy-lib/Abstract.ml
+++ b/esy-lib/Abstract.ml
@@ -38,7 +38,6 @@ module String = struct
     let v v = v
     let render = Core.render
 
-    let toString v = v
     let show v = v
     let pp = Fmt.string
 

--- a/esy-lib/Checksum.ml
+++ b/esy-lib/Checksum.ml
@@ -72,7 +72,7 @@ let checkFile ~path (checksum : t) =
     (* On Windows, the checksum tools packaged with Cygwin require cygwin-style paths *)
     RunAsync.ofBosError (
       let open Result.Syntax in
-      let%bind path = EsyBash.normalizePathForCygwin (Path.toString path) in
+      let%bind path = EsyBash.normalizePathForCygwin (Path.show path) in
       let%bind out = EsyBash.runOut Cmd.(cmd % path |> toBosCmd) in
       match Astring.String.cut ~sep:" " out with
       | Some (v, _) -> return v

--- a/esy-lib/Checksum.mli
+++ b/esy-lib/Checksum.mli
@@ -6,15 +6,11 @@ and kind =
   | Sha256
   | Sha512
 
-val equal : t -> t -> bool
-val compare : t -> t -> int
-val pp : t Fmt.t
-val show : t -> string
+include S.JSONABLE with type t := t
+include S.PRINTABLE with type t := t
+include S.COMPARABLE with type t := t
 
 val parser : t Parse.t
 val parse : string -> (t, string) result
-
-val to_yojson : t Json.encoder
-val of_yojson : t Json.decoder
 
 val checkFile : path:Path.t -> t -> unit RunAsync.t

--- a/esy-lib/ChildProcess.ml
+++ b/esy-lib/ChildProcess.ml
@@ -92,7 +92,7 @@ let run ?env ?resolveProgramInEnv ?stdin ?stdout ?stderr cmd =
     match%lwt process#status with
     | Unix.WEXITED 0 -> return ()
     | _ ->
-      let cmd = Cmd.toString cmd in
+      let cmd = Cmd.show cmd in
       let msg = Printf.sprintf "error running command: %s" cmd in
       error msg
   in

--- a/esy-lib/Cli.ml
+++ b/esy-lib/Cli.ml
@@ -85,8 +85,8 @@ let checkoutConv =
   in
   let print (fmt : Format.formatter) v =
     match v with
-    | `RemoteLocal (remote, local) -> Fmt.pf fmt "%s:%s" remote (Path.toString local)
-    | `Local local -> Fmt.pf fmt ":%s" (Path.toString local)
+    | `RemoteLocal (remote, local) -> Fmt.pf fmt "%s:%s" remote (Path.show local)
+    | `Local local -> Fmt.pf fmt ":%s" (Path.show local)
     | `Remote remote -> Fmt.pf fmt "%s" remote
   in
   Arg.conv ~docv:"VAL" (parse, print)

--- a/esy-lib/Cmd.ml
+++ b/esy-lib/Cmd.ml
@@ -10,7 +10,7 @@ type t = string * string list
   [@@deriving (eq, ord)]
 
 let v tool = tool, []
-let p = Path.toString
+let p = Path.show
 
 let addArg arg (tool, args) =
   let args = arg::args in
@@ -43,12 +43,10 @@ let getTool (tool, _args) = tool
 
 let getArgs (_tool, args) = List.rev args
 
-let toString (tool, args) =
+let show (tool, args) =
   let tool = Filename.quote tool in
   let args = List.rev_map ~f:Filename.quote args in
   StringLabels.concat ~sep:" " (tool::args)
-
-let show = toString
 
 let pp ppf (tool, args) =
   match args with
@@ -126,7 +124,7 @@ let resolveCmd path cmd =
     | x::xs ->
       begin match find x with
       | Ok (Some (x)) ->
-        Ok (Path.toString x)
+        Ok (Path.show x)
       | Ok None
       | Error _ -> resolve xs
       end

--- a/esy-lib/Cmd.mli
+++ b/esy-lib/Cmd.mli
@@ -41,9 +41,7 @@ val getToolAndLine : t -> string * string array
 val getTool : t -> string
 val getArgs : t -> string list
 
-val pp : Format.formatter -> t -> unit
-val show : t -> string
-val toString : t -> string
+include S.PRINTABLE with type t := t
 
 val equal : t -> t -> bool
 val compare : t -> t -> int

--- a/esy-lib/Environment.ml
+++ b/esy-lib/Environment.ml
@@ -68,7 +68,7 @@ end = struct
   let empty = StringMap.empty
   let find = StringMap.find
   let map ~f env =
-    let f value = value |> V.toString |> f |> V.v in
+    let f value = value |> V.show |> f |> V.v in
     StringMap.map f env
 
   let render ctx env =
@@ -99,13 +99,13 @@ end = struct
         let value =
           match binding.Binding.value with
           | Binding.Value value ->
-            Binding.Value (value |> V.toString |> f |> V.v)
+            Binding.Value (value |> V.show |> f |> V.v)
           | Binding.ExpandedValue value ->
-            Binding.ExpandedValue (value |> V.toString |> f |> V.v)
+            Binding.ExpandedValue (value |> V.show |> f |> V.v)
           | Binding.Prefix value ->
-            Binding.Prefix (value |> V.toString |> f |> V.v)
+            Binding.Prefix (value |> V.show |> f |> V.v)
           | Binding.Suffix value ->
-            Binding.Suffix (value |> V.toString |> f |> V.v)
+            Binding.Suffix (value |> V.show |> f |> V.v)
         in
         {binding with value}
       in
@@ -135,30 +135,30 @@ end = struct
         in
         match binding.Binding.value with
         | Value value ->
-          let value = V.toString value in
+          let value = V.show value in
           let%bind value = EsyShellExpansion.render ~scope value in
           let value = V.v value in
           Ok (StringMap.add binding.name value env)
         | ExpandedValue value ->
           Ok (StringMap.add binding.name value env)
         | Prefix value ->
-          let value = V.toString value in
+          let value = V.show value in
           let value =
             match StringMap.find binding.name env with
             | Some prevValue ->
               let sep = System.Environment.sep ~platform ~name:binding.name () in
-              value ^ sep ^ (V.toString prevValue)
+              value ^ sep ^ (V.show prevValue)
             | None -> value
           in
           let value = V.v value in
           Ok (StringMap.add binding.name value env)
         | Suffix value ->
-          let value = V.toString value in
+          let value = V.show value in
           let value =
             match StringMap.find binding.name env with
             | Some prevValue ->
               let sep = System.Environment.sep ~platform ~name:binding.name () in
-              (V.toString prevValue) ^ sep ^ value
+              (V.show prevValue) ^ sep ^ value
             | None -> value
           in
           let value = V.v value in
@@ -175,7 +175,6 @@ module V = Make(struct
   let v v = v
   let of_yojson = Json.Parse.string
   let to_yojson v = `String v
-  let toString v = v
   let show v = v
   let pp = Fmt.string
   let render () v = v

--- a/esy-lib/EsyBashLwt.re
+++ b/esy-lib/EsyBashLwt.re
@@ -1,23 +1,25 @@
-let toRunAsyncCommand = (cmd) => {
-    let resolvedCommand = EsyBash.toEsyBashCommand(Cmd.toBosCmd(cmd));
-    switch (resolvedCommand) {
-    | Ok(v) => RunAsync.return(Cmd.ofBosCmd(v))
-    | Error(`Msg(line)) => RunAsync.error(line)
-    | _ => RunAsync.error("unknown error")
-    };
+let toRunAsyncCommand = cmd => {
+  let resolvedCommand = EsyBash.toEsyBashCommand(Cmd.toBosCmd(cmd));
+  switch (resolvedCommand) {
+  | Ok(v) => RunAsync.return(Cmd.ofBosCmd(v))
+  | Error(`Msg(line)) => RunAsync.error(line)
+  | _ => RunAsync.error("unknown error")
+  };
 };
 
 /**
  * Helper utility to run a command with 'esy-bash', via Lwt.
  * This is meant to replace Lwt's with_process_full in the case
  * of executing bash commands */
-let with_process_full = (cmd, f) => {
-    open RunAsync.Syntax;
-    let%bind res = toRunAsyncCommand(cmd);
-    switch (res) {
-    | Ok(v) =>
+let with_process_full = (cmd, f) =>
+  RunAsync.Syntax.(
+    {
+      let%bind res = toRunAsyncCommand(cmd);
+      switch (res) {
+      | Ok(v) =>
         let tl = Cmd.getToolAndLine(v);
         Lwt_process.with_process_full(tl, f);
-    | _ => RunAsync.error("error running command: " ++ Cmd.toString(cmd))
-    };
-};
+      | _ => RunAsync.error("error running command: " ++ Cmd.show(cmd))
+      };
+    }
+  );

--- a/esy-lib/Git.ml
+++ b/esy-lib/Git.ml
@@ -98,7 +98,7 @@ module ShallowClone = struct
       if%bind Fs.exists dst then
 
         let%bind remoteCommit = lsRemote ~ref:branch ~remote:source ()
-        and localCommit = lsRemote ~remote:(Path.toString dst) () in
+        and localCommit = lsRemote ~remote:(Path.show dst) () in
 
         if remoteCommit = localCommit
         then return ()

--- a/esy-lib/Path.re
+++ b/esy-lib/Path.re
@@ -25,18 +25,21 @@ let isAbs = Fpath.is_abs;
 let isPrefix = Fpath.is_prefix;
 let remPrefix = Fpath.rem_prefix;
 
-let homePath = () => Fpath.v(
-  switch (Sys.getenv_opt("HOME"), System.Platform.host) {
-  | (Some(dir), _) => dir
-  | (None, System.Platform.Windows) => Sys.getenv("USERPROFILE")
-  | (None, _) => failwith("Could not find HOME dir")
-  });
-let dataPath = () => Fpath.v(
-  switch (System.Platform.host) {
-  | System.Platform.Windows => Sys.getenv("LOCALAPPDATA")
-  | _ => Sys.getenv("HOME")
-  }
-);
+let homePath = () =>
+  Fpath.v(
+    switch (Sys.getenv_opt("HOME"), System.Platform.host) {
+    | (Some(dir), _) => dir
+    | (None, System.Platform.Windows) => Sys.getenv("USERPROFILE")
+    | (None, _) => failwith("Could not find HOME dir")
+    },
+  );
+let dataPath = () =>
+  Fpath.v(
+    switch (System.Platform.host) {
+    | System.Platform.Windows => Sys.getenv("LOCALAPPDATA")
+    | _ => Sys.getenv("HOME")
+    },
+  );
 let current = () => Run.ofBosError(Bos.OS.Dir.current());
 
 let relativize = Fpath.relativize;
@@ -63,16 +66,14 @@ let equal = Fpath.equal;
 
 let show = Fpath.to_string;
 let pp = Fpath.pp;
-let toString = Fpath.to_string;
 let toPrettyString = p =>
   Run.Syntax.(
     {
-      let%bind path = {
+      let%bind path =
         switch (remPrefix(homePath(), p)) {
         | Some(p) => return(Fpath.append(Fpath.v("~"), p))
         | None => return(p)
         };
-      };
       return(Fpath.to_string(path));
     }
   );
@@ -89,7 +90,7 @@ let of_yojson = (json: Yojson.Safe.json) =>
   | _ => Error("invalid path")
   };
 
-let to_yojson = (path: t) => `String(toString(path));
+let to_yojson = (path: t) => `String(show(path));
 
 let safeSeg = {
   let replaceAt = Str.regexp("@");

--- a/esy-lib/S.ml
+++ b/esy-lib/S.ml
@@ -3,7 +3,6 @@ module type PRINTABLE = sig
 
   val pp : t Fmt.t
   val show : t -> string
-  val toString : t -> string
 end
 
 module type JSONABLE = sig

--- a/esy-lib/System.ml
+++ b/esy-lib/System.ml
@@ -18,8 +18,6 @@ module Platform = struct
 
   let pp fmt v = Fmt.string fmt (show v)
 
-  let toString = show
-
   let host =
     let uname () =
       let ic = Unix.open_process_in "uname" in
@@ -59,8 +57,6 @@ module Arch = struct
     | Unknown -> "unknown"
 
   let pp fmt v = Fmt.string fmt (show v)
-
-  let toString = show
 
   let host =
     let uname () =

--- a/esy-lib/Tarball.ml
+++ b/esy-lib/Tarball.ml
@@ -48,8 +48,8 @@ let unpackWithTar ?stripComponents ~dst filename =
   let unpack out = 
     let%bind cmd = RunAsync.ofBosError (
       let open Result.Syntax in
-      let%bind nf = EsyBash.normalizePathForCygwin (Path.toString filename) in
-      let%bind normalizedOut = EsyBash.normalizePathForCygwin (Path.toString out) in
+      let%bind nf = EsyBash.normalizePathForCygwin (Path.show filename) in
+      let%bind normalizedOut = EsyBash.normalizePathForCygwin (Path.show out) in
       return Cmd.(v "tar" % "xf" % nf % "-C" % normalizedOut)
     )
     in
@@ -86,8 +86,8 @@ let unpack ?stripComponents ~dst filename =
 let create ~filename src =
   RunAsync.ofBosError (
     let open Result.Syntax in
-    let%bind nf = EsyBash.normalizePathForCygwin (Path.toString filename) in
-    let%bind ns = EsyBash.normalizePathForCygwin (Path.toString src) in
+    let%bind nf = EsyBash.normalizePathForCygwin (Path.show filename) in
+    let%bind ns = EsyBash.normalizePathForCygwin (Path.show src) in
     let cmd = Cmd.(v "tar" % "czf" % nf % "-C" % ns % ".") in
     let%bind res = EsyBash.run (Cmd.toBosCmd cmd) in
     return res

--- a/esy-lib/TermTree.ml
+++ b/esy-lib/TermTree.ml
@@ -5,7 +5,7 @@
 type t =
   | Node of { line : string; children : t list }
 
-let toString (node : t) =
+let render (node : t) =
   let rec nodeToLines ~indent ~lines (Node { line; children }) =
     let lines =
       let indent = indent |> List.rev |> StringLabels.concat ~sep:"" in

--- a/esy/Manifest.ml
+++ b/esy/Manifest.ml
@@ -446,7 +446,7 @@ end = struct
     let open RunAsync.Syntax in
     let%bind opam =
       let%bind data = Fs.readFile path in
-      let filename = OpamFile.make (OpamFilename.of_string (Path.toString path)) in
+      let filename = OpamFile.make (OpamFilename.of_string (Path.show path)) in
       let opam = OpamFile.OPAM.read_from_string ~filename data in
       let opam = OpamFormatUpgrade.opam_file ~filename opam in
       return opam

--- a/esy/NpmRelease.ml
+++ b/esy/NpmRelease.ml
@@ -254,11 +254,11 @@ let make ~ocamlopt ~esyInstallRelease ~outputPath ~concurrency ~(sandbox : Sandb
       (* Replace the storePath with a string of equal length containing only _ *)
       let (origPrefix, destPrefix) =
         let nextStorePrefix =
-          String.make (String.length (Path.toString sandbox.buildConfig.storePath)) '_'
+          String.make (String.length (Path.show sandbox.buildConfig.storePath)) '_'
         in
         (sandbox.buildConfig.storePath, Path.v nextStorePrefix)
       in
-      let%bind () = Fs.writeFile ~data:(Path.toString destPrefix) Path.(binPath / "_storePath") in
+      let%bind () = Fs.writeFile ~data:(Path.show destPrefix) Path.(binPath / "_storePath") in
       Task.rewritePrefix ~cfg:sandbox.cfg ~origPrefix ~destPrefix binPath
     in
 

--- a/esy/PackageBuilder.ml
+++ b/esy/PackageBuilder.ml
@@ -38,7 +38,7 @@ let run
     | `Log ->
       let logPath = Sandbox.Path.toPath sandbox.buildConfig (Task.logPath task) in
       let%lwt fd = Lwt_unix.openfile
-        (Path.toString logPath)
+        (Path.show logPath)
         Lwt_unix.[O_WRONLY; O_CREAT]
         0o644
       in

--- a/esy/Sandbox.ml
+++ b/esy/Sandbox.ml
@@ -420,7 +420,7 @@ let make ~(cfg : Config.t) (spec : EsyInstall.SandboxSpec.t) =
 
           let pkg = {
             Package.
-            id = Path.toString path;
+            id = Path.show path;
             name = Manifest.name manifest;
             version = Manifest.version manifest;
             build;
@@ -473,7 +473,7 @@ let make ~(cfg : Config.t) (spec : EsyInstall.SandboxSpec.t) =
       in
       let pkg = {
         Package.
-        id = Path.toString path;
+        id = Path.show path;
         name;
         version = Source.show source;
         build = Manifest.Build.empty;

--- a/esy/Scope.ml
+++ b/esy/Scope.ml
@@ -171,7 +171,7 @@ end = struct
       else installPath scope
     in
 
-    let p v = Sandbox.Value.toString (Sandbox.Path.toValue v) in
+    let p v = Sandbox.Value.show (Sandbox.Path.toValue v) in
 
     (* add builtins *)
     let env =
@@ -376,7 +376,7 @@ let env ~includeBuildEnv scope =
 let toOpamEnv ~ocamlVersion (scope : t) (name : OpamVariable.Full.t) =
   let open OpamVariable in
 
-  let opamArch = System.Arch.(toString host) in
+  let opamArch = System.Arch.(show host) in
 
   let opamOs =
     match scope.platform with

--- a/esy/Task.ml
+++ b/esy/Task.ml
@@ -86,7 +86,7 @@ let renderEsyCommands ~env scope commands =
   let open Run.Syntax in
   let envScope name =
     match Sandbox.Environment.find name env with
-    | Some v -> Some (Sandbox.Value.toString v)
+    | Some v -> Some (Sandbox.Value.show v)
     | None -> None
   in
 
@@ -127,7 +127,7 @@ let renderOpamSubstsAsCommands _opamEnv substs =
   let commands =
     let f path =
       let path = Path.addExt ".in" path in
-      [Sandbox.Value.v "substs"; Sandbox.Value.v (Path.toString path)]
+      [Sandbox.Value.v "substs"; Sandbox.Value.v (Path.show path)]
     in
     List.map ~f substs
   in
@@ -148,7 +148,7 @@ let renderOpamPatchesToCommands opamEnv patches =
     let%bind filtered = Result.List.map ~f:evalFilter patches in
 
     let toCommand (path, _) =
-      let cmd = ["patch"; "--strip"; "1"; "--input"; Path.toString path] in
+      let cmd = ["patch"; "--strip"; "1"; "--input"; Path.show path] in
       List.map ~f:Sandbox.Value.v cmd
     in
 
@@ -299,7 +299,7 @@ let ofSandbox
 
         (* a special tag which is communicated by the installer and specifies
          * the version of distribution of vcs commit sha *)
-        let source = Manifest.Source.toString pkg.source in
+        let source = Manifest.Source.show pkg.source in
 
         let sandboxEnv =
           sandbox.env

--- a/esy/bin/esyCommand.ml
+++ b/esy/bin/esyCommand.ml
@@ -23,7 +23,7 @@ module EsyRuntime = struct
           Printf.sprintf
           "unable to resolve %s from %s"
           req
-          (Path.toString currentDirname)
+          (Path.show currentDirname)
         in
         RunAsync.error msg
       | Error (`Msg err) -> RunAsync.error err
@@ -307,8 +307,8 @@ module SandboxInfo = struct
 
   let cachePath (cfg : Config.t) (spec : EsyInstall.SandboxSpec.t) =
     let hash = [
-      Path.toString cfg.storePath;
-      Path.toString spec.path;
+      Path.show cfg.storePath;
+      Path.show spec.path;
       cfg.esyVersion
     ]
       |> String.concat "$$"
@@ -329,7 +329,7 @@ module SandboxInfo = struct
         in
         let cachePath = cachePath cfg info.spec in
         let%bind () = Fs.createDir (Path.parent cachePath) in
-        Lwt_io.with_file ~mode:Lwt_io.Output (Path.toString cachePath) f
+        Lwt_io.with_file ~mode:Lwt_io.Output (Path.show cachePath) f
       in
 
       let%bind () =
@@ -341,7 +341,7 @@ module SandboxInfo = struct
               let%lwt () = Lwt_io.flush oc in
               return ()
             in
-            Lwt_io.with_file ~mode:Lwt_io.Output (Path.toString filename) f
+            Lwt_io.with_file ~mode:Lwt_io.Output (Path.show filename) f
           in
           let sandboxBin = Path.(info.spec.path / "node_modules" / ".cache" / "_esy" / "build" / "bin") in
           let%bind () = Fs.createDir sandboxBin in
@@ -396,7 +396,7 @@ module SandboxInfo = struct
         then return None
         else return (Some info)
       in
-      try%lwt Lwt_io.with_file ~mode:Lwt_io.Input (Path.toString cachePath) f
+      try%lwt Lwt_io.with_file ~mode:Lwt_io.Input (Path.show cachePath) f
       with | Unix.Unix_error _ -> return None
     in Perf.measureLwt ~label:"reading sandbox info cache" f
 
@@ -467,7 +467,7 @@ module SandboxInfo = struct
       | Some task ->
         Sandbox.Path.(Task.installPath task / "lib")
         |> Sandbox.Path.toPath sandbox.Sandbox.buildConfig
-        |> Path.toString
+        |> Path.show
       | None -> ""
     in
     let env =
@@ -532,7 +532,7 @@ module SandboxInfo = struct
       let env =
         `CustomEnv Astring.String.Map.(
           empty |>
-          add "OCAMLPATH" (Path.toString ocamlpath)
+          add "OCAMLPATH" (Path.show ocamlpath)
       ) in
       let cmd = Cmd.(
         v (p ocamlfind)
@@ -604,7 +604,7 @@ let withBuildTaskByPath
     let findByPath (task : Task.t) =
       let pkg = Task.pkg task in
       Path.Set.mem packagePath pkg.originPath
-      || String.equal (Path.toString packagePath) pkg.id
+      || String.equal (Path.show packagePath) pkg.id
     in
     begin match Task.Graph.find ~f:findByPath info.task with
     | None -> errorf "No package found at %a" Path.pp packagePath
@@ -898,7 +898,7 @@ let makeLsCommand ~computeTermNode ~includeTransitive (info: SandboxInfo.t) =
     )
   in
   match%bind Task.Graph.fold ~f ~init:(return None) info.task with
-  | Some tree -> return (print_endline (TermTree.toString tree))
+  | Some tree -> return (print_endline (TermTree.render tree))
   | None -> return ()
 
 let formatPackageInfo ~built:(built : bool)  (task : Task.t) =
@@ -987,7 +987,7 @@ let lsModules copts only () =
       Path.ofString (meta.location ^ Path.dirSep ^ meta.archive) |> function
       | Ok archive ->
         if%bind Fs.exists archive then begin
-          let archive = Path.toString archive in
+          let archive = Path.show archive in
           let%bind lines =
             SandboxInfo.modules ~ocamlobjinfo archive
           in
@@ -1134,12 +1134,12 @@ let add ({CommonOptions. installSandbox; _} as copts) (reqs : string list) () =
           let constr =
             match record.Solution.Record.version with
             | Version.Npm version ->
-              SemverVersion.Formula.DNF.toString
+              SemverVersion.Formula.DNF.show
                 (SemverVersion.caretRangeOfVersion version)
             | Version.Opam version ->
               OpamPackage.Version.to_string version
             | Version.Source _ ->
-              Version.toString record.Solution.Record.version
+              Version.show record.Solution.Record.version
           in
           name, `String constr
         | None -> assert false
@@ -1337,7 +1337,7 @@ let gc (copts : CommonOptions.t) dryRun (roots : Path.t list) () =
   let perform path =
     if dryRun
     then (
-      print_endline (Path.toString path);
+      print_endline (Path.show path);
       return ()
     ) else Fs.rmPath path
   in

--- a/esyi/Fetch.ml
+++ b/esyi/Fetch.ml
@@ -254,7 +254,7 @@ module Layout = struct
       let convert =
         let f (installation : installation) =
           Format.asprintf "%a" Record.pp installation.record,
-          Path.toString installation.path
+          Path.show installation.path
         in
         List.map ~f layout
       in
@@ -584,7 +584,7 @@ let runLifecycleScript ~installation ~name script =
     let script =
       Printf.sprintf
         "cd %s && %s"
-        (Filename.quote (Path.toString installation.path))
+        (Filename.quote (Path.show installation.path))
         script
     in
     (* TODO(windows): use cmd here *)
@@ -693,8 +693,8 @@ let fetch ~(sandbox : Sandbox.t) (solution : Solution.t) =
           Printf.sprintf
             "inconsistent state: no dist were fetched for %s@%s at %s"
             record.Record.name
-            (Version.toString record.Record.version)
-            (Path.toString path)
+            (Version.show record.Record.version)
+            (Path.show path)
         in
         failwith msg
     in

--- a/esyi/FetchStorage.ml
+++ b/esyi/FetchStorage.ml
@@ -23,8 +23,8 @@ let cacheId source (record : Solution.Record.t) =
     |> String.Sub.v ~start:0 ~stop:8
     |> String.Sub.to_string
   in
-  let version = Version.toString record.version in
-  let source = Source.toString source in
+  let version = Version.show record.version in
+  let source = Source.show source in
   match record.opam with
   | None ->
     Printf.sprintf "%s__%s__%s_v2" record.name version (hash [source])

--- a/esyi/NpmRegistry.ml
+++ b/esyi/NpmRegistry.ml
@@ -171,7 +171,7 @@ let package ~name ~version registry () =
     let desc = Format.asprintf "fetch %s@%a" name SemverVersion.Version.pp version in
     let name = Str.global_replace (Str.regexp "/") "%2f" name in
     let%bind data =
-      let url = registry.url ^ "/" ^ name ^ "/" ^ SemverVersion.Version.toString version in
+      let url = registry.url ^ "/" ^ name ^ "/" ^ SemverVersion.Version.show version in
       retryInCaseOfError ~num:3 ~desc (fun () -> Curl.get url)
     in
     RunAsync.ofRun (

--- a/esyi/OpamManifest.ml
+++ b/esyi/OpamManifest.ml
@@ -24,7 +24,7 @@ module File = struct
     let open RunAsync.Syntax in
     let load () =
       let%bind data = Fs.readFile path in
-      let filename = Path.toString path in
+      let filename = Path.show path in
       return (ofString ?upgradeIfOpamVersionIsLessThan ~filename data)
     in
     match cache with

--- a/esyi/OpamPackageVersion.ml
+++ b/esyi/OpamPackageVersion.ml
@@ -20,14 +20,13 @@ module Version = struct
   let majorMinorPatch _v = None
   let prerelease _v = false
   let stripPrerelease v = v
-  let toString = OpamPackage.Version.to_string
   let to_yojson v = `String (show v)
   let of_yojson = function
     | `String v -> parse v
     | _ -> Error "expected a string"
 
   let ofSemver v =
-    let v = SemverVersion.Version.toString v in
+    let v = SemverVersion.Version.show v in
     parse v
 end
 

--- a/esyi/OpamRegistry.ml
+++ b/esyi/OpamRegistry.ml
@@ -72,7 +72,7 @@ let make ~cfg () =
     let%bind repo =
       let path = Path.(repoPath / "repo") in
       let%bind data = Fs.readFile path in
-      let filename = OpamFile.make (OpamFilename.of_string (Path.toString path)) in
+      let filename = OpamFile.make (OpamFilename.of_string (Path.show path)) in
       let repo = OpamFile.Repo.read_from_string ~filename data in
       return repo
     in

--- a/esyi/Package.ml
+++ b/esyi/Package.ml
@@ -61,17 +61,16 @@ module Resolution = struct
     let resolution = Yojson.Safe.to_string (resolution_to_yojson resolution) in
     name ^ resolution |> Digest.string |> Digest.to_hex
 
-  let toString ({name; resolution;} as r) =
+  let show ({name; resolution;} as r) =
     let resolution =
       match resolution with
-      | Version version -> Version.toString version
+      | Version version -> Version.show version
       | SourceOverride { source; override = _; } ->
-        Source.toString source ^ "@" ^ digest r
+        Source.show source ^ "@" ^ digest r
     in
     name ^ "@" ^ resolution
 
-  let show = toString
-  let pp fmt r = Fmt.string fmt (toString r)
+  let pp fmt r = Fmt.string fmt (show r)
 
 end
 
@@ -242,8 +241,6 @@ module OpamOverride = struct
     exportedEnv: (PackageJson.ExportedEnv.t [@default PackageJson.ExportedEnv.empty]);
     opam: (Opam.t [@default Opam.empty]);
   } [@@deriving (yojson, eq, ord, show)]
-
-  let toString = show
 
   let empty =
     {

--- a/esyi/Package.mli
+++ b/esyi/Package.mli
@@ -66,8 +66,7 @@ module Dependencies : sig
     | OpamFormula of Dep.t disj conj
     | NpmFormula of Req.t conj
 
-  val pp : t Fmt.t
-  val show : t -> string
+  include S.PRINTABLE with type t := t
 
   val toApproximateRequests : t -> Req.t list
 end

--- a/esyi/PackageJson.ml
+++ b/esyi/PackageJson.ml
@@ -6,8 +6,6 @@ module Command = struct
     | Unparsed of string
     [@@deriving (show, eq, ord)]
 
-  let toString = show
-
   let of_yojson (json : Json.t) =
     match json with
     | `String command -> Ok (Unparsed command)
@@ -33,8 +31,6 @@ module CommandList = struct
     [@@deriving (show, eq, ord)]
 
   let empty = []
-
-  let toString = show
 
   let of_yojson (json : Json.t) =
     let open Result.Syntax in
@@ -98,7 +94,6 @@ module Env = struct
     StringMap.pp ~sep:(Fmt.unit ", ") ppItem
 
   let show env = Format.asprintf "%a" pp env
-  let toString = show
 end
 
 module EnvOverride = struct
@@ -183,7 +178,6 @@ module ExportedEnv = struct
     StringMap.pp ~sep:(Fmt.unit ", ") ppItem
 
   let show env = Format.asprintf "%a" pp env
-  let toString = show
 
 end
 

--- a/esyi/Req.ml
+++ b/esyi/Req.ml
@@ -3,16 +3,14 @@ type t = {
   spec: VersionSpec.t;
 } [@@deriving (eq, ord)]
 
-let toString {name; spec} =
-  name ^ "@" ^ (VersionSpec.toString spec)
-
-let show = toString
+let show {name; spec} =
+  name ^ "@" ^ (VersionSpec.show spec)
 
 let to_yojson req =
-  `String (toString req)
+  `String (show req)
 
 let pp fmt req =
-  Fmt.fmt "%s" fmt (toString req)
+  Fmt.fmt "%s" fmt (show req)
 
 let matches ~name ~version req =
   name = req.name && VersionSpec.matches ~version req.spec

--- a/esyi/Resolver.ml
+++ b/esyi/Resolver.ml
@@ -84,7 +84,7 @@ let loadPackageOfGithub ?manifest ~allowEmptyPackage ~name ~version ~source ~use
 
   let filenames =
     match manifest with
-    | Some manifest -> [SandboxSpec.ManifestSpec.toString manifest]
+    | Some manifest -> [SandboxSpec.ManifestSpec.show manifest]
     | None -> ["esy.json"; "package.json"]
   in
 
@@ -163,7 +163,7 @@ let loadPackageOfPath ?manifest ~allowEmptyPackage ~name ~version ~source (path 
   in
   let filenames =
     match manifest with
-    | Some manifest -> [SandboxSpec.ManifestSpec.toString manifest]
+    | Some manifest -> [SandboxSpec.ManifestSpec.show manifest]
     | None -> [
       "esy.json";
       "package.json";

--- a/esyi/SandboxSpec.ml
+++ b/esyi/SandboxSpec.ml
@@ -5,11 +5,10 @@ module ManifestSpec = struct
   | OpamAggregated of string list
   [@@deriving ord, eq]
 
-  let toString = function
-    | Esy fname | Opam fname -> fname
+  let show = function
+    | Esy fname
+    | Opam fname -> fname
     | OpamAggregated fnames -> String.concat "," fnames
-
-  let show = toString
 
   let pp fmt manifest =
     match manifest with
@@ -98,7 +97,7 @@ let name spec =
   | OpamAggregated _ -> "opam"
   | Opam "opam" -> "opam"
   | Esy "package.json" | Esy "esy.json" -> "default"
-  | Opam fname | Esy fname -> Path.(toString (remExt (v fname)))
+  | Opam fname | Esy fname -> Path.(show (remExt (v fname)))
 
 let isDefault spec =
   match spec.manifest with
@@ -180,7 +179,6 @@ let pp fmt spec =
   ManifestSpec.pp fmt spec.manifest
 
 let show spec = Format.asprintf "%a" pp spec
-let toString spec = Format.asprintf "%a" pp spec
 
 module Set = Set.Make(struct
   type nonrec t = t

--- a/esyi/SemverVersion.ml
+++ b/esyi/SemverVersion.ml
@@ -35,7 +35,7 @@ module Version = struct
   let make ?(prerelease=[]) ?(build=[]) major minor patch =
     {major; minor; patch; prerelease; build}
 
-  let toString v =
+  let show v =
     let prelease = match v.prerelease with
     | [] -> ""
     | v -> Format.asprintf "-%a" ppPrerelease v
@@ -46,10 +46,8 @@ module Version = struct
     in
     Format.asprintf "%i.%i.%i%s%s" v.major v.minor v.patch prelease build
 
-  let show = toString
-
   let pp fmt v =
-    Fmt.pf fmt "%s" (toString v)
+    Fmt.pf fmt "%s" (show v)
 
   let majorMinorPatch v = Some (v.major, v.minor, v.patch)
 
@@ -411,7 +409,7 @@ module Version = struct
     | _ -> Error "expected string"
 
   let to_yojson v =
-    `String (toString v)
+    `String (show v)
 
 end
 

--- a/esyi/Solution.ml
+++ b/esyi/Solution.ml
@@ -71,7 +71,7 @@ module Id = struct
     | None -> Error "invalid id"
 
   let to_yojson (name, version) =
-    `String (name ^ "@" ^ Version.toString version)
+    `String (name ^ "@" ^ Version.show version)
 
   let of_yojson = function
     | `String v -> parse v
@@ -94,7 +94,7 @@ module Id = struct
     let to_yojson v_to_yojson map =
       let items =
         let f (name, version) v items =
-          let k = name ^ "@" ^ Version.toString version in
+          let k = name ^ "@" ^ Version.show version in
           (k, v_to_yojson v)::items
         in
         fold f map []

--- a/esyi/Solver.ml
+++ b/esyi/Solver.ml
@@ -550,7 +550,7 @@ let solveDependenciesNaively
 
   let lookupDependencies, addDependencies =
     let solved = Hashtbl.create 100 in
-    let key pkg = pkg.Package.name ^ "." ^ (Version.toString pkg.Package.version) in
+    let key pkg = pkg.Package.name ^ "." ^ (Version.show pkg.Package.version) in
     let lookup pkg =
       Hashtbl.find_opt solved (key pkg)
     in

--- a/esyi/Source.ml
+++ b/esyi/Source.ml
@@ -36,31 +36,29 @@ let manifest (src : t) =
   | Archive _ -> None
   | NoSource -> None
 
-let toString = function
+let show = function
   | Github {user; repo; commit; manifest = None;} ->
     Printf.sprintf "github:%s/%s#%s" user repo commit
   | Github {user; repo; commit; manifest = Some manifest;} ->
-    Printf.sprintf "github:%s/%s:%s#%s" user repo (MS.toString manifest) commit
+    Printf.sprintf "github:%s/%s:%s#%s" user repo (MS.show manifest) commit
   | Git {remote; commit; manifest = None;} ->
     Printf.sprintf "git:%s#%s" remote commit
   | Git {remote; commit; manifest = Some manifest;} ->
-    Printf.sprintf "git:%s:%s#%s" remote (MS.toString manifest) commit
+    Printf.sprintf "git:%s:%s#%s" remote (MS.show manifest) commit
   | Archive {url; checksum} ->
     Printf.sprintf "archive:%s#%s" url (Checksum.show checksum)
   | LocalPath {path; manifest = None;} ->
-    Printf.sprintf "path:%s" (Path.toString path)
+    Printf.sprintf "path:%s" (Path.show path)
   | LocalPath {path; manifest = Some manifest;} ->
-    Printf.sprintf "path:%s/%s" (Path.toString path) (MS.toString manifest)
+    Printf.sprintf "path:%s/%s" (Path.show path) (MS.show manifest)
   | LocalPathLink {path; manifest = None;} ->
-    Printf.sprintf "link:%s" (Path.toString path)
+    Printf.sprintf "link:%s" (Path.show path)
   | LocalPathLink {path; manifest = Some manifest;} ->
-    Printf.sprintf "link:%s/%s" (Path.toString path) (MS.toString manifest)
+    Printf.sprintf "link:%s/%s" (Path.show path) (MS.show manifest)
   | NoSource -> "no-source:"
 
-let show = toString
-
 let pp fmt src =
-  Fmt.pf fmt "%s" (toString src)
+  Fmt.pf fmt "%s" (show src)
 
 module Parse = struct
   include Parse
@@ -243,7 +241,7 @@ let%test_module "parsing" = (module struct
 end)
 
 let to_yojson v =
-  `String (toString v)
+  `String (show v)
 
 let of_yojson json =
   match json with

--- a/esyi/SourceSpec.ml
+++ b/esyi/SourceSpec.ml
@@ -27,24 +27,24 @@ type t =
   | NoSource
   [@@deriving (eq, ord)]
 
-let toString = function
+let show = function
   | Github {user; repo; ref = None; manifest = None;} ->
     Printf.sprintf "github:%s/%s" user repo
   | Github {user; repo; ref = None; manifest = Some manifest;} ->
-    Printf.sprintf "github:%s/%s:%s" user repo (MS.toString manifest)
+    Printf.sprintf "github:%s/%s:%s" user repo (MS.show manifest)
   | Github {user; repo; ref = Some ref; manifest = None} ->
     Printf.sprintf "github:%s/%s#%s" user repo ref
   | Github {user; repo; ref = Some ref; manifest = Some manifest} ->
-    Printf.sprintf "github:%s/%s:%s#%s" user repo (MS.toString manifest) ref
+    Printf.sprintf "github:%s/%s:%s#%s" user repo (MS.show manifest) ref
 
   | Git {remote; ref = None; manifest = None;} ->
     Printf.sprintf "git:%s" remote
   | Git {remote; ref = None; manifest = Some manifest;} ->
-    Printf.sprintf "git:%s:%s" remote (MS.toString manifest)
+    Printf.sprintf "git:%s:%s" remote (MS.show manifest)
   | Git {remote; ref = Some ref; manifest = None} ->
     Printf.sprintf "git:%s#%s" remote ref
   | Git {remote; ref = Some ref; manifest = Some manifest} ->
-    Printf.sprintf "git:%s:%s#%s" remote (MS.toString manifest) ref
+    Printf.sprintf "git:%s:%s#%s" remote (MS.show manifest) ref
 
   | Archive {url; checksum = Some checksum} ->
     Printf.sprintf "archive:%s#%s" url (Checksum.show checksum)
@@ -52,21 +52,21 @@ let toString = function
     Printf.sprintf "archive:%s" url
 
   | LocalPath {path; manifest = None;} ->
-    Printf.sprintf "path:%s" (Path.toString path)
+    Printf.sprintf "path:%s" (Path.show path)
   | LocalPath {path; manifest = Some manifest;} ->
-    Printf.sprintf "path:%s/%s" (Path.toString path) (MS.toString manifest)
+    Printf.sprintf "path:%s/%s" (Path.show path) (MS.show manifest)
 
   | LocalPathLink {path; manifest = None;} ->
-    Printf.sprintf "link:%s" (Path.toString path)
+    Printf.sprintf "link:%s" (Path.show path)
   | LocalPathLink {path; manifest = Some manifest;} ->
-    Printf.sprintf "link:%s/%s" (Path.toString path) (MS.toString manifest)
+    Printf.sprintf "link:%s/%s" (Path.show path) (MS.show manifest)
 
   | NoSource -> "no-source:"
 
-let to_yojson src = `String (toString src)
+let to_yojson src = `String (show src)
 
 let pp fmt spec =
-  Fmt.pf fmt "%s" (toString spec)
+  Fmt.pf fmt "%s" (show spec)
 
 let matches ~source spec =
   let eqManifestName = [%derive.eq: MS.t option] in

--- a/esyi/SourceSpec.mli
+++ b/esyi/SourceSpec.mli
@@ -29,9 +29,9 @@ type t =
     }
   | NoSource
 
-val toString : t -> string
+include S.PRINTABLE with type t := t
+
 val to_yojson : t -> [> `String of string ]
-val pp : t Fmt.t
 val ofSource : Source.t -> t
 val equal : t -> t -> bool
 val compare : t -> t -> int

--- a/esyi/Universe.ml
+++ b/esyi/Universe.ml
@@ -50,7 +50,7 @@ let findVersionExn ~name ~version (univ : t) =
     let msg =
       Printf.sprintf
         "inconsistent state: package not in the universr %s@%s"
-        name (Version.toString version)
+        name (Version.show version)
     in
     failwith msg
 
@@ -117,7 +117,7 @@ module CudfVersionMap = struct
       let msg =
         Printf.sprintf
           "inconsistent state: found a package not in the cudf version map %s@%s"
-          name (Version.toString version)
+          name (Version.show version)
       in
       failwith msg
 

--- a/esyi/Version.ml
+++ b/esyi/Version.ml
@@ -4,16 +4,14 @@ type t =
   | Source of Source.t
   [@@deriving (ord, eq)]
 
-let toString v =
+let show v =
   match v with
-  | Npm t -> SemverVersion.Version.toString(t)
-  | Opam v -> "opam:" ^ OpamPackageVersion.Version.toString(v)
-  | Source src -> (Source.toString src)
-
-let show = toString
+  | Npm t -> SemverVersion.Version.show t
+  | Opam v -> "opam:" ^ OpamPackageVersion.Version.show v
+  | Source src -> (Source.show src)
 
 let pp fmt v =
-  Fmt.fmt "%s" fmt (toString v)
+  Fmt.fmt "%s" fmt (show v)
 
 module Parse = struct
   include Parse
@@ -88,7 +86,7 @@ let parseExn v =
   | Ok v -> v
   | Error err -> failwith err
 
-let to_yojson v = `String (toString v)
+let to_yojson v = `String (show v)
 
 let of_yojson json =
   let open Result.Syntax in
@@ -97,9 +95,9 @@ let of_yojson json =
 
 let toNpmVersion v =
   match v with
-  | Npm v -> SemverVersion.Version.toString(v)
-  | Opam t -> OpamPackageVersion.Version.toString(t)
-  | Source src -> Source.toString src
+  | Npm v -> SemverVersion.Version.show v
+  | Opam t -> OpamPackageVersion.Version.show t
+  | Source src -> Source.show src
 
 module Map = Map.Make(struct
   type nonrec t = t

--- a/esyi/VersionBase.ml
+++ b/esyi/VersionBase.ml
@@ -139,10 +139,8 @@ module Constraint = struct
         then matchesSimple ~version constr
         else false
 
-    let toString c =
-      Format.asprintf "%a" pp c
-
-    let show = toString
+    let show v =
+      Format.asprintf "%a" pp v
 
     let rec map ~f constr =
       match constr with
@@ -240,8 +238,6 @@ module Formula = struct
       let show f =
         Format.asprintf "%a" pp f
 
-      let toString = show
-
       let rec map ~f formulas =
         let mapConj (formulas) =
           (List.map ~f:(Constraint.map ~f) formulas)
@@ -281,8 +277,6 @@ module Formula = struct
 
       let show f =
         Format.asprintf "%a" pp f
-
-      let toString = show
 
       let matches ~version (formulas) =
         let matchesDisj (formulas) =
@@ -374,7 +368,6 @@ let%test_module "Formula" = (module struct
       | Some v -> Ok v
       | None -> Error "not a version"
     let parseExn = int_of_string
-    let toString = string_of_int
   end
 
   module C = Constraint.Make(Version)

--- a/esyi/VersionSpec.ml
+++ b/esyi/VersionSpec.ml
@@ -5,16 +5,16 @@ type t =
   | Source of SourceSpec.t
   [@@deriving (eq, ord)]
 
-let toString = function
-  | Npm formula -> SemverVersion.Formula.DNF.toString formula
+let show = function
+  | Npm formula -> SemverVersion.Formula.DNF.show formula
   | NpmDistTag (tag, _version) -> tag
-  | Opam formula -> OpamPackageVersion.Formula.DNF.toString formula
-  | Source src -> SourceSpec.toString src
+  | Opam formula -> OpamPackageVersion.Formula.DNF.show formula
+  | Source src -> SourceSpec.show src
 
 let pp fmt spec =
-  Fmt.string fmt (toString spec)
+  Fmt.string fmt (show spec)
 
-let to_yojson src = `String (toString src)
+let to_yojson src = `String (show src)
 
 let matches ~version spec =
   match spec, version with

--- a/esyi/VersionSpec.mli
+++ b/esyi/VersionSpec.mli
@@ -9,11 +9,11 @@ type t =
   | Opam of OpamPackageVersion.Formula.DNF.t
   | Source of SourceSpec.t
 
-val pp : t Fmt.t
-val toString : t -> string
-val to_yojson : t -> [> `String of string ]
 
 include S.COMPARABLE with type t := t
+include S.PRINTABLE with type t := t
+
+val to_yojson : t Json.encoder
 
 val parserNpm : t Parse.t
 val parserOpam : t Parse.t

--- a/test/Curl.ml
+++ b/test/Curl.ml
@@ -20,7 +20,7 @@ let%test "curl download simple file" =
             (* We need to normalize the path on Windows - file:///E:/.../ won't work! *)
             (* The normalize gives us a path of the form file:///cygdrive/e/.../ which does. *)
             (* This won't impact HTTP requests though - just our test using the local file system *)
-            let url = EsyBash.normalizePathForCygwin (Path.toString(fileToCurl)) in
+            let url = EsyBash.normalizePathForCygwin (Path.show(fileToCurl)) in
 
             match url with
             | Error _ -> Lwt.return false

--- a/test/Patch.ml
+++ b/test/Patch.ml
@@ -4,7 +4,7 @@ module Path = EsyLib.Path
 let%test "simple patch test" =
     let test () = 
         let f tempPath =
-            print_endline ("Running test: " ^ (Path.toString tempPath));
+            print_endline ("Running test: " ^ (Path.show tempPath));
             let fileToPatch = Path.(tempPath / "input.txt") in
             let patchFile = Path.(tempPath / "patch.txt") in
             let originalContents = "Hello OCaml\n" in

--- a/test/Task.ml
+++ b/test/Task.ml
@@ -55,7 +55,7 @@ module TestCommandExpr = struct
 
   let commandsEqual = [%derive.eq: string list list]
   let checkCommandsEqual commands expectation =
-    let commands = List.map (List.map Sandbox.Value.toString) commands in
+    let commands = List.map (List.map Sandbox.Value.show) commands in
     commandsEqual commands expectation
 
   let dep = Sandbox.Package.{


### PR DESCRIPTION
We already have `show` there and this caused a lot of boilerplate and
confusion on which one to use. I defaulted on `show` as this is what
`ppx_deriving` generates though I'd prefer to have `toString`.

I've left `CudfName.toString` as to be symmetrical to `CudfName.ofString`
and this is actually not for showing values but rather for conversion.