### PR TITLE
Remove equal from COMPARABLE sig

### DIFF
--- a/esy-build-package/Build.re
+++ b/esy-build-package/Build.re
@@ -22,7 +22,7 @@ type t = {
 type build = t;
 
 let isRoot = (build: t) =>
-  Config.Value.equal(build.plan.sourcePath, Config.Value.project);
+  Config.Value.compare(build.plan.sourcePath, Config.Value.project) == 0;
 
 let regex = (base, segments) => {
   let pat = String.concat(Path.dirSep, [Path.show(base), ...segments]);

--- a/esy-build-package/Config.re
+++ b/esy-build-package/Config.re
@@ -99,11 +99,11 @@ module Path: {
         cwd /\/ p;
       };
     let p = normalize(p);
-    if (equal(p, cfg.storePath)) {
+    if (compare(p, cfg.storePath) == 0) {
       store;
-    } else if (equal(p, cfg.localStorePath)) {
+    } else if (compare(p, cfg.localStorePath) == 0) {
       localStore;
-    } else if (equal(p, cfg.projectPath)) {
+    } else if (compare(p, cfg.projectPath) == 0) {
       project;
     } else {
       switch (remPrefix(cfg.storePath, p)) {

--- a/esy-build-package/Plan.re
+++ b/esy-build-package/Plan.re
@@ -2,7 +2,7 @@ module Path = EsyLib.Path;
 
 module Env = EsyLib.Environment.Make(Config.Value);
 
-[@deriving (yojson, ord, eq)]
+[@deriving (yojson, ord)]
 type t = {
   id: string,
   name: string,

--- a/esy-build-package/Run.re
+++ b/esy-build-package/Run.re
@@ -194,7 +194,7 @@ let copyContents = (~from, ~ignore=[], dest) => {
   let f = (path, acc) =>
     switch (acc) {
     | Ok () =>
-      if (Path.equal(path, from)) {
+      if (Path.compare(path, from) == 0) {
         Ok();
       } else if (Path.Set.mem(
                    Path.remEmptySeg(Path.parent(path)),

--- a/esy-lib/Abstract.ml
+++ b/esy-lib/Abstract.ml
@@ -42,7 +42,6 @@ module String = struct
     let pp = Fmt.string
 
     let compare = String.compare
-    let equal = String.equal
 
     let of_yojson = Json.Parse.string
     let to_yojson v = `String v

--- a/esy-lib/BuildType.re
+++ b/esy-lib/BuildType.re
@@ -1,4 +1,4 @@
-[@deriving (show, eq, ord)]
+[@deriving (show, ord)]
 type t =
   | InSource
   | JbuilderLike

--- a/esy-lib/Checksum.ml
+++ b/esy-lib/Checksum.ml
@@ -1,5 +1,5 @@
 type t = kind * string
-[@@deriving eq, ord]
+[@@deriving ord]
 
 and kind =
 | Md5

--- a/esy-lib/Cmd.ml
+++ b/esy-lib/Cmd.ml
@@ -7,7 +7,7 @@
  * reversed argument order.
  *)
 type t = string * string list
-  [@@deriving (eq, ord)]
+  [@@deriving ord]
 
 let v tool = tool, []
 let p = Path.show

--- a/esy-lib/Cmd.mli
+++ b/esy-lib/Cmd.mli
@@ -42,9 +42,7 @@ val getTool : t -> string
 val getArgs : t -> string list
 
 include S.PRINTABLE with type t := t
-
-val equal : t -> t -> bool
-val compare : t -> t -> int
+include S.COMPARABLE with type t := t
 
 val resolveInvocation : string list -> t -> (t, [> `Msg of string ]) result
 (** TODO: remove away, use resolveInvocation instead *)

--- a/esy-lib/Environment.ml
+++ b/esy-lib/Environment.ml
@@ -5,7 +5,7 @@ module Binding = struct
     value : 'v value;
     origin : string option;
   }
-  [@@deriving eq, ord]
+  [@@deriving ord]
 
   and 'v value =
     | Value of 'v
@@ -60,7 +60,7 @@ end = struct
 
   type t =
     V.t StringMap.t
-    [@@deriving ord, eq, yojson]
+    [@@deriving ord, yojson]
 
   type env = t
 
@@ -81,7 +81,7 @@ end = struct
   module Bindings = struct
     type t =
       V.t Binding.t list
-      [@@deriving eq, ord]
+      [@@deriving ord]
 
     let empty = []
     let value ?origin name value = {Binding. name; value = Value value; origin}

--- a/esy-lib/Parse.ml
+++ b/esy-lib/Parse.ml
@@ -31,12 +31,12 @@ let parse p input =
   parse_string (p <* end_of_input) input
 
 module Test = struct
-  let expectParses ~pp ~equal parse input expectation =
+  let expectParses ~pp ~compare parse input expectation =
     match parse input with
     | Error err ->
       Format.printf "Error parsing '%s': %s@\n" input err;
       false
-    | Ok v when equal v expectation -> true
+    | Ok v when compare v expectation = 0 -> true
     | Ok v ->
       Format.printf
       "Error parsing '%s':@\n  expected: %a@\n  got:      %a@\n"

--- a/esy-lib/Path.re
+++ b/esy-lib/Path.re
@@ -60,7 +60,6 @@ let normalizeAndRemoveEmptySeg = p =>
 /* COMPARABLE */
 
 let compare = Fpath.compare;
-let equal = Fpath.equal;
 
 /* PRINTABLE */
 

--- a/esy-lib/S.ml
+++ b/esy-lib/S.ml
@@ -15,7 +15,6 @@ end
 module type COMPARABLE = sig
   type t
 
-  val equal : t -> t -> bool
   val compare : t -> t -> int
 end
 

--- a/esy-lib/SourceType.re
+++ b/esy-lib/SourceType.re
@@ -1,4 +1,4 @@
-[@deriving (show, eq, ord)]
+[@deriving (show, ord)]
 type t =
   | Immutable
   | Transient;

--- a/esy-lib/StringMap.ml
+++ b/esy-lib/StringMap.ml
@@ -36,7 +36,6 @@ let of_yojson v_of_yojson =
   | _ -> Error "expected an object"
 
 type 'a stringMap = 'a t
-let equal_stringMap = equal
 let compare_stringMap = compare
 
 module Override : sig
@@ -50,7 +49,6 @@ module Override : sig
   val apply : 'a stringMap -> 'a t -> 'a stringMap
 
   val compare : ('a -> 'a -> int) -> 'a t -> 'a t -> int
-  val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
 
   val of_yojson :
     (string -> Yojson.Safe.json -> ('a, string) result)
@@ -64,7 +62,7 @@ end = struct
 
   type 'a t =
     'a override stringMap
-    [@@deriving eq, ord]
+    [@@deriving ord]
 
   and 'a override =
     | Drop
@@ -115,20 +113,20 @@ end = struct
     let override = empty |> add "c" (Edit "d") in
     let result = apply orig override in
     let expect = empty |> add "a" "b" |> add "c" "d" in
-    equal_stringMap String.equal result expect
+    compare_stringMap String.compare result expect = 0
 
   let%test "apply: drop key" =
     let orig = empty |> add "a" "b" |> add "c" "d" in
     let override = empty |> add "c" Drop in
     let result = apply orig override in
     let expect = empty |> add "a" "b" in
-    equal_stringMap String.equal result expect
+    compare_stringMap String.compare result expect = 0
 
   let%test "apply: replace key" =
     let orig = empty |> add "a" "b" |> add "c" "d" in
     let override = empty |> add "c" (Edit "d!") in
     let result = apply orig override in
     let expect = empty |> add "a" "b" |> add "c" "d!" in
-    equal_stringMap String.equal result expect
+    compare_stringMap String.compare result expect = 0
 
 end

--- a/esy-lib/System.ml
+++ b/esy-lib/System.ml
@@ -6,7 +6,7 @@ module Platform = struct
     | Windows (* mingw msvc *)
     | Unix (* all other unix-y systems *)
     | Unknown
-    [@@deriving eq, ord]
+    [@@deriving ord]
 
   let show = function
     | Darwin -> "darwin"
@@ -45,7 +45,7 @@ module Arch = struct
     | Arm32
     | Arm64
     | Unknown
-    [@@deriving eq, ord]
+    [@@deriving ord]
 
   let show = function
     | X86_32 -> "x86_32"

--- a/esy/Manifest.ml
+++ b/esy/Manifest.ml
@@ -93,11 +93,11 @@ module Scripts = struct
   type script = {
     command : Command.t;
   }
-  [@@deriving (eq, ord)]
+  [@@deriving ord]
 
   type t =
     script StringMap.t
-    [@@deriving (eq, ord)]
+    [@@deriving ord]
 
   let empty = StringMap.empty
 

--- a/esy/Sandbox.ml
+++ b/esy/Sandbox.ml
@@ -329,7 +329,7 @@ let make ~(cfg : Config.t) (spec : EsyInstall.SandboxSpec.t) =
         | None -> deps
       in
       let%lwt devDependencies =
-        if Path.equal buildConfig.EsyBuildPackage.Config.projectPath path
+        if Path.compare buildConfig.EsyBuildPackage.Config.projectPath path = 0
         then
           addDependencies
             ~ignoreCircularDep
@@ -366,7 +366,7 @@ let make ~(cfg : Config.t) (spec : EsyInstall.SandboxSpec.t) =
     in
 
     let%bind manifest, source, sourcePath, packagesPath, override =
-      let asRoot = Path.equal path spec.path in
+      let asRoot = Path.compare path spec.path = 0 in
       if asRoot
       then
         let%bind m = Manifest.ofSandboxSpec spec in

--- a/esy/bin/esyCommand.ml
+++ b/esy/bin/esyCommand.ml
@@ -170,7 +170,7 @@ module CommonOptions = struct
       then return path
       else
         let parent = Path.parent path in
-        if not (Path.equal path parent)
+        if not (Path.compare path parent = 0)
         then climb (Path.parent path)
         else
           let%bind msg = RunAsync.ofRun (

--- a/esyi/Fetch.ml
+++ b/esyi/Fetch.ml
@@ -115,7 +115,7 @@ module Layout = struct
         let rec aux = function
           | (modules, path)::rest ->
             Hashtbl.replace modules record.Record.name record;
-            if Path.equal insertionPath path
+            if Path.compare insertionPath path = 0
             then ()
             else aux rest
           | [] -> ()
@@ -129,7 +129,7 @@ module Layout = struct
         | ((modules, _) as here)::upTheTree ->
           begin match Hashtbl.find_opt modules record.Record.name with
           | Some r ->
-            if Record.equal r record
+            if Record.compare r record = 0
             then `Done (here, here::upTheTree)
             else `None
           | None ->

--- a/esyi/OpamPackageVersion.ml
+++ b/esyi/OpamPackageVersion.ml
@@ -5,7 +5,6 @@ module P = Parse
 module Version = struct
   type t = OpamPackage.Version.t
 
-  let equal a b = OpamPackage.Version.compare a b = 0
   let compare = OpamPackage.Version.compare
   let show = OpamPackage.Version.to_string
   let pp fmt v = Fmt.pf fmt "opam:%s" (show v)

--- a/esyi/Package.ml
+++ b/esyi/Package.ml
@@ -1,9 +1,9 @@
 module String = Astring.String
 
 [@@@ocaml.warning "-32"]
-type 'a disj = 'a list [@@deriving eq]
+type 'a disj = 'a list
 [@@@ocaml.warning "-32"]
-type 'a conj = 'a list [@@deriving eq]
+type 'a conj = 'a list
 
 module Override = struct
   module BuildType = struct
@@ -20,7 +20,7 @@ module Override = struct
     buildEnv: PackageJson.Env.t option [@default None];
     buildEnvOverride: PackageJson.EnvOverride.t option [@default None];
     dependencies : PackageJson.Dependencies.t option [@default None];
-  } [@@deriving yojson, eq, ord]
+  } [@@deriving yojson, ord]
 end
 
 module Resolution = struct
@@ -29,7 +29,7 @@ module Resolution = struct
     name : string;
     resolution : resolution;
   }
-  [@@deriving eq, ord]
+  [@@deriving ord]
 
   and resolution =
     | Version of Version.t
@@ -213,7 +213,7 @@ module File = struct
     content : string;
     (* file, permissions add 0o644 default for backward compat. *)
     perm : (int [@default 0o644]);
-  } [@@deriving (yojson, show, ord, eq)]
+  } [@@deriving yojson, show, ord]
 end
 
 module OpamOverride = struct
@@ -222,7 +222,7 @@ module OpamOverride = struct
     type t = {
       source: (source option [@default None]);
       files: (File.t list [@default []]);
-    } [@@deriving (yojson, eq, ord, show)]
+    } [@@deriving yojson, ord, show]
 
     and source = {
       url: string;
@@ -240,7 +240,7 @@ module OpamOverride = struct
     peerDependencies: (PackageJson.Dependencies.t [@default PackageJson.Dependencies.empty]) ;
     exportedEnv: (PackageJson.ExportedEnv.t [@default PackageJson.ExportedEnv.empty]);
     opam: (Opam.t [@default Opam.empty]);
-  } [@@deriving (yojson, eq, ord, show)]
+  } [@@deriving yojson, ord, show]
 
   let empty =
     {

--- a/esyi/Package.mli
+++ b/esyi/Package.mli
@@ -78,9 +78,8 @@ module File : sig
     perm : int;
   }
 
-  val equal : t -> t -> bool
-  val to_yojson : t Json.encoder
-  val of_yojson : t Json.decoder
+  include S.COMPARABLE with type t := t
+  include S.JSONABLE with type t := t
 end
 
 module OpamOverride : sig

--- a/esyi/PackageJson.ml
+++ b/esyi/PackageJson.ml
@@ -4,7 +4,7 @@ module Command = struct
   type t =
     | Parsed of string list
     | Unparsed of string
-    [@@deriving (show, eq, ord)]
+    [@@deriving show, ord]
 
   let of_yojson (json : Json.t) =
     match json with
@@ -28,7 +28,7 @@ module CommandList = struct
   [@@@ocaml.warning "-32"]
   type t =
     Command.t list
-    [@@deriving (show, eq, ord)]
+    [@@deriving show, ord]
 
   let empty = []
 
@@ -54,11 +54,11 @@ module Env = struct
     name : string;
     value : string;
   }
-  [@@deriving (show, eq, ord)]
+  [@@deriving show, ord]
 
   type t =
     item StringMap.t
-    [@@deriving (eq, ord)]
+    [@@deriving ord]
 
   let empty = StringMap.empty
 
@@ -97,7 +97,7 @@ module Env = struct
 end
 
 module EnvOverride = struct
-  type t = Env.item StringMap.Override.t [@@deriving eq, ord]
+  type t = Env.item StringMap.Override.t [@@deriving ord]
   let of_yojson = StringMap.Override.of_yojson Env.item_of_yojson
   let to_yojson = StringMap.Override.to_yojson Env.item_to_yojson
 end
@@ -108,7 +108,7 @@ module ExportedEnv = struct
   type scope =
     | Local
     | Global
-    [@@deriving (show, eq, ord)]
+    [@@deriving show, ord]
 
   let scope_of_yojson = function
     | `String "global" -> Ok Global
@@ -135,10 +135,10 @@ module ExportedEnv = struct
     scope : scope;
     exclusive : bool;
   }
-  [@@deriving (show, eq, ord)]
+  [@@deriving show, ord]
 
   type t = item StringMap.t
-    [@@deriving (eq, ord)]
+    [@@deriving ord]
 
   let empty = StringMap.empty
 
@@ -185,7 +185,7 @@ module ExportedEnvOverride = struct
 
   type t =
     ExportedEnv.item StringMap.Override.t
-    [@@deriving (ord, eq)]
+    [@@deriving ord]
 
   let of_yojson = StringMap.Override.of_yojson ExportedEnv.item_of_yojson
   let to_yojson = StringMap.Override.to_yojson ExportedEnv.item_to_yojson
@@ -194,7 +194,7 @@ end
 
 module Dependencies = struct
 
-  type t = Req.t list [@@deriving (eq, ord)]
+  type t = Req.t list [@@deriving ord]
 
   let empty = []
 

--- a/esyi/PackagePath.ml
+++ b/esyi/PackagePath.ml
@@ -2,7 +2,7 @@ module String = Astring.String
 
 type t =
   segment list * string
-  [@@deriving (eq, ord)]
+  [@@deriving ord]
 
 and segment =
   | Pkg of string
@@ -17,6 +17,8 @@ let show (path, pkg) =
     |> List.map ~f:(function | Pkg name -> name | AnyPkg -> "**")
     |> String.concat ~sep:"/"
   in path ^ "/" ^ pkg
+
+let pp fmt v = Fmt.pf fmt "%s" (show v)
 
 let parse v =
   let parts = String.cuts ~empty:true ~sep:(("/")[@reason.raw_literal "/"]) v in

--- a/esyi/PackagePath.mli
+++ b/esyi/PackagePath.mli
@@ -14,11 +14,11 @@ and segment =
   | Pkg of string
   | AnyPkg
 
-val show : t -> string
 val parse : string -> (t, string) result
 
-val equal : t -> t -> bool
-val compare : t -> t -> int
+include S.PRINTABLE with type t := t
+include S.COMPARABLE with type t := t
+include S.JSONABLE with type t := t
 
 val to_yojson : t Json.encoder
 val of_yojson : t Json.decoder

--- a/esyi/Req.ml
+++ b/esyi/Req.ml
@@ -1,7 +1,7 @@
 type t = {
   name: string;
   spec: VersionSpec.t;
-} [@@deriving (eq, ord)]
+} [@@deriving ord]
 
 let show {name; spec} =
   name ^ "@" ^ (VersionSpec.show spec)
@@ -360,7 +360,7 @@ let%test_module "parsing" = (module struct
   let expectParsesTo input e =
     match parse input with
     | Ok req ->
-      if equal req e
+      if compare req e = 0
       then true
       else (
         Format.printf "@[<v>parsing: %s@\n     got: %a@\nexpected: %a@\n@]@\n" input pp req pp e;

--- a/esyi/SandboxSpec.ml
+++ b/esyi/SandboxSpec.ml
@@ -3,7 +3,7 @@ module ManifestSpec = struct
   | Esy of string
   | Opam of string
   | OpamAggregated of string list
-  [@@deriving ord, eq]
+  [@@deriving ord]
 
   let show = function
     | Esy fname
@@ -83,13 +83,13 @@ end
 type t = {
   path : Path.t;
   manifest : ManifestSpec.t
-} [@@deriving ord, eq]
+} [@@deriving ord]
 
 let doesPathReferToConcreteManifest path =
   Path.(
     hasExt ".json" path
     || hasExt ".opam" path
-    || Path.(equal path (v "opam"))
+    || Path.(compare path (v "opam") = 0)
   )
 
 let name spec =

--- a/esyi/SemverVersion.ml
+++ b/esyi/SemverVersion.ml
@@ -7,7 +7,7 @@ module Version = struct
     patch : int;
     prerelease : prerelease;
     build : build;
-  } [@@deriving eq]
+  }
 
   and prerelease = segment list
 
@@ -210,7 +210,7 @@ module Version = struct
       match e, p with
       | Error _, Error _ -> true
       | Ok e, Ok p ->
-        if equal p e
+        if compare p e = 0
         then true
         else (
           Format.printf
@@ -709,7 +709,7 @@ module Formula = struct
       match e, p with
       | Error _, Error _ -> true
       | Ok e, Ok p ->
-        if DNF.equal p e
+        if DNF.compare p e = 0
         then true
         else (
           Format.printf

--- a/esyi/Solution.ml
+++ b/esyi/Solution.ml
@@ -46,18 +46,17 @@ module Record = struct
     then Version.compare a.version b.version
     else c
 
-  let equal a b =
-    String.equal a.name b.name && Version.equal a.version b.version
-
   let pp fmt record =
     Fmt.pf fmt "%s@%a" record.name Version.pp record.version
+
+  let show = Format.asprintf "%a" pp
 
   module Map = Map.Make(struct type nonrec t = t let compare = compare end)
   module Set = Set.Make(struct type nonrec t = t let compare = compare end)
 end
 
 module Id = struct
-  type t = string * Version.t [@@deriving (ord, eq)]
+  type t = string * Version.t [@@deriving ord]
 
   let rec parse v =
     let open Result.Syntax in
@@ -122,7 +121,7 @@ and t = {
   root : Id.t option;
   records : Record.t Id.Map.t;
   dependencies : Id.Set.t Id.Map.t;
-} [@@deriving eq]
+}
 
 let root sol =
   match sol.root with
@@ -254,7 +253,7 @@ module LockfileV1 = struct
 
   let solutionOfLockfile root node =
     let f id {record; dependencies} sol =
-      if Id.equal root id
+      if Id.compare root id = 0
       then addRoot ~record ~dependencies sol
       else add ~record ~dependencies sol
     in

--- a/esyi/Solution.mli
+++ b/esyi/Solution.mli
@@ -25,8 +25,8 @@ module Record : sig
     opam : Opam.t option;
   }
 
-  val pp : t Fmt.t
-  val equal : t -> t -> bool
+  include S.COMPARABLE with type t := t
+  include S.PRINTABLE with type t := t
 
   module Map : Map.S with type key := t
   module Set : Set.S with type elt := t
@@ -47,8 +47,6 @@ type t
 val root : t -> Record.t option
 val dependencies : Record.t -> t -> Record.Set.t
 val records : t -> Record.Set.t
-
-val equal : t -> t -> bool
 
 val empty : t
 

--- a/esyi/Solver.ml
+++ b/esyi/Solver.ml
@@ -205,7 +205,7 @@ let solutionRecordOfPkg (pkg : Package.t) =
         version = opam.version;
         opam = opam.opam;
         override =
-          if Package.OpamOverride.equal opam.override Package.OpamOverride.empty
+          if Package.OpamOverride.compare opam.override Package.OpamOverride.empty = 0
           then None
           else Some opam.override;
       }

--- a/esyi/Source.ml
+++ b/esyi/Source.ml
@@ -25,7 +25,7 @@ type t =
       manifest : SandboxSpec.ManifestSpec.t option;
     }
   | NoSource
-  [@@deriving (ord, eq)]
+  [@@deriving ord]
 
 let manifest (src : t) =
   match src with
@@ -137,7 +137,7 @@ let parse = Parse.(parse parser)
 let%test_module "parsing" = (module struct
 
   let expectParses =
-    Parse.Test.expectParses ~pp ~equal parse
+    Parse.Test.expectParses ~pp ~compare parse
 
   let%test "github:user/repo#commit" =
     expectParses

--- a/esyi/SourceSpec.mli
+++ b/esyi/SourceSpec.mli
@@ -30,11 +30,10 @@ type t =
   | NoSource
 
 include S.PRINTABLE with type t := t
+include S.COMPARABLE with type t := t
 
 val to_yojson : t -> [> `String of string ]
 val ofSource : Source.t -> t
-val equal : t -> t -> bool
-val compare : t -> t -> int
 val matches : source:Source.t -> t -> bool
 
 val parser : t Parse.t

--- a/esyi/Version.ml
+++ b/esyi/Version.ml
@@ -2,7 +2,7 @@ type t =
   | Npm of SemverVersion.Version.t
   | Opam of OpamPackageVersion.Version.t
   | Source of Source.t
-  [@@deriving (ord, eq)]
+  [@@deriving ord]
 
 let show v =
   match v with
@@ -42,7 +42,7 @@ let parse ?(tryAsOpam=false) =
 
 let%test_module "parsing" = (module struct
 
-  let expectParses = Parse.Test.expectParses ~pp ~equal
+  let expectParses = Parse.Test.expectParses ~pp ~compare
 
   let%test "1.0.0" =
     expectParses

--- a/esyi/VersionBase.ml
+++ b/esyi/VersionBase.ml
@@ -95,7 +95,7 @@ module Constraint = struct
       | LTE of Version.t
       | NONE
       | ANY
-      [@@deriving (yojson, eq, ord)]
+      [@@deriving (yojson, ord)]
 
     let pp fmt = function
       | EQ v -> Fmt.pf fmt "=%a" Version.pp v
@@ -168,17 +168,17 @@ module Formula = struct
     type constr = Constraint.t
 
     [@@@ocaml.warning "-32"]
-    type 'f conj = 'f list [@@deriving (show, yojson, eq, ord)]
+    type 'f conj = 'f list [@@deriving (show, yojson, ord)]
 
     [@@@ocaml.warning "-32"]
-    type 'f disj = 'f list [@@deriving (show, yojson, eq, ord)]
+    type 'f disj = 'f list [@@deriving (show, yojson, ord)]
 
     module VersionSet = Constraint.VersionSet
 
     module DNF = struct
       type t =
         Constraint.t conj disj
-        [@@deriving (yojson, eq, ord)]
+        [@@deriving (yojson, ord)]
 
       let unit constr =
         [[constr]]
@@ -264,7 +264,7 @@ module Formula = struct
       [@@@ocaml.warning "-32"]
       type t =
         Constraint.t disj conj
-        [@@deriving yojson, eq, ord]
+        [@@deriving yojson, ord]
 
       let pp fmt f =
         let ppDisj fmt = function
@@ -356,7 +356,6 @@ let%test_module "Formula" = (module struct
   module Version = struct
     type t = int [@@deriving yojson]
     let majorMinorPatch n = Some (n, 0, 0)
-    let equal = (=)
     let compare = compare
     let pp = Fmt.int
     let show = string_of_int

--- a/esyi/VersionSpec.ml
+++ b/esyi/VersionSpec.ml
@@ -3,7 +3,7 @@ type t =
   | NpmDistTag of string * SemverVersion.Version.t option
   | Opam of OpamPackageVersion.Formula.DNF.t
   | Source of SourceSpec.t
-  [@@deriving (eq, ord)]
+  [@@deriving ord]
 
 let show = function
   | Npm formula -> SemverVersion.Formula.DNF.show formula
@@ -23,7 +23,7 @@ let matches ~version spec =
   | Npm _, _ -> false
 
   | NpmDistTag (_tag, Some resolvedVersion), Version.Npm version ->
-    SemverVersion.Version.equal resolvedVersion version
+    SemverVersion.Version.compare resolvedVersion version = 0
   | NpmDistTag (_tag, None), Version.Npm _ -> assert false
   | NpmDistTag (_tag, _), _ -> false
 


### PR DESCRIPTION
Similar to how we removed toStirng from PRINTABLE now we remove equal from COMPARABLE.

Next step in this direction will be to ditch ppx_deriving and rely on ppx_compare to generate compare functions (this one does have better error messages and locations and also more "modern"-ish).