### PR TITLE
test-e2e: Remove --runInband option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ refmt::
 # Test
 #
 
-JEST = $(BIN)/jest --runInBand
+JEST = $(BIN)/jest
 
 test-unit::
 	@esy b dune build @runtest

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,7 @@ install:
 
 build_script:
      - npm run build
-     - jest --runInBand test-e2e
+     - jest test-e2e
      - npm run test:unit
      - npm run release:make-platform-package
 


### PR DESCRIPTION
@andreypopp mentioned in #471 potentially removing the `--runInBand` option - I tested it out and it seemed to work fine across all our CI (and testing locally).