### PR TITLE
Windows: AppVeyor - Just cache the 'i' and 'source-tarballs' folder

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,8 @@ platform:
     - x64
 
 cache:
-    - C:\Users\appveyor\.esy
+    - C:\Users\appveyor\.esy\3_\i
+    - C:\Users\appveyor\.esy\source-tarballs
 
 # Needed for running unit tests - blocked by bryphe/esy-bash#16
 environment:


### PR DESCRIPTION
This change is to minimize the amount of items we send to AppVeyor to cache - we were exceeding the size limit. Hopefully by scoping it down we'll be able to cache succesfully.