### PR TITLE
Improve error formatting

### DIFF
--- a/esy-build-package/bin/esyBuildPackageCommand.re
+++ b/esy-build-package/bin/esyBuildPackageCommand.re
@@ -157,8 +157,13 @@ let runToCompletion = (~forceExitOnError=false, run) =>
     if (forceExitOnError) {
       exit(exitCode);
     } else {
-      let msg = Format.asprintf("@\ncommand failed:@\n%a", Cmd.pp, cmd);
-      `Error((false, msg));
+      Format.fprintf(
+        Format.err_formatter,
+        "@[<h>error: command failed: %a@]@.",
+        Cmd.pp,
+        cmd,
+      );
+      `Error((false, "exiting with errors above..."));
     };
   | _ => `Ok()
   };

--- a/esy-lib/Cli.ml
+++ b/esy-lib/Cli.ml
@@ -210,8 +210,3 @@ let setupLogTerm =
     const setupLog
     $ Fmt_cli.style_renderer ()
     $ Logs_cli.level ~env:(Arg.env_var "ESY__LOG") ())
-
-let eval ?(argv=Sys.argv) ~defaultCommand ~commands () =
-  let result = Cmdliner.Term.eval_choice ~argv defaultCommand commands in
-  Lwt_main.run (ProgressReporter.clearStatus ());
-  result

--- a/esy-lib/Path.rei
+++ b/esy-lib/Path.rei
@@ -7,45 +7,48 @@
 type t = Fpath.t;
 type ext = Fpath.ext;
 
-let v : string => t;
-let (/) : t => string => t;
-let (/\/) : t => t => t;
+let v: string => t;
+let (/): (t, string) => t;
+let (/\/): (t, t) => t;
 
-let addSeg : (t, string) => t;
-let append : (t, t) => t;
+let addSeg: (t, string) => t;
+let append: (t, t) => t;
 
-let ofString : string => result(t, [> |`Msg(string)]);
-let current : unit => Run.t(t);
-let homePath : unit => t;
-let dataPath : unit => t;
+let ofString: string => result(t, [> | `Msg(string)]);
+let current: unit => Run.t(t);
+let homePath: unit => t;
+let dataPath: unit => t;
 
-let isPrefix : (t, t) => bool;
-let remPrefix : (t, t) => option(t);
+let isPrefix: (t, t) => bool;
+let remPrefix: (t, t) => option(t);
 
-let isAbs : (t) => bool;
-let basename : t => string;
-let parent : t => t;
-let relativize : (~root:t, t) => option(t);
+let isAbs: t => bool;
+let basename: t => string;
+let parent: t => t;
+let relativize: (~root: t, t) => option(t);
+let tryRelativize: (~root: t, t) => t;
+let tryRelativizeToCurrent: t => t;
 
-let addExt : (ext, t) => t;
-let hasExt : (ext, t) => bool;
-let remExt : (~multi: bool=?, t) => t;
-let getExt : (~multi: bool=?, t) => ext;
+let addExt: (ext, t) => t;
+let hasExt: (ext, t) => bool;
+let remExt: (~multi: bool=?, t) => t;
+let getExt: (~multi: bool=?, t) => ext;
 
-let dirSep : string;
+let dirSep: string;
+
+let showPretty: t => string;
+let ppPretty: Fmt.t(t);
 
 include S.PRINTABLE with type t := t;
 include S.COMPARABLE with type t := t;
 include S.JSONABLE with type t := t;
 
-module Set : (module type of Fpath.Set);
+module Set: (module type of Fpath.Set);
 
-let safeSeg : string => string;
-let safePath : string => string;
+let safeSeg: string => string;
+let safePath: string => string;
 
-let remEmptySeg : t => t;
-let normalize : t => t;
-let normalizePathSlashes : string => string;
-let normalizeAndRemoveEmptySeg : t => t;
-
-let toPrettyString : t => Run.t(string);
+let remEmptySeg: t => t;
+let normalize: t => t;
+let normalizePathSlashes: string => string;
+let normalizeAndRemoveEmptySeg: t => t;

--- a/esy-lib/Run.ml
+++ b/esy-lib/Run.ml
@@ -19,7 +19,7 @@ let ppContext fmt context =
   Fmt.(list ~sep:(unit "@\n") ppContextItem) fmt (List.rev context)
 
 let ppError fmt (msg, context) =
-  Fmt.pf fmt "@[<v 2>@[<h>%a@]@\n%a@]" Fmt.text msg ppContext context
+  Fmt.pf fmt "@[<v 2>@[<h>error: %a@]@\n%a@]" Fmt.text msg ppContext context
 
 let return v =
   Ok v

--- a/esy-lib/Run.ml
+++ b/esy-lib/Run.ml
@@ -15,7 +15,8 @@ let ppContextItem fmt = function
   | LogOutput (filename, out) ->
     Fmt.pf fmt "@[<h 2>%s@\n%a@]" filename Fmt.text out
 
-let ppContext = Fmt.(list ~sep:(unit "@\n") ppContextItem)
+let ppContext fmt context =
+  Fmt.(list ~sep:(unit "@\n") ppContextItem) fmt (List.rev context)
 
 let ppError fmt (msg, context) =
   Fmt.pf fmt "@[<v 2>@[<h>%a@]@\n%a@]" Fmt.text msg ppContext context

--- a/esy/Build.ml
+++ b/esy/Build.ml
@@ -9,7 +9,7 @@ let buildTask ?(quiet=false) ?force ?stderrout ~buildOnly sandbox (task : Task.t
   let pkg = Task.pkg task in
   let f () =
     let open RunAsync.Syntax in
-    let context = Printf.sprintf "Building %s@%s" pkg.name pkg.version in
+    let context = Printf.sprintf "building %s@%s" pkg.name pkg.version in
     let%lwt () = if not quiet
       then Logs_lwt.app(fun m -> m "%s: starting" context)
       else Lwt.return ()

--- a/esy/Manifest.ml
+++ b/esy/Manifest.ml
@@ -779,8 +779,8 @@ end = struct
       in
 
       RunAsync.contextf manifest
-        "reading manifest at %a"
-        Path.pp (Path.tryRelativizeToCurrent path)
+        "reading package metadata from %a"
+        Path.ppPretty path
 
   let ofSandboxSpec ~cfg (spec : SandboxSpec.t) =
 
@@ -814,7 +814,7 @@ end = struct
         let manifest = RunAsync.ofRun (readManifest ~path overrides manifest) in
         RunAsync.contextf
           manifest
-          "reading manifest at %a" Path.pp (Path.tryRelativizeToCurrent path)
+          "reading package metadata from %a" Path.ppPretty path
       end
     | ManifestSpec.ManyOpam fnames ->
       let paths = List.map ~f:(fun fname -> Path.(spec.path / fname)) fnames in

--- a/esy/PackageBuilder.ml
+++ b/esy/PackageBuilder.ml
@@ -92,7 +92,7 @@ let build
   | _, Some (logPath, fd) ->
     UnixLabels.close fd;
     let%bind log = Fs.readFile logPath in
-    RunAsync.withContextOfLog ~header:"Build log:" log (error "build failed")
+    RunAsync.withContextOfLog ~header:"build log:" log (error "build failed")
   | _, None ->
     error "build failed"
 

--- a/esy/Sandbox.ml
+++ b/esy/Sandbox.ml
@@ -548,7 +548,13 @@ let make ~(cfg : Config.t) (spec : EsyInstall.SandboxSpec.t) =
       return (`PackageWithBuild (pkg, None))
 
   and loadPackageCached ?name (path : Path.t) stack =
-    let compute () = loadPackage ?name path stack in
+    let compute () =
+      let pkg = loadPackage ?name path stack in
+      let asRoot = Path.compare path spec.path = 0 in
+      if asRoot
+      then RunAsync.contextf pkg "loading package metadata at %a" Path.pp (Path.tryRelativizeToCurrent path)
+      else RunAsync.contextf pkg "loading root package metadata"
+    in
     Memoize.compute packageCache (path, name) compute
   in
 

--- a/esy/Sandbox.ml
+++ b/esy/Sandbox.ml
@@ -552,7 +552,7 @@ let make ~(cfg : Config.t) (spec : EsyInstall.SandboxSpec.t) =
       let pkg = loadPackage ?name path stack in
       let asRoot = Path.compare path spec.path = 0 in
       if asRoot
-      then RunAsync.contextf pkg "loading package metadata at %a" Path.pp (Path.tryRelativizeToCurrent path)
+      then RunAsync.contextf pkg "loading package metadata at %a" Path.ppPretty path
       else RunAsync.contextf pkg "loading root package metadata"
     in
     Memoize.compute packageCache (path, name) compute

--- a/esy/bin/esyCommand.ml
+++ b/esy/bin/esyCommand.ml
@@ -172,13 +172,7 @@ module CommonOptions = struct
         let parent = Path.parent path in
         if not (Path.compare path parent = 0)
         then climb (Path.parent path)
-        else
-          let%bind msg = RunAsync.ofRun (
-            let open Run.Syntax in
-            let%bind currentPath = Path.toPrettyString currentPath in
-            let msg = Printf.sprintf "No sandbox found (from %s and up)" currentPath in
-            return msg
-          ) in error msg
+        else errorf "No sandbox found (from %a and up)" Path.ppPretty currentPath
     in
     climb currentPath
 

--- a/esy/bin/esyCommand.ml
+++ b/esy/bin/esyCommand.ml
@@ -1401,6 +1401,7 @@ let makeCommand
       match Lwt_main.run res with
       | Ok () -> `Ok ()
       | Error error ->
+        Lwt_main.run (Cli.ProgressReporter.clearStatus ());
         let msg = Run.formatError error in
         let msg = Printf.sprintf "error, exiting...\n%s" msg in
         `Error (false, msg)

--- a/esyi/Solver.ml
+++ b/esyi/Solver.ml
@@ -232,7 +232,7 @@ let add ~(dependencies : Dependencies.t) solver =
         let%bind () =
           RunAsync.contextf
             (addDependencies pkg.dependencies)
-            "processing package %a" Package.pp pkg
+            "resolving %a" Package.pp pkg
         in
         universe := Universe.add ~pkg !universe;
         return ()

--- a/esyi/Source.ml
+++ b/esyi/Source.ml
@@ -34,7 +34,7 @@ let manifest (src : t) =
   | Archive _ -> None
   | NoSource -> None
 
-let show = function
+let show' ~showPath = function
   | Github {user; repo; commit; manifest = None;} ->
     Printf.sprintf "github:%s/%s#%s" user repo commit
   | Github {user; repo; commit; manifest = Some manifest;} ->
@@ -46,17 +46,23 @@ let show = function
   | Archive {url; checksum} ->
     Printf.sprintf "archive:%s#%s" url (Checksum.show checksum)
   | LocalPath {path; manifest = None;} ->
-    Printf.sprintf "path:%s" (Path.show path)
+    Printf.sprintf "path:%s" (showPath path)
   | LocalPath {path; manifest = Some manifest;} ->
-    Printf.sprintf "path:%s/%s" (Path.show path) (ManifestSpec.Filename.show manifest)
+    Printf.sprintf "path:%s/%s" (showPath path) (ManifestSpec.Filename.show manifest)
   | LocalPathLink {path; manifest = None;} ->
-    Printf.sprintf "link:%s" (Path.show path)
+    Printf.sprintf "link:%s" (showPath path)
   | LocalPathLink {path; manifest = Some manifest;} ->
-    Printf.sprintf "link:%s/%s" (Path.show path) (ManifestSpec.Filename.show manifest)
+    Printf.sprintf "link:%s/%s" (showPath path) (ManifestSpec.Filename.show manifest)
   | NoSource -> "no-source:"
+
+let show = show' ~showPath:Path.show
+let showPretty = show' ~showPath:Path.showPretty
 
 let pp fmt src =
   Fmt.pf fmt "%s" (show src)
+
+let ppPretty fmt src =
+  Fmt.pf fmt "%s" (showPretty src)
 
 module Parse = struct
   include Parse

--- a/esyi/Source.mli
+++ b/esyi/Source.mli
@@ -26,6 +26,8 @@ type t =
 
 include S.COMMON with type t := t
 
+val ppPretty : t Fmt.t
+
 val parser : t Parse.t
 val parse : string -> (t, string) result
 

--- a/test-e2e/build/with-linked-dep.test.js
+++ b/test-e2e/build/with-linked-dep.test.js
@@ -66,7 +66,7 @@ describe('Build with a linked dep', () => {
   async function checkShouldNotRebuildIfNoChanges(p) {
     const noOpBuild = await p.esy('build');
     expect(noOpBuild.stdout).not.toEqual(
-      expect.stringMatching('Building dep@1.0.0: starting'),
+      expect.stringMatching('building dep@1.0.0: starting'),
     );
   }
 
@@ -77,7 +77,7 @@ describe('Build with a linked dep', () => {
     await open(path.join(p.projectPath, 'dep', 'dummy'), 'w').then(close);
 
     const {stdout} = await p.esy('build');
-    expect(stdout).toEqual(expect.stringMatching('Building dep@1.0.0: starting'));
+    expect(stdout).toEqual(expect.stringMatching('building dep@1.0.0: starting'));
   }
 
   describe('out of source build', () => {

--- a/test-e2e/errors/build-errors.test.js
+++ b/test-e2e/errors/build-errors.test.js
@@ -4,6 +4,8 @@ const outdent = require('outdent');
 const helpers = require('../test/helpers.js');
 const {packageJson, dir} = helpers;
 
+helpers.skipSuiteOnWindows('needs fixes for path pretty printing');
+
 type ChildProcessError = {
   stderr: string,
 };

--- a/test-e2e/errors/build-errors.test.js
+++ b/test-e2e/errors/build-errors.test.js
@@ -1,0 +1,184 @@
+// @flow
+
+const outdent = require('outdent');
+const helpers = require('../test/helpers.js');
+const {packageJson, dir} = helpers;
+
+type ChildProcessError = {
+  stderr: string,
+};
+
+function expectAndReturnRejection(p): Promise<ChildProcessError> {
+  return (p.then(() => expect(true).toBe(false), err => err): any);
+}
+
+describe('build errors', function() {
+  it('reports errors in metadata of a root package', async () => {
+    const p = await helpers.createTestSandbox();
+    await p.fixture(
+      packageJson({
+        name: 'root',
+        esy: {},
+        dependencies: [],
+      }),
+    );
+
+    const err = await expectAndReturnRejection(p.esy('build'));
+    expect(err.stderr.trim()).toEqual(
+      outdent`
+      error: expected object
+        reading package metadata from path:./package.json
+        loading root package metadata
+      esy: exiting due to errors above
+      `,
+    );
+  });
+
+  it('reports errors in metadata of a dependency', async () => {
+    const p = await helpers.createTestSandbox();
+    await p.fixture(
+      packageJson({
+        name: 'root',
+        esy: {},
+        dependencies: {dep: '*'},
+      }),
+      dir(
+        'node_modules',
+        dir(
+          'dep',
+          packageJson({
+            name: 'dep',
+            version: '0.0.0',
+            esy: {},
+            dependencies: [],
+          }),
+        ),
+      ),
+    );
+
+    const err = await expectAndReturnRejection(p.esy('build'));
+    expect(err.stderr).toMatch(
+      outdent`
+      error: invalid package dep: error: expected object
+        reading package metadata from node_modules/dep
+        loading root package metadata
+        processing package: root@0.0.0
+      esy: exiting due to errors above
+      `,
+    );
+  });
+
+  it('reports errors in root builds', async () => {
+    const p = await helpers.createTestSandbox();
+    await p.fixture(
+      packageJson({
+        name: 'root',
+        esy: {build: 'false'},
+      }),
+    );
+
+    const err = await expectAndReturnRejection(p.esy('build'));
+    expect(err.stderr).toMatch(
+      outdent`
+      error: command failed: 'false'
+      esy-build-package: exiting with errors above...
+      error: build failed
+        building root@0.0.0
+      esy: exiting due to errors above
+      `,
+    );
+  });
+
+  it('reports errors in dependency builds', async () => {
+    const p = await helpers.createTestSandbox();
+    await p.fixture(
+      packageJson({
+        name: 'root',
+        esy: {},
+        dependencies: {dep: '*'},
+      }),
+      dir(
+        'node_modules',
+        dir(
+          'dep',
+          packageJson({
+            name: 'dep',
+            version: '0.0.0',
+            esy: {build: 'false'},
+          }),
+        ),
+      ),
+    );
+
+    const err = await expectAndReturnRejection(p.esy('build'));
+    expect(err.stderr).toMatch(
+      outdent`
+      error: build failed
+        build log:
+          # esy-build-package: building: dep@0.0.0
+          # esy-build-package: running: 'false'
+          error: command failed: 'false'
+          esy-build-package: exiting with errors above...
+          
+        building dep@0.0.0
+      esy: exiting due to errors above
+      `,
+    );
+  });
+
+  it('reports errors about unknown dependencies', async () => {
+    const p = await helpers.createTestSandbox();
+    await p.fixture(
+      packageJson({
+        name: 'root',
+        esy: {build: 'true'},
+        dependencies: {
+          'some-unknown-dependency': '*',
+        },
+      }),
+    );
+
+    const err = await expectAndReturnRejection(p.esy('install'));
+    expect(err.stderr).toMatch(
+      outdent`
+      error: no npm package some-unknown-dependency found
+        resolving some-unknown-dependency@*
+      esy: exiting due to errors above
+      `,
+    );
+  });
+
+  it('reports errors about unknown dependencies (nested case)', async () => {
+    const p = await helpers.createTestSandbox();
+    await p.fixture(
+      packageJson({
+        name: 'root',
+        esy: {build: 'true'},
+        dependencies: {
+          dep: 'path:./dep',
+        },
+      }),
+      dir(
+        'dep',
+        packageJson({
+          name: 'dep',
+          version: '0.0.0',
+          esy: {build: 'true'},
+          dependencies: {
+            'some-unknown-dependency': '*',
+          },
+        }),
+      ),
+    );
+
+    const err = await expectAndReturnRejection(p.esy('install'));
+    expect(err.stderr).toMatch(
+      outdent`
+      error: no npm package some-unknown-dependency found
+        resolving some-unknown-dependency@*
+        resolving dep@path:dep
+      esy: exiting due to errors above
+      `,
+    );
+  });
+});

--- a/test-e2e/test/NpmRegistryMock.js
+++ b/test-e2e/test/NpmRegistryMock.js
@@ -397,8 +397,6 @@ async function initialize(
     statusCode: number,
     errorMessage: string,
   ): boolean {
-    console.error(errorMessage);
-
     res.writeHead(statusCode);
     res.end(errorMessage);
 


### PR DESCRIPTION
This PR improves error formatting.

What's done:

- Errors are reported not via cmdliner but with `Format.fprintf` directly.

  Previously errors were reported via cmdliner which messed up with formatting
  and introduced a lot of unneccessary line breaks.

- Add context to errors: some errors were missing context which made it hard to analyse.

- Improve error context pretty printer: now context closer to the error origin
  will be printed closer to the error message.

- Clear progress reporter on errors (cleaner error layout).

- Error messages wording.

- Added test suite which assert errors in common errorneous situations (missing
  deps, invalid metadata and so on).