### PR TITLE
Resolve LocalPath/LocalPathLink against root path

### DIFF
--- a/esy/Manifest.ml
+++ b/esy/Manifest.ml
@@ -806,7 +806,10 @@ end = struct
         EsyInstall.Source.parse source
       ) in
       let%bind { SourceResolver. overrides; source = resolvedSource; manifest; } =
-        SourceResolver.resolve ~cfg:cfg.Config.installCfg source
+        SourceResolver.resolve
+          ~cfg:cfg.Config.installCfg
+          ~root:spec.path
+          source
       in
       begin match manifest with
       | None -> errorf "no manifest found at %a" Source.pp resolvedSource

--- a/esyi/Resolver.ml
+++ b/esyi/Resolver.ml
@@ -55,6 +55,7 @@ let toOpamOcamlVersion version =
 
 type t = {
   cfg: Config.t;
+  root: Path.t;
   pkgCache: PackageCache.t;
   srcCache: SourceCache.t;
   opamRegistry : OpamRegistry.t;
@@ -68,9 +69,10 @@ type t = {
   sourceToSource : (Source.t, Source.t) Hashtbl.t;
 }
 
-let make ~cfg () =
+let make ~cfg ~root () =
   RunAsync.return {
     cfg;
+    root;
     pkgCache = PackageCache.make ();
     srcCache = SourceCache.make ();
     opamRegistry = OpamRegistry.make ~cfg ();
@@ -211,7 +213,11 @@ let packageOfSource ~allowEmptyPackage ~name ~overrides (source : Source.t) reso
 
   let pkg =
     let%bind { SourceResolver. overrides; source = resolvedSource; manifest; } =
-      SourceResolver.resolve ~cfg:resolver.cfg ~overrides source
+      SourceResolver.resolve
+        ~cfg:resolver.cfg
+        ~overrides
+        ~root:resolver.root
+        source
     in
 
     let%bind pkg =

--- a/esyi/Resolver.mli
+++ b/esyi/Resolver.mli
@@ -4,6 +4,7 @@ type t
 (** Make new resolver *)
 val make :
   cfg:Config.t
+  -> root:Path.t
   -> unit
   -> t RunAsync.t
 

--- a/esyi/Sandbox.ml
+++ b/esyi/Sandbox.ml
@@ -186,7 +186,7 @@ let make ~cfg (spec : SandboxSpec.t) =
     match spec.manifest with
     | ManifestSpec.One (Esy, fname)
     | ManifestSpec.One (Opam, fname) ->
-      let source = "path:" ^ Path.(spec.path / fname |> show) in
+      let source = "path:" ^ fname in
       begin match Source.parse source with
       | Ok source -> ofSource ~cfg ~spec source
       | Error msg -> RunAsync.errorf "unable to construct sandbox: %s" msg

--- a/esyi/Sandbox.ml
+++ b/esyi/Sandbox.ml
@@ -15,7 +15,7 @@ let ocamlReqAny =
 let makeOpamSandbox ~cfg ~spec _projectPath (paths : Path.t list) =
   let open RunAsync.Syntax in
 
-  let%bind resolver = Resolver.make ~cfg () in
+  let%bind resolver = Resolver.make ~cfg ~root:spec.path () in
 
   let%bind opams =
 
@@ -149,7 +149,7 @@ let ofSource ~cfg ~spec source =
   in
 
   let%bind resolver =
-    Resolver.make ~cfg ()
+    Resolver.make ~cfg ~root:spec.path ()
   in
 
   match%bind Resolver.package ~resolution resolver with

--- a/esyi/SourceResolver.ml
+++ b/esyi/SourceResolver.ml
@@ -109,6 +109,7 @@ let ofPath ?manifest (path : Path.t)
 let resolve
   ?(overrides=Package.Overrides.empty)
   ~cfg
+  ~root
   (source : Source.t) =
   let open RunAsync.Syntax in
 
@@ -117,7 +118,7 @@ let resolve
     match source with
     | LocalPath {path; manifest}
     | LocalPathLink {path; manifest} ->
-      let%bind pkg = ofPath ?manifest path in
+      let%bind pkg = ofPath ?manifest Path.(root // path) in
       return pkg
     | Git {remote; commit; manifest;} ->
       Fs.withTempDir begin fun repo ->

--- a/esyi/SourceResolver.mli
+++ b/esyi/SourceResolver.mli
@@ -25,5 +25,17 @@ and manifest = {
 val resolve :
   ?overrides:Package.Overrides.t
   -> cfg:Config.t
+  -> root:Path.t
   -> Source.t
   -> resolution RunAsync.t
+(**
+
+  Resolve [source] and produce a [resolution].
+
+  A set of predefined [overrides] can be passed, in this case newly discovered
+  overrides are being appended to it.
+
+  Argument [root] is used to resolve [Source.LocalPath] and
+  [Source.LocalPathLink] sources.
+
+ *)


### PR DESCRIPTION
We add `~root` arg to `SourceResolver.resolve` and configure it with a project
path. This is used to resolve `LocalPath`/`LocalPathLink` sources.

Then we fix sandbox init code not to store abs paths in a lockfile.