### PR TITLE
Fix how we report solver errors

### DIFF
--- a/esyi/OpamManifest.ml
+++ b/esyi/OpamManifest.ml
@@ -322,6 +322,7 @@ let toPackage ?(ignoreFiles=false) ?source ~name ~version manifest =
       name;
       version;
       originalVersion = None;
+      originalName = None;
       kind = Package.Esy;
       source;
       overrides = Package.Overrides.empty;

--- a/esyi/OpamPackageVersion.ml
+++ b/esyi/OpamPackageVersion.ml
@@ -130,7 +130,10 @@ module Formula = struct
     ParseUtils.disjunction ~parse:parseSimple v
 
   let parse v =
-    Ok (parseExn v)
+    try Ok (parseExn v)
+    with _ ->
+      let msg = "unable to parse formula: " ^ v in
+      Error msg
 
   let parserDnf =
     P.(

--- a/esyi/Package.ml
+++ b/esyi/Package.ml
@@ -650,6 +650,7 @@ type t = {
   name : string;
   version : Version.t;
   originalVersion : Version.t option;
+  originalName : string option;
   source : Source.t * Source.t list;
   overrides : Overrides.t;
   dependencies: Dependencies.t;

--- a/esyi/Package.mli
+++ b/esyi/Package.mli
@@ -199,8 +199,11 @@ module Dependencies : sig
     | NpmFormula of NpmFormula.t
 
   include S.PRINTABLE with type t := t
+  include S.COMPARABLE with type t := t
 
   val toApproximateRequests : t -> Req.t list
+
+  val filterDependenciesByName : name:string -> t -> t
 end
 
 module File : sig

--- a/esyi/Package.mli
+++ b/esyi/Package.mli
@@ -281,6 +281,7 @@ type t = {
   name : string;
   version : Version.t;
   originalVersion : Version.t option;
+  originalName : string option;
   source : Source.t * Source.t list;
   overrides : Overrides.t;
   dependencies: Dependencies.t;

--- a/esyi/PackageJson.ml
+++ b/esyi/PackageJson.ml
@@ -69,6 +69,7 @@ let packageOfJson ?(parseResolutions=false) ?source ~name ~version json =
     name;
     version;
     originalVersion;
+    originalName = pkgJson.name;
     dependencies = Package.Dependencies.NpmFormula dependencies;
     devDependencies = Package.Dependencies.NpmFormula pkgJson.devDependencies;
     resolutions;

--- a/esyi/Resolver.ml
+++ b/esyi/Resolver.ml
@@ -198,6 +198,7 @@ let packageOfSource ~allowEmptyPackage ~name ~overrides (source : Source.t) reso
       name;
       version = Version.Source source;
       originalVersion = None;
+      originalName = None;
       source = source, [];
       overrides = Package.Overrides.empty;
       dependencies = Package.Dependencies.NpmFormula [];

--- a/esyi/Sandbox.ml
+++ b/esyi/Sandbox.ml
@@ -74,6 +74,7 @@ let makeOpamSandbox ~cfg ~spec _projectPath (paths : Path.t list) =
         name = "empty";
         version;
         originalVersion = None;
+        originalName = None;
         source = source, [];
         overrides = Package.Overrides.empty;
         dependencies;
@@ -111,6 +112,7 @@ let makeOpamSandbox ~cfg ~spec _projectPath (paths : Path.t list) =
       name = "root";
       version;
       originalVersion = None;
+      originalName = None;
       source = source, [];
       overrides = Package.Overrides.empty;
       dependencies = Package.Dependencies.OpamFormula dependencies;

--- a/esyi/Solver.ml
+++ b/esyi/Solver.ml
@@ -318,7 +318,7 @@ let parseCudfSolution ~cudfUniverse data =
   IO.close_in i;
   solution
 
-let solveDependencies ~installed ~strategy dependencies solver =
+let solveDependencies ~root ~installed ~strategy dependencies solver =
   let open RunAsync.Syntax in
 
   let runSolver filenameIn filenameOut =
@@ -343,9 +343,10 @@ let solveDependencies ~installed ~strategy dependencies solver =
 
   let dummyRoot = {
     Package.
-    name = "ROOT";
+    name = root.Package.name;
     version = Version.parseExn "0.0.0";
     originalVersion = None;
+    originalName = root.originalName;
     source = Source.NoSource, [];
     overrides = Package.Overrides.empty;
     opam = None;
@@ -677,6 +678,7 @@ let solve (sandbox : Sandbox.t) =
   let%bind installed =
     let%bind res =
       solveDependencies
+        ~root:sandbox.root
         ~installed:Package.Set.empty
         ~strategy:Strategy.trendy
         dependencies

--- a/esyi/Solver.ml
+++ b/esyi/Solver.ml
@@ -164,7 +164,6 @@ module Explanation = struct
         | Algo.Diagnostic.Missing (pkg, vpkglist) ->
           let pkg = Universe.CudfMapping.decodePkgExn pkg cudfMapping in
           let requestor, path = resolveDepChain pkg in
-          prerr_endline pkg.name;
           let trace =
             if pkg.Package.name = root.Package.name
             then []

--- a/esyi/Solver.ml
+++ b/esyi/Solver.ml
@@ -164,10 +164,11 @@ module Explanation = struct
         | Algo.Diagnostic.Missing (pkg, vpkglist) ->
           let pkg = Universe.CudfMapping.decodePkgExn pkg cudfMapping in
           let requestor, path = resolveDepChain pkg in
+          prerr_endline pkg.name;
           let trace =
             if pkg.Package.name = root.Package.name
             then []
-            else requestor::path
+            else pkg::requestor::path
           in
           let f reasons (name, _) =
             let name = Universe.CudfMapping.decodePkgName name in
@@ -176,7 +177,7 @@ module Explanation = struct
               | Ok available -> Lwt.return available
               | Error _ -> Lwt.return []
             in
-            let constr = Dependencies.filterDependenciesByName ~name requestor.dependencies in
+            let constr = Dependencies.filterDependenciesByName ~name pkg.dependencies in
             let missing = Reason.missing ~available {constr; trace} in
             if not (Reason.Set.mem missing reasons)
             then return (Reason.Set.add missing reasons)

--- a/test-e2e/errors/solve-errors.test.js
+++ b/test-e2e/errors/solve-errors.test.js
@@ -1,0 +1,189 @@
+// @flow
+
+const outdent = require('outdent');
+const helpers = require('../test/helpers.js');
+const {packageJson, file, dir} = helpers;
+
+helpers.skipSuiteOnWindows('needs fixes for path pretty printing');
+
+type ChildProcessError = {
+  stderr: string,
+};
+
+function expectAndReturnRejection(p): Promise<ChildProcessError> {
+  return (p.then(() => expect(true).toBe(false), err => err): any);
+}
+
+describe('"esy solve" errors', function() {
+  it('reports errors about conflict', async () => {
+    const p = await helpers.createTestSandbox();
+
+    await p.defineNpmPackage({
+      name: 'conflict',
+      version: '1.0.0',
+      esy: {},
+    });
+
+    await p.defineNpmPackage({
+      name: 'conflict',
+      version: '2.0.0',
+      esy: {},
+    });
+
+    await p.fixture(
+      packageJson({
+        name: 'root',
+        esy: {},
+        dependencies: {
+          dep: './dep',
+          conflict: '2.0.0',
+        },
+      }),
+      dir(
+        'dep',
+        packageJson({
+          name: 'dep',
+          esy: {},
+          dependencies: {
+            conflict: '1.0.0',
+          },
+        }),
+      ),
+    );
+
+    const err = await expectAndReturnRejection(p.esy('install --skip-repository-update'));
+    expect(err.stderr.trim()).toEqual(
+      outdent`
+      error: No solution found:
+     
+      Conflicting constraints:
+        root -> dep -> conflict@=1.0.0
+        root -> conflict@=2.0.0
+     
+        
+      esy: exiting due to errors above
+      `,
+    );
+  });
+
+  it('reports errors about conflict (one side is opam package)', async () => {
+    const p = await helpers.createTestSandbox();
+
+    await p.defineNpmPackage({
+      name: '@esy-ocaml/substs',
+      version: '1.0.0',
+      esy: {},
+    });
+
+    await p.defineOpamPackage({
+      name: 'conflict',
+      version: '1.0.0',
+      opam: outdent`
+        opam-version: "2.0"
+      `,
+      url: null,
+    });
+
+    await p.defineOpamPackage({
+      name: 'conflict',
+      version: '2.0.0',
+      opam: outdent`
+        opam-version: "2.0"
+      `,
+      url: null,
+    });
+
+    await p.fixture(
+      packageJson({
+        name: 'root',
+        esy: {},
+        dependencies: {
+          dep: 'path:./dep/dep.opam',
+          '@opam/conflict': '2.0.0',
+        },
+      }),
+      dir(
+        'dep',
+        file(
+          'dep.opam',
+          outdent`
+          opam-version: "2.0"
+          depends: [
+            "conflict" {< "2.0.0"}
+          ]
+          `,
+        ),
+      ),
+    );
+
+    const err = await expectAndReturnRejection(p.esy('install --skip-repository-update'));
+    expect(err.stderr.trim()).toEqual(
+      outdent`
+      error: No solution found:
+
+      Conflicting constraints:
+        root -> dep -> @opam/conflict@<opam:2.0.0
+        root -> @opam/conflict@=opam:2.0.0
+
+        
+      esy: exiting due to errors above
+      `,
+    );
+  });
+
+  it('reports errors about missing opam packages', async () => {
+    const p = await helpers.createTestSandbox();
+
+    await p.defineNpmPackage({
+      name: '@esy-ocaml/substs',
+      version: '1.0.0',
+      esy: {},
+    });
+
+    await p.defineOpamPackage({
+      name: 'conflict',
+      version: '1.0.0',
+      opam: outdent`
+        opam-version: "2.0"
+      `,
+      url: null,
+    });
+
+    await p.fixture(
+      packageJson({
+        name: 'root',
+        esy: {},
+        dependencies: {
+          dep: 'path:./dep/dep.opam',
+          '@opam/conflict': '1.0.0',
+        },
+      }),
+      dir(
+        'dep',
+        file(
+          'dep.opam',
+          outdent`
+          opam-version: "2.0"
+          depends: [
+            "conflict" {> "1.0.0"}
+          ]
+          `,
+        ),
+      ),
+    );
+
+    const err = await expectAndReturnRejection(p.esy('install --skip-repository-update'));
+    expect(err.stderr.trim()).toEqual(
+      outdent`
+      error: No solution found:
+
+      Conflicting constraints:
+        root -> dep -> @opam/conflict@<opam:2.0.0
+        root -> @opam/conflict@=opam:2.0.0
+
+        
+      esy: exiting due to errors above
+      `,
+    );
+  });
+});

--- a/test-e2e/errors/solve-errors.test.js
+++ b/test-e2e/errors/solve-errors.test.js
@@ -177,10 +177,14 @@ describe('"esy solve" errors', function() {
       outdent`
       error: No solution found:
 
-      Conflicting constraints:
-        root -> dep -> @opam/conflict@<opam:2.0.0
-        root -> @opam/conflict@=opam:2.0.0
-
+      No package matching:
+     
+        root -> dep -> @opam/conflict@>opam:1.0.0
+        
+        Versions available:
+        
+          @opam/conflict@opam:1.0.0
+     
         
       esy: exiting due to errors above
       `,


### PR DESCRIPTION
Example:

```
error: No solution found:

Conflicting constraints:
  root -> dep -> conflict@=1.0.0
  root -> conflict@=2.0.0


esy: exiting due to errors above
```