### PR TITLE
Fix lockfile naming

### DIFF
--- a/esyi/SandboxSpec.ml
+++ b/esyi/SandboxSpec.ml
@@ -34,10 +34,9 @@ let buildPath spec = Path.(localPrefixPath spec / "build")
 
 let lockfilePath spec =
   match spec.manifest with
-  | One (Esy, "package.json") | One (Esy, "esy.json") -> Path.(spec.path / "esy.lock.json")
-  | _ ->
-    let name = name spec in
-    Path.(spec.path / ("esy." ^ name ^ ".json"))
+  | One (Esy, "package.json")
+  | One (Esy, "esy.json") -> Path.(spec.path / "esy.lock.json")
+  | _ -> Path.(spec.path / (name spec ^ ".esy.lock.json"))
 
 let ofPath path =
   let open RunAsync.Syntax in

--- a/test-e2e/install/basic-esy.test.js
+++ b/test-e2e/install/basic-esy.test.js
@@ -1,6 +1,8 @@
 /* @flow */
 
 const helpers = require('../test/helpers.js');
+const path = require('path');
+const fs = require('../test/fs.js');
 
 describe(`Basic tests`, () => {
   test(`it should correctly install a single dependency that contains no sub-dependencies`, async () => {
@@ -15,6 +17,8 @@ describe(`Basic tests`, () => {
     const p = await helpers.createTestSandbox(...fixture);
 
     await p.esy(`install`);
+
+    expect(await fs.exists(path.join(p.projectPath, 'esy.lock.json'))).toBeTruthy();
 
     await expect(
       p.runJavaScriptInNodeAndReturnJson(`require('no-deps')`),

--- a/test-e2e/install/basic-npm.test.js
+++ b/test-e2e/install/basic-npm.test.js
@@ -1,7 +1,8 @@
 /* @flow */
 
-const path = require('path');
 const helpers = require('../test/helpers.js');
+const path = require('path');
+const fs = require('../test/fs.js');
 
 helpers.skipSuiteOnWindows();
 
@@ -17,6 +18,8 @@ describe(`Basic tests for npm packages`, () => {
 
     const p = await helpers.createTestSandbox(...fixture);
     await p.esy('install');
+
+    expect(await fs.exists(path.join(p.projectPath, 'esy.lock.json'))).toBeTruthy();
 
     await expect(
       p.runJavaScriptInNodeAndReturnJson(`require('no-deps')`),

--- a/test-e2e/install/mutliple-sandbox.test.js
+++ b/test-e2e/install/mutliple-sandbox.test.js
@@ -1,5 +1,7 @@
 // @flow
 
+const path = require('path');
+const fs = require('../test/fs.js');
 const helpers = require('../test/helpers.js');
 
 const {file, packageJson} = helpers;
@@ -41,6 +43,8 @@ describe('projects with multiple sandboxes', function() {
       esy: {},
     });
 
+    // install default sandbox
+
     await p.esy('install');
 
     expect(await helpers.crawlLayout(p.projectPath, 'default')).toMatchObject({
@@ -48,6 +52,10 @@ describe('projects with multiple sandboxes', function() {
         'default-dep': {name: 'default-dep', version: '0.0.0'},
       },
     });
+    expect(await fs.exists(path.join(p.projectPath, 'esy.lock.json'))).toBeTruthy();
+
+    // install custom sandbox
+
     await p.esy('@package.custom.json install');
 
     expect(await helpers.crawlLayout(p.projectPath, 'package.custom')).toMatchObject({
@@ -55,5 +63,8 @@ describe('projects with multiple sandboxes', function() {
         'custom-dep': {name: 'custom-dep', version: '0.0.0'},
       },
     });
+    expect(
+      await fs.exists(path.join(p.projectPath, 'package.custom.esy.lock.json')),
+    ).toBeTruthy();
   });
 });

--- a/test-e2e/test/FixtureUtils.js
+++ b/test-e2e/test/FixtureUtils.js
@@ -48,7 +48,7 @@ function file(name: string, data: string): FixtureFile {
   return {type: 'file', name, data};
 }
 
-function json(name, json: Object): FixtureFile {
+function json(name: string, json: Object): FixtureFile {
   const data = JSON.stringify(json, null, 2);
   return {type: 'file', name, data};
 }


### PR DESCRIPTION
Minor fix to lockfile naming for non-default sandboxes (sandboxes defined via a non-package.json manifest).

We have `esy.lock.json` currently for default sandboxes. This commit makes
lockfiles naming for non-default sandboxes to follow:

    <sandbox-id>.esy.lock.json

Also this PR adds test assertions for lockfile existence just to lock that behaviour.