### PR TITLE
Support packages without sources

### DIFF
--- a/esyi/Resolver.ml
+++ b/esyi/Resolver.ml
@@ -267,7 +267,8 @@ let package ~(resolution : Resolution.t) resolver =
           path
       end
 
-    | NoSource -> error "no source"
+    | NoSource ->
+      return (makeDummyPackage resolution.name (Version.Source source) source)
   in
 
   let ofVersion (version : Version.t) =

--- a/esyi/SourceSpec.ml
+++ b/esyi/SourceSpec.ml
@@ -111,6 +111,7 @@ let matches ~source spec =
     String.equal url1 url2
   | Archive _, _ -> false
 
+  | NoSource, NoSource -> true
   | NoSource, _ -> false
 
 let ofSource (source : Source.t) =


### PR DESCRIPTION
Currently we fail on resolving packages with `no-source:` source specified, now instead we synthesise an empty package which then can be overridden with custom build/install commands and dependencies.

After #458