### PR TITLE
Fixes to path:/link: resolution

### DIFF
--- a/esyi/Package.ml
+++ b/esyi/Package.ml
@@ -376,7 +376,7 @@ module Resolution = struct
       let%bind version = Version.parse v in
       return (Version version)
     | `Assoc _ ->
-      let%bind source = Json.Decode.fieldWith ~name:"source" Source.of_yojson json in
+      let%bind source = Json.Decode.fieldWith ~name:"source" Source.relaxed_of_yojson json in
       let%bind override = Json.Decode.fieldWith ~name:"override" override_of_yojson json in
       return (SourceOverride {source; override;})
     | _ -> Error "expected string or object"

--- a/esyi/PackageJson.ml
+++ b/esyi/PackageJson.ml
@@ -18,6 +18,7 @@ module Manifest = struct
     tarball : string;
     shasum : string;
   }
+
 end
 
 module ResolutionsOfManifest = struct
@@ -26,6 +27,29 @@ module ResolutionsOfManifest = struct
   } [@@deriving of_yojson { strict = false }]
 end
 
+let rebaseDependencies source reqs =
+  let open Run.Syntax in
+  let f req =
+    match source, req.Req.spec with
+    | (Source.LocalPath {path = basePath; _} | Source.LocalPathLink {path = basePath; _}),
+      VersionSpec.Source (SourceSpec.LocalPath {path; manifest;}) ->
+      let path = Path.(basePath // path |> normalizeAndRemoveEmptySeg) in
+      let spec = VersionSpec.Source (SourceSpec.LocalPath {path; manifest;}) in
+      return (Req.make ~name:req.name ~spec)
+    | (Source.LocalPath {path = basePath; _} | Source.LocalPathLink {path = basePath; _}),
+      VersionSpec.Source (SourceSpec.LocalPathLink {path; manifest;}) ->
+      let path = Path.(basePath // path |> normalizeAndRemoveEmptySeg) in
+      let spec = VersionSpec.Source (SourceSpec.LocalPathLink {path; manifest;}) in
+      return (Req.make ~name:req.name ~spec)
+    | _, VersionSpec.Source (SourceSpec.LocalPath _)
+    | _, VersionSpec.Source (SourceSpec.LocalPathLink _) ->
+      errorf
+        "path constraints %a are not allowed from %a"
+        VersionSpec.pp req.spec Source.pp source
+    | _ -> return req
+  in
+  Result.List.map ~f reqs
+
 let packageOfJson ?(parseResolutions=false) ?source ~name ~version json =
   let open Run.Syntax in
   let%bind pkgJson = Json.parseJsonWith Manifest.of_yojson json in
@@ -33,23 +57,6 @@ let packageOfJson ?(parseResolutions=false) ?source ~name ~version json =
     match pkgJson.Manifest.version with
     | Some version -> Some (Version.Npm version)
     | None -> None
-  in
-  let dependencies =
-    match pkgJson.esy with
-    | None
-    | Some {EsyPackageJson. _dependenciesForNewEsyInstaller= None} ->
-      pkgJson.dependencies
-    | Some {EsyPackageJson. _dependenciesForNewEsyInstaller= Some dependencies} ->
-      dependencies
-  in
-  let%bind resolutions =
-    match parseResolutions with
-    | false -> return Package.Resolutions.empty
-    | true ->
-      let%bind {ResolutionsOfManifest. resolutions} =
-        Json.parseJsonWith ResolutionsOfManifest.of_yojson json
-      in
-      return resolutions
   in
 
   let%bind source =
@@ -64,6 +71,29 @@ let packageOfJson ?(parseResolutions=false) ?source ~name ~version json =
       error "unable to determine package source, missing 'dist' metadata"
   in
 
+
+  let dependencies =
+    match pkgJson.esy with
+    | None
+    | Some {EsyPackageJson. _dependenciesForNewEsyInstaller= None} ->
+      pkgJson.dependencies
+    | Some {EsyPackageJson. _dependenciesForNewEsyInstaller= Some dependencies} ->
+      dependencies
+  in
+
+  let%bind dependencies = rebaseDependencies source dependencies in
+  let%bind devDependencies = rebaseDependencies source pkgJson.devDependencies in
+
+  let%bind resolutions =
+    match parseResolutions with
+    | false -> return Package.Resolutions.empty
+    | true ->
+      let%bind {ResolutionsOfManifest. resolutions} =
+        Json.parseJsonWith ResolutionsOfManifest.of_yojson json
+      in
+      return resolutions
+  in
+
   return {
     Package.
     name;
@@ -71,7 +101,7 @@ let packageOfJson ?(parseResolutions=false) ?source ~name ~version json =
     originalVersion;
     originalName = pkgJson.name;
     dependencies = Package.Dependencies.NpmFormula dependencies;
-    devDependencies = Package.Dependencies.NpmFormula pkgJson.devDependencies;
+    devDependencies = Package.Dependencies.NpmFormula devDependencies;
     resolutions;
     source = source, [];
     overrides = Package.Overrides.empty;

--- a/esyi/Resolver.ml
+++ b/esyi/Resolver.ml
@@ -461,10 +461,16 @@ let resolveSource ~name ~(sourceSpec : SourceSpec.t) (resolver : t) =
         return (Source.Archive {url; checksum})
 
       | SourceSpec.LocalPath {path; manifest;} ->
-        return (Source.LocalPath {path; manifest;})
+        let abspath = Path.(resolver.root // path) in
+        if%bind Fs.exists abspath
+        then return (Source.LocalPath {path; manifest;})
+        else errorf "path '%a' does not exist" Path.ppPretty abspath
 
       | SourceSpec.LocalPathLink {path; manifest;} ->
-        return (Source.LocalPathLink {path; manifest;})
+        let abspath = Path.(resolver.root // path) in
+        if%bind Fs.exists abspath
+        then return (Source.LocalPathLink {path; manifest;})
+        else errorf "path '%a' does not exist" Path.ppPretty abspath
     in
     Hashtbl.replace resolver.sourceSpecToSource sourceSpec source;
     return source

--- a/esyi/Source.ml
+++ b/esyi/Source.ml
@@ -169,7 +169,15 @@ let to_yojson v =
 
 let of_yojson json =
   match json with
-  | `String string -> parse string
+  | `String string ->
+    parse string
+  | _ -> Error "expected string"
+
+let relaxed_of_yojson json =
+  match json with
+  | `String string ->
+    let parse = Parse.(parse (parser <|> parserRelaxed)) in
+    parse string
   | _ -> Error "expected string"
 
 module Map = Map.Make(struct

--- a/esyi/Source.ml
+++ b/esyi/Source.ml
@@ -259,35 +259,41 @@ let%test_module "parsing" = (module struct
     parse "no-source:";
     [%expect {| NoSource |}]
 
-  let parseRelaxedd =
+  let parseRelaxed =
     Parse.Test.parse ~sexp_of:sexp_of_t parseRelaxed
 
   let%expect_test "user/repo#commit" =
-    parseRelaxedd "user/repo#commit";
+    parseRelaxed "user/repo#commit";
     [%expect {| (Github (user user) (repo repo) (commit commit) (manifest ())) |}]
 
   let%expect_test "user/repo:lwt.opam#commit" =
-    parseRelaxedd "user/repo:lwt.opam#commit";
+    parseRelaxed "user/repo:lwt.opam#commit";
     [%expect {| (Github (user user) (repo repo) (commit commit) (manifest ((Opam lwt.opam)))) |}]
 
   let%expect_test "http://example.com#abc123" =
-    parseRelaxedd "http://example.com#abc123";
+    parseRelaxed "http://example.com#abc123";
     [%expect {| (Archive (url http://example.com) (checksum (Sha1 abc123))) |}]
 
   let%expect_test "https://example.com#abc123" =
-    parseRelaxedd "https://example.com#abc123";
+    parseRelaxed "https://example.com#abc123";
     [%expect {| (Archive (url https://example.com) (checksum (Sha1 abc123))) |}]
 
   let%expect_test "https://example.com#md5:abc123" =
-    parseRelaxedd "https://example.com#md5:abc123";
+    parseRelaxed "https://example.com#md5:abc123";
     [%expect {| (Archive (url https://example.com) (checksum (Md5 abc123))) |}]
 
+  let%expect_test "http://localhost:56886/dep/-/dep-1.0.0.tgz#fabe490fb72a10295d554037341d8c7d5497cde9" =
+    parseRelaxed "http://localhost:56886/dep/-/dep-1.0.0.tgz#fabe490fb72a10295d554037341d8c7d5497cde9";
+    [%expect {|
+      (Archive (url http://localhost:56886/dep/-/dep-1.0.0.tgz)
+       (checksum (Sha1 fabe490fb72a10295d554037341d8c7d5497cde9))) |}]
+
   let%expect_test "/some/path" =
-    parseRelaxedd "/some/path";
+    parseRelaxed "/some/path";
     [%expect {| (LocalPath (path /some/path) (manifest ())) |}]
 
   let%expect_test "some" =
-    parseRelaxedd "some";
+    parseRelaxed "some";
     [%expect {| Error parsing 'some': : not a path |}]
 
 end)

--- a/esyi/Source.mli
+++ b/esyi/Source.mli
@@ -26,6 +26,8 @@ type t =
 
 include S.COMMON with type t := t
 
+val relaxed_of_yojson : t Json.decoder
+
 val sexp_of_t : t -> Sexplib0.Sexp.t
 val ppPretty : t Fmt.t
 

--- a/test-e2e/errors/solve-errors.test.js
+++ b/test-e2e/errors/solve-errors.test.js
@@ -305,4 +305,50 @@ describe('"esy solve" errors', function() {
       `,
     );
   });
+
+  it('reports errors about missing link: packages (path does not exist)', async () => {
+    const p = await helpers.createTestSandbox();
+
+    await p.fixture(
+      packageJson({
+        name: 'root',
+        esy: {},
+        dependencies: {
+          missing: 'path:./missing',
+        },
+      }),
+    );
+
+    const err = await expectAndReturnRejection(p.esy('install --skip-repository-update'));
+    expect(err.stderr.trim()).toEqual(
+      outdent`
+      error: path 'missing' does not exist
+        resolving missing@path:missing
+      esy: exiting due to errors above
+      `,
+    );
+  });
+
+  it('reports errors about missing link: packages (path does not exist)', async () => {
+    const p = await helpers.createTestSandbox();
+
+    await p.fixture(
+      packageJson({
+        name: 'root',
+        esy: {},
+        dependencies: {
+          missing: 'link:./missing',
+        },
+      }),
+    );
+
+    const err = await expectAndReturnRejection(p.esy('install --skip-repository-update'));
+    expect(err.stderr.trim()).toEqual(
+      outdent`
+      error: path 'missing' does not exist
+        resolving missing@link:missing
+      esy: exiting due to errors above
+      `,
+    );
+  });
 });

--- a/test-e2e/install/link.test.js
+++ b/test-e2e/install/link.test.js
@@ -90,4 +90,154 @@ describe(`installing linked packages`, () => {
     const binContents = await helpers.readFile(binPath);
     expect(binContents.toString()).toEqual('something');
   });
+
+  test('it should install local packages of dependencies (path: -> path:)', async () => {
+    const fixture = [
+      packageJson({
+        name: 'root',
+        version: '1.0.0',
+        esy: {},
+        dependencies: {
+          dep: 'path:./dep',
+        },
+      }),
+      dir(
+        'dep',
+        packageJson({
+          name: 'dep',
+          version: '1.0.0',
+          esy: {},
+          dependencies: {
+            linkedDep: 'path:../linkedDep',
+          },
+        }),
+      ),
+      dir(
+        'linkedDep',
+        packageJson({
+          name: 'linkedDep',
+          version: '1.0.0',
+          esy: {},
+        }),
+      ),
+    ];
+    const p = await helpers.createTestSandbox(...fixture);
+
+    await p.esy(`install`);
+
+    const layout = await helpers.crawlLayout(p.projectPath);
+    expect(layout).toMatchObject({
+      name: 'root',
+      dependencies: {
+        dep: {
+          name: 'dep',
+          version: '1.0.0',
+        },
+        linkedDep: {
+          name: 'linkedDep',
+          version: '1.0.0',
+        },
+      },
+    });
+  });
+
+  test('it should install local packages of dependencies (path: -> link:)', async () => {
+    const fixture = [
+      packageJson({
+        name: 'root',
+        version: '1.0.0',
+        esy: {},
+        dependencies: {
+          dep: 'path:./dep',
+        },
+      }),
+      dir(
+        'dep',
+        packageJson({
+          name: 'dep',
+          version: '1.0.0',
+          esy: {},
+          dependencies: {
+            linkedDep: 'link:../linkedDep',
+          },
+        }),
+      ),
+      dir(
+        'linkedDep',
+        packageJson({
+          name: 'linkedDep',
+          version: '1.0.0',
+          esy: {},
+        }),
+      ),
+    ];
+    const p = await helpers.createTestSandbox(...fixture);
+
+    await p.esy(`install`);
+
+    const layout = await helpers.crawlLayout(p.projectPath);
+    expect(layout).toMatchObject({
+      name: 'root',
+      dependencies: {
+        dep: {
+          name: 'dep',
+          version: '1.0.0',
+        },
+        linkedDep: {
+          name: 'linkedDep',
+          version: '1.0.0',
+        },
+      },
+    });
+  });
+
+  test('it should install local packages of dependencies (link: -> link:)', async () => {
+    const fixture = [
+      packageJson({
+        name: 'root',
+        version: '1.0.0',
+        esy: {},
+        dependencies: {
+          dep: 'link:./dep',
+        },
+      }),
+      dir(
+        'dep',
+        packageJson({
+          name: 'dep',
+          version: '1.0.0',
+          esy: {},
+          dependencies: {
+            linkedDep: 'link:../linkedDep',
+          },
+        }),
+      ),
+      dir(
+        'linkedDep',
+        packageJson({
+          name: 'linkedDep',
+          version: '1.0.0',
+          esy: {},
+        }),
+      ),
+    ];
+    const p = await helpers.createTestSandbox(...fixture);
+
+    await p.esy(`install`);
+
+    const layout = await helpers.crawlLayout(p.projectPath);
+    expect(layout).toMatchObject({
+      name: 'root',
+      dependencies: {
+        dep: {
+          name: 'dep',
+          version: '1.0.0',
+        },
+        linkedDep: {
+          name: 'linkedDep',
+          version: '1.0.0',
+        },
+      },
+    });
+  });
 });

--- a/test-e2e/install/resolutions.test.js
+++ b/test-e2e/install/resolutions.test.js
@@ -325,7 +325,6 @@ describe(`Installing with resolutions`, () => {
     const url = await helpers.getPackageHttpArchivePath(p.npmRegistry, 'dep', '1.0.0');
     const hash = await helpers.getPackageArchiveHash(p.npmRegistry, 'dep', '1.0.0');
     const source = `${url}#${hash}`;
-    console.log(source);
 
     await p.fixture(
       helpers.packageJson({

--- a/test-e2e/install/resolutions.test.js
+++ b/test-e2e/install/resolutions.test.js
@@ -271,7 +271,7 @@ describe(`Installing with resolutions`, () => {
             override: {
               dependencies: {
                 // this path should be resolved against this location
-                depdep: 'path:../depdep',
+                depdep: 'path:./depdep',
               },
             },
           },

--- a/test-e2e/install/resolutions.test.js
+++ b/test-e2e/install/resolutions.test.js
@@ -207,4 +207,169 @@ describe(`Installing with resolutions`, () => {
       },
     });
   });
+
+  test(`resolutions could have linked packages`, async () => {
+    const fixture = [
+      helpers.packageJson({
+        name: 'root',
+        version: '1.0.0',
+        esy: {},
+        dependencies: {dep: '1.0.0'},
+        resolutions: {dep: 'link:./dep'},
+      }),
+      helpers.dir(
+        'dep',
+        helpers.packageJson({
+          name: 'dep',
+          version: '1.0.0',
+          esy: {},
+          dependencies: {
+            // this path should be resolved against this location
+            depdep: 'link:../depdep',
+          },
+        }),
+      ),
+      helpers.dir(
+        'depdep',
+        helpers.packageJson({
+          name: 'depdep',
+          version: '1.0.0',
+          esy: {},
+        }),
+      ),
+    ];
+    const p = await helpers.createTestSandbox(...fixture);
+
+    await p.esy(`install`);
+
+    const layout = await helpers.crawlLayout(p.projectPath);
+    expect(layout).toMatchObject({
+      name: 'root',
+      dependencies: {
+        dep: {
+          name: 'dep',
+          version: '1.0.0',
+        },
+        depdep: {
+          name: 'depdep',
+          version: '1.0.0',
+        },
+      },
+    });
+  });
+
+  test(`resolutions overrides could inject linked packages`, async () => {
+    const fixture = [
+      helpers.packageJson({
+        name: 'root',
+        version: '1.0.0',
+        esy: {},
+        dependencies: {dep: '1.0.0'},
+        resolutions: {
+          dep: {
+            source: 'path:./dep',
+            override: {
+              dependencies: {
+                // this path should be resolved against this location
+                depdep: 'path:../depdep',
+              },
+            },
+          },
+        },
+      }),
+      helpers.dir(
+        'dep',
+        helpers.packageJson({
+          name: 'dep',
+          version: '1.0.0',
+          esy: {},
+        }),
+      ),
+      helpers.dir(
+        'depdep',
+        helpers.packageJson({
+          name: 'depdep',
+          version: '1.0.0',
+          esy: {},
+        }),
+      ),
+    ];
+    const p = await helpers.createTestSandbox(...fixture);
+
+    await p.esy(`install`);
+
+    const layout = await helpers.crawlLayout(p.projectPath);
+    expect(layout).toMatchObject({
+      name: 'root',
+      dependencies: {
+        dep: {
+          name: 'dep',
+          version: '1.0.0',
+        },
+        depdep: {
+          name: 'depdep',
+          version: '1.0.0',
+        },
+      },
+    });
+  });
+
+  test(`resolutions overrides could inject linked packages to non local packages`, async () => {
+    const p = await helpers.createTestSandbox();
+
+    await p.defineNpmPackage({
+      name: 'dep',
+      version: '1.0.0',
+    });
+
+    const url = await helpers.getPackageHttpArchivePath(p.npmRegistry, 'dep', '1.0.0');
+    const hash = await helpers.getPackageArchiveHash(p.npmRegistry, 'dep', '1.0.0');
+    const source = `${url}#${hash}`;
+    console.log(source);
+
+    await p.fixture(
+      helpers.packageJson({
+        name: 'root',
+        version: '1.0.0',
+        esy: {},
+        dependencies: {dep: '1.0.0'},
+        resolutions: {
+          dep: {
+            source: `${url}#${hash}`,
+            override: {
+              dependencies: {
+                // this path should be resolved against dep's location
+                depdep: 'path:./depdep',
+              },
+            },
+          },
+        },
+      }),
+      helpers.dir(
+        'depdep',
+        helpers.packageJson({
+          name: 'depdep',
+          version: '1.0.0',
+          esy: {},
+        }),
+      ),
+    );
+
+    await p.esy(`install`);
+
+    const layout = await helpers.crawlLayout(p.projectPath);
+    expect(layout).toMatchObject({
+      name: 'root',
+      dependencies: {
+        dep: {
+          name: 'dep',
+          version: '1.0.0',
+        },
+        depdep: {
+          name: 'depdep',
+          version: '1.0.0',
+        },
+      },
+    });
+  });
 });

--- a/test-e2e/test/NpmRegistryMock.js
+++ b/test-e2e/test/NpmRegistryMock.js
@@ -462,6 +462,7 @@ module.exports = {
   getPackageDirectoryPath,
   getPackageHttpArchivePath,
   getPackageArchivePath,
+  getPackageArchiveHash,
   definePackage,
   definePackageOfFixture,
   defineLocalPackage,

--- a/test-e2e/test/helpers.js
+++ b/test-e2e/test/helpers.js
@@ -3,6 +3,7 @@
 jest.setTimeout(120000);
 
 import type {Fixture} from './FixtureUtils.js';
+import type {PackageRegistry} from './NpmRegistryMock.js';
 const path = require('path');
 const fs = require('fs-extra');
 const fsUtils = require('./fs.js');
@@ -39,6 +40,7 @@ export type TestSandbox = {
   projectPath: string,
   esyPrefixPath: string,
   npmPrefixPath: string,
+  npmRegistry: PackageRegistry,
 
   fixture: (...fixture: Fixture) => Promise<void>,
 
@@ -153,6 +155,7 @@ async function createTestSandbox(...fixture: Fixture): Promise<TestSandbox> {
     run,
     esy,
     npm,
+    npmRegistry,
     fixture: async (...fixture) => {
       await FixtureUtils.initialize(projectPath, fixture);
     },
@@ -206,6 +209,7 @@ module.exports = {
   json: FixtureUtils.json,
   skipSuiteOnWindows,
   ESYCOMMAND,
+  getPackageArchiveHash: NpmRegistryMock.getPackageArchiveHash,
   getPackageDirectoryPath: NpmRegistryMock.getPackageDirectoryPath,
   getPackageHttpArchivePath: NpmRegistryMock.getPackageHttpArchivePath,
   getPackageArchivePath: NpmRegistryMock.getPackageArchivePath,


### PR DESCRIPTION
This PR fixes (one can say even formalizes) how we resolve `path:` and `link:`
dependencies:

- We now resolve `path:` and `link:` against the source which we load metadata
  from. Previously we resolved them only relative to a root package.

- We only allow `path:` and `link:` dependencies from local dependencies (other
  `path:` and `link:` dependencies). Otherwise it doesn't make much sense.

Add e2e tests which cover that too.