### PR TITLE
Support resolving metadata from https sources

### DIFF
--- a/esyi/FetchStorage.ml
+++ b/esyi/FetchStorage.ml
@@ -1,5 +1,106 @@
 module String = Astring.String
 
+let sourceTarballPath ~cfg source =
+  let id = Path.safePath (Source.show source) in
+  Path.(cfg.Config.cacheTarballsPath // v id |> addExt "tgz")
+
+let fetchSourceIntoPath' source path =
+  let open RunAsync.Syntax in
+  match source with
+
+  | Source.LocalPath { path = srcPath; manifest = _; } ->
+    let%bind names = Fs.listDir srcPath in
+    let copy name =
+      let src = Path.(srcPath / name) in
+      let dst = Path.(path / name) in
+      Fs.copyPath ~src ~dst
+    in
+    let%bind () =
+      RunAsync.List.waitAll (List.map ~f:copy names)
+    in
+    return (Ok ())
+
+  | Source.LocalPathLink _ ->
+    (* this case is handled separately *)
+    return (Ok ())
+
+  | Source.NoSource ->
+    return (Ok ())
+
+  | Source.Archive {url; checksum}  ->
+    let f tempPath =
+      let%bind () = Fs.createDir tempPath in
+      let tarballPath = Path.(tempPath / Filename.basename url) in
+      match%lwt Curl.download ~output:tarballPath url with
+      | Ok () ->
+        let%bind () = Checksum.checkFile ~path:tarballPath checksum in
+        let%bind () = Tarball.unpack ~stripComponents:1 ~dst:path tarballPath in
+        return (Ok ())
+      | Error err -> return (Error err)
+    in
+    Fs.withTempDir f
+
+  | Source.Github github ->
+    let f tempPath =
+      let%bind () = Fs.createDir tempPath in
+      let tarballPath = Path.(tempPath / "package.tgz") in
+      let%bind () =
+        let url =
+          Printf.sprintf
+            "https://api.github.com/repos/%s/%s/tarball/%s"
+            github.user github.repo github.commit
+        in
+        Curl.download ~output:tarballPath url
+      in
+      let%bind () =  Tarball.unpack ~stripComponents:1 ~dst:path tarballPath in
+      return (Ok ())
+    in
+    Fs.withTempDir f
+
+  | Source.Git git ->
+    let%bind () = Git.clone ~dst:path ~remote:git.remote () in
+    let%bind () = Git.checkout ~ref:git.commit ~repo:path () in
+    let%bind () = Fs.rmPath Path.(path / ".git") in
+    return (Ok ())
+
+let fetchSourceIntoCache ~cfg source =
+  let open RunAsync.Syntax in
+  let tarballPath = sourceTarballPath ~cfg source in
+
+  let%bind tarballIsInCache = Fs.exists tarballPath in
+
+  match tarballIsInCache with
+  | true ->
+    return (Ok tarballPath)
+  | false ->
+    Fs.withTempDir (fun sourcePath ->
+      let%bind fetched =
+        RunAsync.contextf (
+          let%bind () = Fs.createDir sourcePath in
+          fetchSourceIntoPath' source sourcePath
+        )
+        "fetching %a" Source.pp source
+      in
+
+      match fetched with
+      | Ok () ->
+        let%bind () =
+          let%bind () = Fs.createDir (Path.parent tarballPath) in
+          let tempTarballPath = Path.(tarballPath |> addExt ".tmp") in
+          let%bind () = Tarball.create ~filename:tempTarballPath sourcePath in
+          let%bind () = Fs.rename ~src:tempTarballPath tarballPath in
+          return ()
+        in
+        return (Ok tarballPath)
+      | Error err -> return (Error err)
+    )
+
+let fetchSource ~cfg source =
+  let open RunAsync.Syntax in
+  match%bind fetchSourceIntoCache ~cfg source with
+  | Ok tarballPath -> return tarballPath
+  | Error err -> Lwt.return (Error err)
+
 module Dist = struct
   type t = {
     source : Source.t;
@@ -8,158 +109,39 @@ module Dist = struct
 
   let pp fmt dist =
     Fmt.pf fmt "%s@%a" dist.record.name Version.pp dist.record.version
-
-  let tarballPath ~(cfg : Config.t) (dist : t) =
-
-    let hash vs =
-      vs
-      |> String.concat ~sep:"__"
-      |> Digest.string
-      |> Digest.to_hex
-      |> String.Sub.v ~start:0 ~stop:8
-      |> String.Sub.to_string
-    in
-
-    let id = Path.safePath (
-      let version = Version.show dist.record.version in
-      let source = Source.show dist.source in
-      Printf.sprintf "%s__%s__%s_v2" dist.record.name version (hash [source])
-    ) in
-
-    Path.(cfg.cacheTarballsPath // v id |> addExt "tgz")
 end
 
 let fetch ~(cfg : Config.t) (record : Solution.Record.t) =
   let open RunAsync.Syntax in
 
-  let doFetch path source =
-    match source with
-
-    | Source.LocalPath { path = srcPath; manifest = _; } ->
-      let%bind names = Fs.listDir srcPath in
-      let copy name =
-        let src = Path.(srcPath / name) in
-        let dst = Path.(path / name) in
-        Fs.copyPath ~src ~dst
-      in
-      let%bind () =
-        RunAsync.List.waitAll (List.map ~f:copy names)
-      in
-      return `Done
-
-    | Source.LocalPathLink _ ->
-      (* this case is handled separately *)
-      return `Done
-
-    | Source.NoSource ->
-      return `Done
-
-    | Source.Archive {url; checksum}  ->
-      let f tempPath =
-        let%bind () = Fs.createDir tempPath in
-        let tarballPath = Path.(tempPath / Filename.basename url) in
-        match%lwt Curl.download ~output:tarballPath url with
-        | Ok () ->
-          let%bind () = Checksum.checkFile ~path:tarballPath checksum in
-          let%bind () = Tarball.unpack ~stripComponents:1 ~dst:path tarballPath in
-          return `Done
-        | Error err -> return (`TryNext err)
-      in
-      Fs.withTempDir f
-
-    | Source.Github github ->
-      let f tempPath =
-        let%bind () = Fs.createDir tempPath in
-        let tarballPath = Path.(tempPath / "package.tgz") in
-        let%bind () =
-          let url =
-            Printf.sprintf
-              "https://api.github.com/repos/%s/%s/tarball/%s"
-              github.user github.repo github.commit
-          in
-          Curl.download ~output:tarballPath url
+  let rec fetch' errs sources =
+    match sources with
+    | source::rest ->
+      begin match%bind fetchSourceIntoCache ~cfg source with
+      | Ok (_ : Path.t) -> return {Dist. record; source;}
+      | Error err -> fetch' ((source, err)::errs) rest
+      end
+    | [] ->
+      Logs_lwt.err (fun m ->
+        let ppErr fmt (source, err) =
+          Fmt.pf fmt
+            "source: %a@\nerror: %a"
+            Source.pp source
+            Run.ppError err
         in
-        let%bind () =  Tarball.unpack ~stripComponents:1 ~dst:path tarballPath in
-        return `Done
-      in
-      Fs.withTempDir f
-
-    | Source.Git git ->
-      let%bind () = Git.clone ~dst:path ~remote:git.remote () in
-      let%bind () = Git.checkout ~ref:git.commit ~repo:path () in
-      let%bind () = Fs.rmPath Path.(path / ".git") in
-      return `Done
+        m "unable to fetch %a:@[<v 2>@\n%a@]"
+          Solution.Record.pp record
+          Fmt.(list ~sep:(unit "@\n") ppErr) errs
+      );%lwt
+      error "installation error"
   in
 
-  let doFetchIfNeeded source =
-    let dist = {
-      Dist.
-      record;
-      source;
-    } in
+  let sources =
+    let main, mirrors = record.source in
+    main::mirrors
+  in
 
-    let tarballPath = Dist.tarballPath ~cfg dist in
-
-    let%bind tarballIsInCache = Fs.exists tarballPath in
-
-    match source, tarballIsInCache with
-    | Source.LocalPathLink _, _ ->
-      return (`Done dist)
-    | _, true ->
-      return (`Done dist)
-    | _, false ->
-      Fs.withTempDir (fun sourcePath ->
-        let%bind fetched =
-          RunAsync.contextf (
-            let%bind () = Fs.createDir sourcePath in
-            doFetch sourcePath source
-          )
-          "fetching %a" Source.pp source
-        in
-
-        match fetched with
-        | `Done ->
-          let%bind () =
-            let%bind () = Fs.createDir (Path.parent tarballPath) in
-            let tempTarballPath = Path.(tarballPath |> addExt ".tmp") in
-            let%bind () = Tarball.create ~filename:tempTarballPath sourcePath in
-            let%bind () = Fs.rename ~src:tempTarballPath tarballPath in
-            return ()
-          in
-          return (`Done dist)
-        | `TryNext err -> return (`TryNext err)
-      )
-    in
-
-    let rec tryFetch errs sources =
-      match sources with
-      | source::nextSources ->
-        begin match%bind doFetchIfNeeded source with
-        | `Done dist -> return dist
-        | `TryNext err ->
-          tryFetch ((source, err)::errs) nextSources
-        end
-      | [] ->
-        Logs_lwt.err (fun m ->
-          let ppErr fmt (source, err) =
-            Fmt.pf fmt
-              "source: %a@\nerror: %a"
-              Source.pp source
-              Run.ppError err
-          in
-          m "unable to fetch %a:@[<v 2>@\n%a@]"
-            Solution.Record.pp record
-            Fmt.(list ~sep:(unit "@\n") ppErr) errs
-        );%lwt
-        error "installation error"
-    in
-
-    let sources =
-      let main, mirrors = record.source in
-      main::mirrors
-    in
-
-    tryFetch [] sources
+  fetch' [] sources
 
 let install ~cfg ~path dist =
   let open RunAsync.Syntax in
@@ -212,7 +194,7 @@ let install ~cfg ~path dist =
       let%bind () = finishInstall path in
       return ()
     | _ ->
-      let tarballPath = Dist.tarballPath ~cfg dist in
+      let tarballPath = sourceTarballPath ~cfg dist.source in
       let%bind () = Tarball.unpack ~dst:path tarballPath in
       let%bind () = finishInstall path in
       return ()

--- a/esyi/FetchStorage.mli
+++ b/esyi/FetchStorage.mli
@@ -2,25 +2,32 @@
  * Package storage.
  *)
 
+val fetchSource :
+  cfg : Config.t
+  -> Source.t
+  -> Path.t RunAsync.t
+(** Fetch source and cache a compressed tarball. *)
+
+(** Distribution. *)
 module Dist : sig
   type t
   val pp : Format.formatter -> t -> unit
 end
 
-(**
- * Make sure package specified by [name], [version] and [source] is in store and
- * return it.
- *)
 val fetch :
   cfg : Config.t
   -> Solution.Record.t
   -> Dist.t RunAsync.t
-
 (**
- * Install package from storage into destination.
+ * Make sure package specified by [name], [version] and [source] is in store and
+ * return it.
  *)
+
 val install :
   cfg : Config.t
   -> path : Path.t
   -> Dist.t
   -> unit RunAsync.t
+(**
+ * Install package from storage into destination.
+ *)

--- a/esyi/Resolver.ml
+++ b/esyi/Resolver.ml
@@ -235,32 +235,27 @@ let package ~(resolution : Resolution.t) resolver =
       Fs.withTempDir begin fun repo ->
         let%bind () = Git.clone ~dst:repo ~remote () in
         let%bind () = Git.checkout ~ref:commit ~repo () in
-        let%bind pkg = loadPackageOfPath
+        loadPackageOfPath
           ?manifest
           ~name:resolution.name
           ~version:(Version.Source source)
           ~allowEmptyPackage
           ~source
           repo
-        in
-        return pkg
       end
     | Github {user; repo; commit; manifest;} ->
-      let%bind pkg =
-        loadPackageOfGithub
-          ?manifest
-          ~name:resolution.name
-          ~version:(Version.Source source)
-          ~allowEmptyPackage
-          ~source
-          ~user
-          ~repo
-          ~ref:commit
-          ()
-      in
-      return pkg
-    | NoSource -> error "no source"
+      loadPackageOfGithub
+        ?manifest
+        ~name:resolution.name
+        ~version:(Version.Source source)
+        ~allowEmptyPackage
+        ~source
+        ~user
+        ~repo
+        ~ref:commit
+        ()
     | Archive _ -> error "not implemented"
+    | NoSource -> error "no source"
   in
 
   let ofVersion (version : Version.t) =

--- a/esyi/Resolver.ml
+++ b/esyi/Resolver.ml
@@ -254,7 +254,19 @@ let package ~(resolution : Resolution.t) resolver =
         ~repo
         ~ref:commit
         ()
-    | Archive _ -> error "not implemented"
+
+    | Archive _ ->
+      let%bind tarballPath = FetchStorage.fetchSource ~cfg:resolver.cfg source in
+      Fs.withTempDir begin fun path ->
+        let%bind () = Tarball.unpack ~dst:path tarballPath in
+        loadPackageOfPath
+          ~name:resolution.name
+          ~version:(Version.Source source)
+          ~allowEmptyPackage
+          ~source
+          path
+      end
+
     | NoSource -> error "no source"
   in
 

--- a/test-e2e/install/sources.test.js
+++ b/test-e2e/install/sources.test.js
@@ -5,22 +5,22 @@ const helpers = require('../test/helpers.js');
 helpers.skipSuiteOnWindows();
 
 describe(`Tests for installations from custom sources`, () => {
-  describe('Installation from github', () => {
-    async function assertLayoutCorrect(path) {
-      await expect(helpers.crawlLayout(path)).resolves.toMatchObject({
-        dependencies: {
-          'example-yarn-package': {
-            name: 'example-yarn-package',
-            version: '1.0.0',
-          },
-          lodash: {
-            name: 'lodash',
-            version: '4.24.0',
-          },
+  async function assertLayoutCorrect(path) {
+    await expect(helpers.crawlLayout(path)).resolves.toMatchObject({
+      dependencies: {
+        'example-yarn-package': {
+          name: 'example-yarn-package',
+          version: '1.0.0',
         },
-      });
-    }
+        lodash: {
+          name: 'lodash',
+          version: '4.24.0',
+        },
+      },
+    });
+  }
 
+  describe('Installation from github', () => {
     test('it should install without ref', async () => {
       const fixture = [
         helpers.packageJson({
@@ -112,21 +112,6 @@ describe(`Tests for installations from custom sources`, () => {
   });
 
   describe('Installation from git', () => {
-    async function assertLayoutCorrect(path) {
-      await expect(helpers.crawlLayout(path)).resolves.toMatchObject({
-        dependencies: {
-          'example-yarn-package': {
-            name: 'example-yarn-package',
-            version: '1.0.0',
-          },
-          lodash: {
-            name: 'lodash',
-            version: '4.24.0',
-          },
-        },
-      });
-    }
-
     test('install from git+https:// with no ref', async () => {
       const fixture = [
         helpers.packageJson({
@@ -240,5 +225,25 @@ describe(`Tests for installations from custom sources`, () => {
       await p.esy('install');
       await assertLayoutCorrect(p.projectPath);
     });
+  });
+
+  test('install from https://', async () => {
+    const fixture = [
+      helpers.packageJson({
+        name: 'root',
+        version: '1.0.0',
+        dependencies: {
+          'example-yarn-package':
+            'https://codeload.github.com/yarnpkg/example-yarn-package/tar.gz/0b8f43#02988284bf71a3584f1809c513a2eebd51341911',
+        },
+      }),
+    ];
+    const p = await helpers.createTestSandbox(...fixture);
+    await p.defineNpmPackage({
+      name: 'lodash',
+      version: '4.24.0',
+    });
+    await p.esy('install');
+    await assertLayoutCorrect(p.projectPath);
   });
 });


### PR DESCRIPTION
We didn't support resolving metadata from https sources:

```
"dependencies": {
  "pkg": "https://example.com/pkg.tgz#checksum"
}
```

This PR adds this feature which will be useful for resolutions with overrides to quickly port packages into esy:
```
"resolutions": {
  "pkg": {
    "source": "https://example.com/pkg.tgz#checksum",
    "override": {
      "build": ["describe", "how", "to", "build", "pkg"]
    }
}
```

I've added `FetchStorage.fetchSource` function which fetches sources directly into cache, that allows to reuse the same fetched tarball between resolution and fetching phases of installer.