### PR TITLE
Fix solver criteria by introducing staleness

### DIFF
--- a/esyi/OpamRegistry.ml
+++ b/esyi/OpamRegistry.ml
@@ -179,8 +179,19 @@ let resolve
       else return None
     end
 
+(* Some opam packages don't make sense for esy. *)
+let isEnabledForEsy name =
+  match OpamPackage.Name.to_string name with
+  | "ocaml-system" -> false
+  | _ -> true
+
 let versions ?ocamlVersion ~(name : OpamPackage.Name.t) registry =
   let open RunAsync.Syntax in
+
+  if not (isEnabledForEsy name)
+  then return []
+  else
+
   let%bind registry = initRegistry registry in
   match%bind getPackageVersionIndex registry ~name with
   | None -> errorf "no opam package %s found" (OpamPackage.Name.to_string name)
@@ -199,6 +210,11 @@ let versions ?ocamlVersion ~(name : OpamPackage.Name.t) registry =
 
 let version ~(name : OpamPackage.Name.t) ~version registry =
   let open RunAsync.Syntax in
+
+  if not (isEnabledForEsy name)
+  then return None
+  else
+
   let%bind registry = initRegistry registry in
   match%bind resolve ~name ~version registry with
   | None -> return None

--- a/esyi/Solver.ml
+++ b/esyi/Solver.ml
@@ -3,7 +3,7 @@ module Resolutions = Package.Resolutions
 module Resolution = Package.Resolution
 
 module Strategy = struct
-  let trendy = "-removed,-notuptodate,-new"
+  let trendy = "-count[staleness,solution],-removed,-notuptodate,-new"
   (* let minimalAddition = "-removed,-changed,-notuptodate" *)
 end
 
@@ -409,7 +409,16 @@ let solveDependencies ~root ~installed ~strategy dependencies solver =
     Cudf.default_request with
     install = [cudfRoot.Cudf.package, Some (`Eq, cudfRoot.Cudf.version)]
   } in
-  let preamble = Cudf.default_preamble in
+
+  let preamble =
+    {
+      Cudf.default_preamble with
+      property =
+        ("staleness", `Int None)
+        ::("original-version", `String None)
+        ::Cudf.default_preamble.property
+    }
+  in
 
   (* The solution has CRLF on Windows, which breaks the parser *)
   let normalizeSolutionData s = 


### PR DESCRIPTION
This solves #488 by introducing new property staleness (a distance from
the current version to the most up to date version).

Apparently `-notupdate` wasn't enough and I still don't understand why.

The property `staleness` is similar to `version-lag` property as
described in opam docs.

Also I've added `original-version` property which holds the original
(not CUDF encoded) version which helps debugging CUDF documents.