### PR TITLE
Refactor esy manifest loading

### DIFF
--- a/esy/Manifest.mli
+++ b/esy/Manifest.mli
@@ -128,8 +128,7 @@ include MANIFEST
  * load manifest. Client code can check those paths to invalidate caches.
  *)
 val ofDir :
-  ?name:string
-  -> ?manifest:EsyInstall.SandboxSpec.ManifestSpec.t
+  ?manifest:EsyInstall.SandboxSpec.ManifestSpec.t
   -> Path.t
   -> (t * Path.Set.t) option RunAsync.t
 

--- a/esy/Sandbox.ml
+++ b/esy/Sandbox.ml
@@ -380,7 +380,6 @@ let make ~(cfg : Config.t) (spec : EsyInstall.SandboxSpec.t) =
           | _ -> path
         in
         let%bind m = Manifest.ofDir
-          ?name
           ?manifest:(Source.manifest link.source)
           sourcePath
         in


### PR DESCRIPTION
This cleans up how esy loads & treats manifests from `node_modules`.

Note that `esy build` still supports two cases:

a. `node_modules` produced by `esy install` command (populated with `_esylink` files)
b. `node_modules` produced with any other installer (no `_esylink` files)
c. mixed variant between a. and b.

- `module type MANIFEST` defines an API which should be implemented by modules which load manifests from a directory
- `module Manifest` provides facade API which discovers which concrete impl. to use. It was refactored to store a first class module to a concrete impl. Previously it was a variant which resulted in unneeded boilerplate which just dispatched `MANIFEST` API to the right branch.
- `module EsyManifest` — loads manifests from esy metadata
- `module OpamManifest` (split from `Opam`) — loads manifests from installed opam packages (by consulting `_esylink`) or by reading a specified `*.opam` file.
- `module OpamRootManifest` (split from `Opam`) — loads manifests from a set of `*.opam` files found at the root of a sandbox. This behaves differently than `OpamManifest` as it aggregates info from all specified `*.opam` files.