### PR TITLE
Windows - Install: Fix issues with lockfile generation

### DIFF
--- a/esy-lib/Path.re
+++ b/esy-lib/Path.re
@@ -85,6 +85,11 @@ let compare = Fpath.compare;
 let show = Fpath.to_string;
 let pp = Fpath.pp;
 
+let showNormalized = p => {
+  let p = show(p);
+  normalizePathSlashes(p);
+};
+
 let showPretty = p => {
   let p =
     switch (remPrefix(homePath(), p)) {

--- a/esy-lib/Path.rei
+++ b/esy-lib/Path.rei
@@ -36,6 +36,7 @@ let getExt: (~multi: bool=?, t) => ext;
 
 let dirSep: string;
 
+let showNormalized: t => string;
 let showPretty: t => string;
 let ppPretty: Fmt.t(t);
 

--- a/esy-lib/System.ml
+++ b/esy-lib/System.ml
@@ -107,4 +107,6 @@ module Environment = struct
     | Some path -> String.split_on_char sep.[0] path
     | None -> []
 
+  let normalizeNewLines s =
+    Str.global_replace (Str.regexp_string "\r\n") "\n" s
 end

--- a/esy-lib/System.mli
+++ b/esy-lib/System.mli
@@ -35,4 +35,6 @@ module Environment : sig
   (** Value of $PATH environment variable. *)
   val path : string list
 
+  (** Helper method to normalize CRLF (Windows) text-context to LF (POSIX) *)
+  val normalizeNewLines : string -> string
 end

--- a/esyi/FetchStorage.ml
+++ b/esyi/FetchStorage.ml
@@ -50,17 +50,8 @@ let install ~cfg ~path dist =
   let finishInstall path =
 
     let%bind () =
-      let f {Package.File. name; content; perm} =
-        let name = Path.append path (Fpath.v name) in
-        let dirname = Path.parent name in
-        let%bind () = Fs.createDir dirname in
-        (* TODO: move this to the place we read data from *)
-        let contents =
-          if String.get content (String.length content - 1) == '\n'
-          then content
-          else content ^ "\n"
-        in
-        let%bind () = Fs.writeFile ~perm ~data:contents name in
+      let f file =
+        let%bind _ = Package.File.writeToDir path file in
         return()
       in
       List.map ~f record.files |> RunAsync.List.waitAll

--- a/esyi/FetchStorage.ml
+++ b/esyi/FetchStorage.ml
@@ -51,8 +51,7 @@ let install ~cfg ~path dist =
 
     let%bind () =
       let f file =
-        let%bind _ = Package.File.writeToDir ~destinationDir:path file in
-        return()
+        Package.File.writeToDir ~destinationDir:path file
       in
       List.map ~f record.files |> RunAsync.List.waitAll
     in

--- a/esyi/FetchStorage.ml
+++ b/esyi/FetchStorage.ml
@@ -51,7 +51,7 @@ let install ~cfg ~path dist =
 
     let%bind () =
       let f {Package.File. name; content; perm} =
-        let name = Path.append path name in
+        let name = Path.append path (Fpath.v name) in
         let dirname = Path.parent name in
         let%bind () = Fs.createDir dirname in
         (* TODO: move this to the place we read data from *)

--- a/esyi/FetchStorage.ml
+++ b/esyi/FetchStorage.ml
@@ -51,7 +51,7 @@ let install ~cfg ~path dist =
 
     let%bind () =
       let f file =
-        let%bind _ = Package.File.writeToDir path file in
+        let%bind _ = Package.File.writeToDir ~destinationDir:path file in
         return()
       in
       List.map ~f record.files |> RunAsync.List.waitAll

--- a/esyi/OpamManifest.ml
+++ b/esyi/OpamManifest.ml
@@ -42,6 +42,7 @@ let readFiles (path : Path.t) () =
       | Some name ->
         let%bind content = Fs.readFile filePath
         and stats = Fs.stat filePath in
+        let content = System.Environment.normalizeNewLines content in
         return ({Package.File. name; content; perm = stats.Unix.st_perm}::files)
       | None -> return files
     in

--- a/esyi/OpamManifest.ml
+++ b/esyi/OpamManifest.ml
@@ -43,6 +43,7 @@ let readFiles (path : Path.t) () =
         let%bind content = Fs.readFile filePath
         and stats = Fs.stat filePath in
         let content = System.Environment.normalizeNewLines content in
+        let name = Path.showNormalized name in
         return ({Package.File. name; content; perm = stats.Unix.st_perm}::files)
       | None -> return files
     in

--- a/esyi/OpamManifest.ml
+++ b/esyi/OpamManifest.ml
@@ -40,7 +40,7 @@ let readFiles (path : Path.t) () =
     let collect files filePath _fileStats =
       match Path.relativize ~root:filesPath filePath with
       | Some name ->
-        let%bind file = Package.File.readOfPath ~stripPrefix:filesPath name in
+        let%bind file = Package.File.readOfPath ~prefixPath:filesPath ~filePath:name in
         return (file::files)
       | None -> return files
     in

--- a/esyi/OpamManifest.ml
+++ b/esyi/OpamManifest.ml
@@ -40,11 +40,8 @@ let readFiles (path : Path.t) () =
     let collect files filePath _fileStats =
       match Path.relativize ~root:filesPath filePath with
       | Some name ->
-        let%bind content = Fs.readFile filePath
-        and stats = Fs.stat filePath in
-        let content = System.Environment.normalizeNewLines content in
-        let name = Path.showNormalized name in
-        return ({Package.File. name; content; perm = stats.Unix.st_perm}::files)
+        let%bind file = Package.File.readOfPath ~stripPrefix:filesPath name in
+        return (file::files)
       | None -> return files
     in
     Fs.fold ~init:[] ~f:collect filesPath

--- a/esyi/OpamOverrides.re
+++ b/esyi/OpamOverrides.re
@@ -98,11 +98,7 @@ let load = baseDir => {
       let f = (files, path, _stat) =>
         switch (Path.relativize(~root=filesPath, path)) {
         | Some(name) =>
-          let%bind content = Fs.readFile(path)
-          and stat = Fs.stat(path);
-          let content = System.Environment.normalizeNewLines(content);
-          let name = Path.showNormalized(name);
-          let file = {Package.File.name, content, perm: stat.Unix.st_perm};
+          let%bind file = Package.File.readOfPath(~stripPrefix=filesPath, name);
           return([file, ...files]);
         | None =>
           /* This case isn't really possible but... */

--- a/esyi/OpamOverrides.re
+++ b/esyi/OpamOverrides.re
@@ -101,6 +101,7 @@ let load = baseDir => {
           let%bind content = Fs.readFile(path)
           and stat = Fs.stat(path);
           let content = System.Environment.normalizeNewLines(content);
+          let name = Path.showNormalized(name);
           let file = {Package.File.name, content, perm: stat.Unix.st_perm};
           return([file, ...files]);
         | None =>

--- a/esyi/OpamOverrides.re
+++ b/esyi/OpamOverrides.re
@@ -98,7 +98,7 @@ let load = baseDir => {
       let f = (files, path, _stat) =>
         switch (Path.relativize(~root=filesPath, path)) {
         | Some(name) =>
-          let%bind file = Package.File.readOfPath(~stripPrefix=filesPath, name);
+          let%bind file = Package.File.readOfPath(~prefixPath=filesPath, ~filePath=name);
           return([file, ...files]);
         | None =>
           /* This case isn't really possible but... */

--- a/esyi/OpamOverrides.re
+++ b/esyi/OpamOverrides.re
@@ -100,6 +100,7 @@ let load = baseDir => {
         | Some(name) =>
           let%bind content = Fs.readFile(path)
           and stat = Fs.stat(path);
+          let content = System.Environment.normalizeNewLines(content);
           let file = {Package.File.name, content, perm: stat.Unix.st_perm};
           return([file, ...files]);
         | None =>

--- a/esyi/Package.ml
+++ b/esyi/Package.ml
@@ -580,7 +580,7 @@ end
 module File = struct
   [@@@ocaml.warning "-32"]
   type t = {
-    name : Path.t;
+    name : string;
     content : string;
     (* file, permissions add 0o644 default for backward compat. *)
     perm : (int [@default 0o644]);

--- a/esyi/Package.ml
+++ b/esyi/Package.ml
@@ -600,7 +600,7 @@ module File = struct
       let open RunAsync.Syntax in
       let {name; content; perm} = file in
       let dest = Path.append destinationDir (Fpath.v name) in
-      let dirname = Path.parent (Fpath.v name) in
+      let dirname = Path.parent dest in
       let%bind () = Fs.createDir dirname in
       let content =
           if String.get content (String.length content - 1) == '\n'

--- a/esyi/Package.ml
+++ b/esyi/Package.ml
@@ -586,20 +586,20 @@ module File = struct
     perm : (int [@default 0o644]);
   } [@@deriving yojson, show, ord]
 
-  let readOfPath ~stripPrefix p =
+  let readOfPath ~prefixPath ~filePath =
       let open RunAsync.Syntax in
-      let fullPath = Path.append stripPrefix p in
-      let%bind content = Fs.readFile fullPath
-      and stat = Fs.stat fullPath in
+      let p = Path.append prefixPath filePath in
+      let%bind content = Fs.readFile p
+      and stat = Fs.stat p in
       let content = System.Environment.normalizeNewLines content in
       let perm = stat.Unix.st_perm in
-      let name = Path.showNormalized p in
+      let name = Path.showNormalized filePath in
       return {name; content; perm}
 
-  let writeToDir p file =
+  let writeToDir ~destinationDir file =
       let open RunAsync.Syntax in
       let {name; content; perm} = file in
-      let fullPath = Path.append p (Fpath.v name) in
+      let dest = Path.append destinationDir (Fpath.v name) in
       let dirname = Path.parent (Fpath.v name) in
       let%bind () = Fs.createDir dirname in
       let content =
@@ -607,7 +607,7 @@ module File = struct
           then content
           else content ^ "\n"
       in
-      let%bind () = Fs.writeFile ~perm:perm ~data:content fullPath in
+      let%bind () = Fs.writeFile ~perm:perm ~data:content dest in
       return()
 end
 

--- a/esyi/Package.mli
+++ b/esyi/Package.mli
@@ -208,7 +208,7 @@ end
 
 module File : sig
   type t = {
-    name : Path.t;
+    name : string;
     content : string;
     perm : int;
   }

--- a/esyi/Package.mli
+++ b/esyi/Package.mli
@@ -209,8 +209,8 @@ end
 module File : sig
   type t
 
-  val readOfPath : stripPrefix:Path.t -> Path.t -> t RunAsync.t
-  val writeToDir : Path.t -> t -> unit RunAsync.t
+  val readOfPath : prefixPath:Path.t -> filePath:Path.t -> t RunAsync.t
+  val writeToDir : destinationDir:Path.t -> t -> unit RunAsync.t
 
   include S.COMPARABLE with type t := t
   include S.JSONABLE with type t := t

--- a/esyi/Package.mli
+++ b/esyi/Package.mli
@@ -207,11 +207,10 @@ module Dependencies : sig
 end
 
 module File : sig
-  type t = {
-    name : string;
-    content : string;
-    perm : int;
-  }
+  type t
+
+  val readOfPath : stripPrefix:Path.t -> Path.t -> t RunAsync.t
+  val writeToDir : Path.t -> t -> unit RunAsync.t
 
   include S.COMPARABLE with type t := t
   include S.JSONABLE with type t := t


### PR DESCRIPTION
__Issue:__ There are two additional blockers with the windows esy installation workflow, after https://github.com/esy-ocaml/esy-opam-override/pull/24 was addressed:
- When we save files to `esy.lock.json` on Windows, newlines get persisted with `CRLF` (`\r\n`) instead of `LF` (`\n`). This is problematic cross-platform (and means we generate different lockfiles depending on which platform were' on)
- When we save file paths to `esy.lock.json`, they are saved with backslashes instead of forward slashes. As above, this causes problems cross-platform, and is not consistent with what we generate in OSX.

__Fix:__
- Add a `System.Environment.normalizeNewLines` helper method, and use that to sanitize the content of the files prior to persisting them.
- Add a `Path.showNormalized`, which sanitizes the slashes. We save the string value into the `Package` object, so that it doesn't get implicitly to stringed by the default path strategy - which would use the platform specific slashes.