### PR TITLE
Windows: Enable slowtests via appveyor on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ test-e2e-slow::
 	@node ./test-e2e-slow/install-npm.test.js
 	@node ./test-e2e-slow/esy.test.js
 	@node ./test-e2e-slow/reason.test.js
-	@node ./test-e2e-slow/repromise.test.js.test.js
+	@node ./test-e2e-slow/repromise.test.js
 	@node ./test-e2e-slow/fastpack.test.js
 	@node ./test-e2e-slow/release.test.js
 

--- a/Makefile
+++ b/Makefile
@@ -119,14 +119,7 @@ test-e2e::
 	@$(BIN)/jest test-e2e
 
 test-e2e-slow::
-	@echo "Running test suite: e2e (slow tests)"
-	@node ./test-e2e-slow/build-top-100-opam.test.js
-	@node ./test-e2e-slow/install-npm.test.js
-	@node ./test-e2e-slow/esy.test.js
-	@node ./test-e2e-slow/reason.test.js
-	@node ./test-e2e-slow/repromise.test.js
-	@node ./test-e2e-slow/fastpack.test.js
-	@node ./test-e2e-slow/release.test.js
+	@node ./test-e2e-slow/run-slow-tests
 
 test::
 	@echo "Running test suite: unit tests"
@@ -136,9 +129,7 @@ test::
 
 ci::
 	@$(MAKE) test
-	@if [ "$$TRAVIS_TAG" != "" ] || [ $$(echo "$$TRAVIS_COMMIT_MESSAGE" | grep "@slowtest") ]; then \
-		$(MAKE) test-e2e-slow; \
-	fi
+	@$(MAKE) test-e2e-slow
 
 #
 # Release

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,5 +40,5 @@ deploy:
 
 test: off
 
-# on_finish:
-#       - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+on_finish:
+      - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,10 @@ install:
 
 build_script:
      - npm run build
+     - jest test-e2e
+     - npm run test:unit
      - npm run test:e2e-slow
+     - npm run release:make-platform-package
 
 artifacts:
     - path: _platformrelease/*.tgz

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,6 +39,3 @@ deploy:
           appveyor_repo_tag: true
 
 test: off
-
-on_finish:
-      - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/esy-lib/Fs.ml
+++ b/esy-lib/Fs.ml
@@ -18,13 +18,9 @@ let readFile (path : Path.t) =
 let writeFile ?perm ~data (path : Path.t) =
   let path = Path.show path in
   let desc = Printf.sprintf "Unable to write file %s" path in
-  let p = match System.Platform.host with
-      | Windows -> None
-      | _ -> perm
-  in
   toRunAsync ~desc (fun () ->
     let f oc = Lwt_io.write oc data in
-    Lwt_io.with_file ?perm:p ~mode:Lwt_io.Output path f
+    Lwt_io.with_file ?perm ~mode:Lwt_io.Output path f
   )
 
 let openFile ~mode ~perm path =

--- a/esy-lib/Fs.ml
+++ b/esy-lib/Fs.ml
@@ -18,13 +18,13 @@ let readFile (path : Path.t) =
 let writeFile ?perm ~data (path : Path.t) =
   let path = Path.show path in
   let desc = Printf.sprintf "Unable to write file %s" path in
-  let p match System.Platform.host with
+  let p = match System.Platform.host with
       | Windows -> None
       | _ -> perm
   in
   toRunAsync ~desc (fun () ->
     let f oc = Lwt_io.write oc data in
-    Lwt_io.with_file perm:p ~mode:Lwt_io.Output path f
+    Lwt_io.with_file ?perm:p ~mode:Lwt_io.Output path f
   )
 
 let openFile ~mode ~perm path =

--- a/esy-lib/Fs.ml
+++ b/esy-lib/Fs.ml
@@ -18,9 +18,13 @@ let readFile (path : Path.t) =
 let writeFile ?perm ~data (path : Path.t) =
   let path = Path.show path in
   let desc = Printf.sprintf "Unable to write file %s" path in
+  let p match System.Platform.host with
+      | Windows -> None
+      | _ -> perm
+  in
   toRunAsync ~desc (fun () ->
     let f oc = Lwt_io.write oc data in
-    Lwt_io.with_file ?perm ~mode:Lwt_io.Output path f
+    Lwt_io.with_file perm:p ~mode:Lwt_io.Output path f
   )
 
 let openFile ~mode ~perm path =

--- a/esyi/Config.re
+++ b/esyi/Config.re
@@ -70,7 +70,7 @@ let make =
       };
 
       let esyOpamOverride = {
-        let defaultRemote = "https://github.com/bryphe/esy-opam-override";
+        let defaultRemote = "https://github.com/esy-ocaml/esy-opam-override";
         let defaultLocal = Path.(cachePath / "esy-opam-override");
         configureCheckout(~defaultLocal, ~defaultRemote, esyOpamOverride);
       };

--- a/test-e2e-slow/build-top-100-opam.test.js
+++ b/test-e2e-slow/build-top-100-opam.test.js
@@ -152,7 +152,7 @@ function shuffle(array) {
 
 function selectCases(array) {
     // Start with a subset on windows...
-    return os.platform() == "win32" ? shuffle(array.slice(0, 25)) : shuffle(array);
+    return os.platform() == "win32" ? shuffle(array.slice(0, 20)) : shuffle(array);
 }
 
 const startTime = new Date();

--- a/test-e2e-slow/build-top-100-opam.test.js
+++ b/test-e2e-slow/build-top-100-opam.test.js
@@ -181,7 +181,14 @@ for (let c of shuffle(cases)) {
       reposUpdated = true;
     }
 
-    sandbox.esy(...install);
+    for (let i = 0; i < 5; i++) {
+        console.log("Iteration: " + i.toString());
+        try {
+            sandbox.esy(...install);
+        } catch (ex) {
+            console.warn(ex);
+        }
+    }
     sandbox.esy('build');
 
     rmSync(path.join(esyPrefixPath, '3', 'b'));

--- a/test-e2e-slow/build-top-100-opam.test.js
+++ b/test-e2e-slow/build-top-100-opam.test.js
@@ -152,7 +152,7 @@ function shuffle(array) {
 function selectCases(array) {
     if (os.platform() == "win32") {
         // Start with a subset on Windows...
-        return array.slice(0, 25);
+        return array.slice(0, 3);
     } else {
         return shuffle(array);
     }

--- a/test-e2e-slow/build-top-100-opam.test.js
+++ b/test-e2e-slow/build-top-100-opam.test.js
@@ -162,7 +162,7 @@ function selectCases(array) {
 }
 
 const startTime = new Date();
-const runtimeLimit = 17 * 60 * 1000;
+const runtimeLimit = 10 * 60 * 1000;
 
 setup();
 

--- a/test-e2e-slow/build-top-100-opam.test.js
+++ b/test-e2e-slow/build-top-100-opam.test.js
@@ -125,8 +125,8 @@ let reposUpdated = false;
 
 function selectCases(array) {
     if (os.platform() == "win32") {
-        // Start with top 10 on windows
-        return array.slice(0, 10);
+        // Start with top 8 on windows, and work through to enable more!
+        return array.slice(0, 8);
     } else {
         return shuffle(array);
     }

--- a/test-e2e-slow/build-top-100-opam.test.js
+++ b/test-e2e-slow/build-top-100-opam.test.js
@@ -40,8 +40,6 @@ const cases = [
   {name: 'ocamlbuild', toolchains: [ocamlVersion]},
   {name: 'topkg', toolchains: [ocamlVersion]},
   {name: 'ocaml-migrate-parsetree', toolchains: [ocamlVersion]},
-  // Blocked by esy/esy#505
-  // {name: 'coq', toolchains: [ocamlVersion]},
   {name: 'camlp5', toolchains: [ocamlVersion]},
   {name: 'ppx_tools_versioned', toolchains: [ocamlVersion]},
   {name: 'yojson', toolchains: [ocamlVersion]},

--- a/test-e2e-slow/build-top-100-opam.test.js
+++ b/test-e2e-slow/build-top-100-opam.test.js
@@ -200,14 +200,7 @@ for (let c of selectCases(cases)) {
       reposUpdated = true;
     }
 
-    for (let i = 0; i < 5; i++) {
-        console.log("Iteration: " + i.toString());
-        try {
-            sandbox.esy(...install);
-        } catch (ex) {
-            console.warn(ex);
-        }
-    }
+    sandbox.esy(...install);
     sandbox.esy('build');
 
     rmSync(path.join(esyPrefixPath, '3', 'b'));

--- a/test-e2e-slow/build-top-100-opam.test.js
+++ b/test-e2e-slow/build-top-100-opam.test.js
@@ -156,7 +156,7 @@ function selectCases(array) {
 }
 
 const startTime = new Date();
-const runtimeLimit = 10 * 60 * 1000;
+const runtimeLimit = 17 * 60 * 1000;
 
 setup();
 

--- a/test-e2e-slow/build-top-100-opam.test.js
+++ b/test-e2e-slow/build-top-100-opam.test.js
@@ -8,6 +8,7 @@ const {
   esyPrefixPath,
 } = require('./setup.js');
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 const rmSync = require('rimraf').sync;
 const isCi = require('is-ci');
@@ -122,6 +123,15 @@ const cases = [
 
 let reposUpdated = false;
 
+function selectCases(array) {
+    if (os.platform() == "win32") {
+        // Start with top 10 on windows
+        return array.slice(0, 10);
+    } else {
+        return shuffle(array);
+    }
+}
+
 function shuffle(array) {
   array = array.slice(0);
   let counter = array.length;
@@ -144,7 +154,7 @@ const runtimeLimit = 17 * 60 * 1000;
 
 setup();
 
-for (let c of shuffle(cases)) {
+for (let c of selectCases(cases)) {
   for (let toolchain of c.toolchains) {
     const nowTime = new Date();
     if (isCi && nowTime - startTime > runtimeLimit) {

--- a/test-e2e-slow/build-top-100-opam.test.js
+++ b/test-e2e-slow/build-top-100-opam.test.js
@@ -152,7 +152,7 @@ function shuffle(array) {
 
 function selectCases(array) {
     // Start with a subset on windows...
-    return os.platform() == "win32" ? shuffle(array.slice(0, 20)) : shuffle(array);
+    return os.platform() == "win32" ? shuffle(array.slice(0, 10)) : shuffle(array);
 }
 
 const startTime = new Date();

--- a/test-e2e-slow/build-top-100-opam.test.js
+++ b/test-e2e-slow/build-top-100-opam.test.js
@@ -17,7 +17,8 @@ const cases = [
   {name: 'dune', toolchains: [ocamlVersion]},
   {name: 'menhir', toolchains: [ocamlVersion]},
   {name: 'cmdliner', toolchains: [ocamlVersion]},
-  {name: 'coq', toolchains: [ocamlVersion]},
+  // Blocked by esy/esy#505
+  // {name: 'coq', toolchains: [ocamlVersion]},
   {name: 'angstrom', toolchains: [ocamlVersion]},
   {name: 'bos', toolchains: [ocamlVersion]},
   {name: 'bigstringaf', toolchains: [ocamlVersion]},
@@ -39,6 +40,8 @@ const cases = [
   {name: 'ocamlbuild', toolchains: [ocamlVersion]},
   {name: 'topkg', toolchains: [ocamlVersion]},
   {name: 'ocaml-migrate-parsetree', toolchains: [ocamlVersion]},
+  // Blocked by esy/esy#505
+  // {name: 'coq', toolchains: [ocamlVersion]},
   {name: 'camlp5', toolchains: [ocamlVersion]},
   {name: 'ppx_tools_versioned', toolchains: [ocamlVersion]},
   {name: 'yojson', toolchains: [ocamlVersion]},
@@ -152,7 +155,7 @@ function shuffle(array) {
 function selectCases(array) {
     if (os.platform() == "win32") {
         // Start with a subset on Windows...
-        return array.slice(0, 3);
+        return array.slice(0, 25);
     } else {
         return shuffle(array);
     }

--- a/test-e2e-slow/build-top-100-opam.test.js
+++ b/test-e2e-slow/build-top-100-opam.test.js
@@ -186,6 +186,10 @@ for (let c of selectCases(cases)) {
       dependencies: {
         ['@opam/' + c.name]: '*',
       },
+      resolutions: {
+        // Workaround until new version of angstrom is released
+        "@opam/angstrom": "github:esy-ocaml/angstrom#b3a125f"
+      },
       devDependencies: {
         ocaml: toolchain,
       },

--- a/test-e2e-slow/build-top-100-opam.test.js
+++ b/test-e2e-slow/build-top-100-opam.test.js
@@ -153,12 +153,8 @@ function shuffle(array) {
 }
 
 function selectCases(array) {
-    if (os.platform() == "win32") {
-        // Start with a subset on Windows...
-        return array.slice(0, 25);
-    } else {
-        return shuffle(array);
-    }
+    // Start with a subset on windows...
+    return os.platform() == "win32" ? shuffle(array.slice(0, 25)) : shuffle(array);
 }
 
 const startTime = new Date();

--- a/test-e2e-slow/build-top-100-opam.test.js
+++ b/test-e2e-slow/build-top-100-opam.test.js
@@ -14,14 +14,31 @@ const rmSync = require('rimraf').sync;
 const isCi = require('is-ci');
 
 const cases = [
+  {name: 'dune', toolchains: [ocamlVersion]},
+  {name: 'menhir', toolchains: [ocamlVersion]},
+  {name: 'cmdliner', toolchains: [ocamlVersion]},
+  {name: 'coq', toolchains: [ocamlVersion]},
+  {name: 'angstrom', toolchains: [ocamlVersion]},
+  {name: 'bos', toolchains: [ocamlVersion]},
+  {name: 'bigstringaf', toolchains: [ocamlVersion]},
+  {name: 'utop', toolchains: [ocamlVersion]},
+  {name: 'dose3', toolchains: [ocamlVersion]},
+  {name: 'lwt_ppx', toolchains: [ocamlVersion]},
+  {name: 'ppx_deriving_yojson', toolchains: [ocamlVersion]},
+  {name: 'configurator', toolchains: [ocamlVersion]},
+  {name: 'merlin-extend', toolchains: [ocamlVersion]},
+  {name: 'ppx_optional', toolchains: [ocamlVersion]},
+  {name: 'ppx_base', toolchains: [ocamlVersion]},
+  {name: 'jane-street-headers', toolchains: [ocamlVersion]},
+  {name: 'merlin', toolchains: [ocamlVersion]},
   {name: 'ocamlfind', toolchains: [ocamlVersion]},
+  {name: 'splittable_random', toolchains: [ocamlVersion]},
   {name: 'jbuilder', toolchains: [ocamlVersion]},
   {name: 'cppo', toolchains: [ocamlVersion]},
   {name: 'result', toolchains: [ocamlVersion]},
   {name: 'ocamlbuild', toolchains: [ocamlVersion]},
   {name: 'topkg', toolchains: [ocamlVersion]},
   {name: 'ocaml-migrate-parsetree', toolchains: [ocamlVersion]},
-  {name: 'menhir', toolchains: [ocamlVersion]},
   {name: 'camlp5', toolchains: [ocamlVersion]},
   {name: 'ppx_tools_versioned', toolchains: [ocamlVersion]},
   {name: 'yojson', toolchains: [ocamlVersion]},
@@ -33,7 +50,6 @@ const cases = [
   {name: 'ppx_driver', toolchains: [ocamlVersion]},
   {name: 'ppx_core', toolchains: [ocamlVersion]},
   {name: 'camlp4', toolchains: [ocamlVersion]},
-  {name: 'cmdliner', toolchains: [ocamlVersion]},
   {name: 'ppx_sexp_conv', toolchains: [ocamlVersion]},
   {name: 'ppx_optcomp', toolchains: [ocamlVersion]},
   {name: 'ppx_tools', toolchains: [ocamlVersion]},
@@ -54,7 +70,6 @@ const cases = [
   {name: 'cppo_ocamlbuild', toolchains: [ocamlVersion]},
   {name: 'ppx_enumerate', toolchains: [ocamlVersion]},
   {name: 'xmlm', toolchains: [ocamlVersion]},
-  {name: 'configurator', toolchains: [ocamlVersion]},
   {name: 'bin_prot', toolchains: [ocamlVersion]},
   {name: 'conf-libcurl', toolchains: [ocamlVersion]},
   {name: 'core_kernel', toolchains: [ocamlVersion]},
@@ -65,8 +80,6 @@ const cases = [
   {name: 'core', toolchains: [ocamlVersion]},
   {name: 'ppx_variants_conv', toolchains: [ocamlVersion]},
   {name: 'ppx_custom_printf', toolchains: [ocamlVersion]},
-  {name: 'ppx_base', toolchains: [ocamlVersion]},
-  {name: 'utop', toolchains: [ocamlVersion]},
   {name: 'octavius', toolchains: [ocamlVersion]},
   {name: 'variantslib', toolchains: [ocamlVersion]},
   {name: 'ppx_bin_prot', toolchains: [ocamlVersion]},
@@ -91,12 +104,9 @@ const cases = [
   {name: 'ppx_jane', toolchains: [ocamlVersion]},
   {name: 'uutf', toolchains: [ocamlVersion]},
   {name: 'ocp-build', toolchains: [ocamlVersion]},
-  {name: 'merlin', toolchains: [ocamlVersion]},
-  {name: 'ppx_optional', toolchains: [ocamlVersion]},
   {name: 'oasis', toolchains: [ocamlVersion]},
   {name: 'uri', toolchains: [ocamlVersion]},
   {name: 'cryptokit', toolchains: [ocamlVersion]},
-  {name: 'jane-street-headers', toolchains: [ocamlVersion]},
   {name: 'stringext', toolchains: [ocamlVersion]},
   {name: 'spawn', toolchains: [ocamlVersion]},
   {name: 'ocamlmod', toolchains: [ocamlVersion]},
@@ -116,21 +126,11 @@ const cases = [
   {name: 'async_extra', toolchains: [ocamlVersion]},
   {name: 'async', toolchains: [ocamlVersion]},
   {name: 'cudf', toolchains: [ocamlVersion]},
-  {name: 'dose3', toolchains: [ocamlVersion]},
   {name: 'ssl', toolchains: [ocamlVersion]},
   {name: 'tls', toolchains: [ocamlVersion]},
 ];
 
 let reposUpdated = false;
-
-function selectCases(array) {
-    if (os.platform() == "win32") {
-        // Start with top 8 on windows, and work through to enable more!
-        return array.slice(0, 8);
-    } else {
-        return shuffle(array);
-    }
-}
 
 function shuffle(array) {
   array = array.slice(0);
@@ -147,6 +147,15 @@ function shuffle(array) {
   }
 
   return array;
+}
+
+function selectCases(array) {
+    if (os.platform() == "win32") {
+        // Start with a subset on Windows...
+        return array.slice(0, 25);
+    } else {
+        return shuffle(array);
+    }
 }
 
 const startTime = new Date();

--- a/test-e2e-slow/install-npm.test.js
+++ b/test-e2e-slow/install-npm.test.js
@@ -45,17 +45,21 @@ const cases = [
       require('babel-core');
     `,
   },
-  // Blocked by #507
-  // {
-  //   name: 'react-scripts',
-  //   test: `
-  //     require('react-scripts/bin/react-scripts.js');
-  //   `,
-  // },
+  {
+    name: 'react-scripts',
+    test: `
+      require('react-scripts/bin/react-scripts.js');
+    `,
+  }
 ];
 
+// All of these tests are blocked by issue #506 on Windows
+// TODO: Fix #506 and enable these!
 const windowsBlacklist = [
-    "webpack" // Blocked by #506
+    "webpack",
+    "jest-cli",
+    "babel-cli",
+    "react-scripts",
 ];
 
 let p;

--- a/test-e2e-slow/install-npm.test.js
+++ b/test-e2e-slow/install-npm.test.js
@@ -2,6 +2,7 @@
 
 const {createSandbox} = require('./setup.js');
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 
 const cases = [
@@ -52,10 +53,20 @@ const cases = [
   },
 ];
 
+const windowsBlacklist = [
+    "webpack"
+];
+
 let p;
 let reposUpdated = false;
 
 for (let c of cases) {
+
+  if (os.platform() === "win32" && windowsBlacklist.indexOf(c.name) >= 0) {
+    console.warn(`Skipping ${c.name} on Windows due to blocking bug.`);
+    continue;
+  }
+
   console.log(`*** installing ${c.name}`);
   const sandbox = createSandbox();
   console.log(`*** sandboxPath: ${sandbox.path}`);

--- a/test-e2e-slow/install-npm.test.js
+++ b/test-e2e-slow/install-npm.test.js
@@ -54,7 +54,7 @@ const cases = [
 ];
 
 const windowsBlacklist = [
-    "webpack"
+    "webpack" // Blocked by #506
 ];
 
 let p;

--- a/test-e2e-slow/install-npm.test.js
+++ b/test-e2e-slow/install-npm.test.js
@@ -45,12 +45,13 @@ const cases = [
       require('babel-core');
     `,
   },
-  {
-    name: 'react-scripts',
-    test: `
-      require('react-scripts/bin/react-scripts.js');
-    `,
-  },
+  // Blocked by #507
+  // {
+  //   name: 'react-scripts',
+  //   test: `
+  //     require('react-scripts/bin/react-scripts.js');
+  //   `,
+  // },
 ];
 
 const windowsBlacklist = [

--- a/test-e2e-slow/run-slow-tests.js
+++ b/test-e2e-slow/run-slow-tests.js
@@ -3,9 +3,20 @@
 const { execSync } = require("child_process");
 const os = require("os");
 
-const latestCommit = execSync("git log -n1").toString("utf8");
+const getLatestCommitMessage = () => {
+    let travisCommit = process.env["TRAVIS_COMMIT_MESSAGE"];
+    let appVeyorCommit = process.env["APPVEYOR_REPO_COMMIT_MESSAGE"]
 
-if (latestCommit.indexOf("@slowtest") === -1 && !process.env["ESY_SLOWTEST"]) {
+    if (travisCommit) {
+        return travisCommit;
+    } else if (appVeyorCommit) {
+        return appVeyorCommit;
+    } else {
+        return execSync("git log -n1").toString("utf8");
+    }
+}
+
+if (getLatestCommitMessage().indexOf("@slowtest") === -1 && !process.env["ESY_SLOWTEST"]) {
     console.warn("Not running slowtests - commit message was: " + latestCommit);
     process.exit(0);
 }

--- a/test-e2e-slow/run-slow-tests.js
+++ b/test-e2e-slow/run-slow-tests.js
@@ -5,17 +5,28 @@ const { execSync } = require("child_process");
 const latestCommit = execSync("git log --oneline -n1").toString("utf8");
 
 if (latestCommit.indexOf("@slowtest") === -1 && !process.env["ESY_SLOWTEST"]) {
-    console.log("Not running slowtests.");
+    console.warn("Not running slowtests.");
     process.exit(0);
 }
 
-console.log("-- Running test suite: e2e (slow tests) --");
+const isWindows = os.platform() === "win32";
+
+console.log("Running test suite: e2e (slow tests)");
 
 require("./build-top-100-opam.test.js");
+require("./install-npm.test.js");
 require("./esy.test.js");
 
-// Reason test blocked by: https://github.com/facebook/reason/pull/2209
-// require("./reason.test.js");
+if (!isWindows) {
+    // Reason test blocked by: https://github.com/facebook/reason/pull/2209
+    require("./reason.test.js");
 
-// Needs investigation:
-require("./install-npm.test.js");
+    // Windows: Needs investigation
+    require("./repromise.test.js");
+
+    // Windows: Fastpack build not supported yet.
+    require("./fastpack.test.js");
+
+    // Windows: Release blocked by #418
+    require("./release.test.js");
+}

--- a/test-e2e-slow/run-slow-tests.js
+++ b/test-e2e-slow/run-slow-tests.js
@@ -4,17 +4,16 @@ const { execSync } = require("child_process");
 
 const latestCommit = execSync("git log --oneline -n1").toString("utf8");
 
-// run slow tests
-// NOMERGE: Always run slow tests in this branch
-console.log("Running test suite: e2e (slow tests)");
+if (latestCommit.indexOf("@slowtest") === -1 && !process.env["ESY_SLOWTEST"]) {
+    console.log("Not running slowtests.");
+    process.exit(0);
+}
 
-// INVESTIGATE
-// require("./install-npm.test.js");
-
-// Blocked by esy installer issue...
-// require("./reason.test.js");
+console.log("-- Running test suite: e2e (slow tests) --");
 
 require("./esy.test.js");
-
 require("./build-top-100-opam.test.js");
 
+// TODO: Unblock these tests
+// require("./reason.test.js");
+// require("./install-npm.test.js");

--- a/test-e2e-slow/run-slow-tests.js
+++ b/test-e2e-slow/run-slow-tests.js
@@ -11,7 +11,9 @@ if (latestCommit.indexOf("@slowtest") === -1 && !process.env["ESY_SLOWTEST"]) {
 
 console.log("-- Running test suite: e2e (slow tests) --");
 
-require("./esy.test.js");
+// Needs retry logic:
+// require("./esy.test.js");
+
 require("./build-top-100-opam.test.js");
 
 // Reason test blocked by: https://github.com/facebook/reason/pull/2209

--- a/test-e2e-slow/run-slow-tests.js
+++ b/test-e2e-slow/run-slow-tests.js
@@ -7,5 +7,8 @@ const latestCommit = execSync("git log --oneline -n1").toString("utf8");
 // run slow tests
 // NOMERGE: Always run slow tests in this branch
 console.log("Running test suite: e2e (slow tests)");
+
 require("./build-top-100-opam.test.js");
 require("./install-npm.test.js");
+require("./esy.test.js");
+require("./reason.test.js");

--- a/test-e2e-slow/run-slow-tests.js
+++ b/test-e2e-slow/run-slow-tests.js
@@ -10,7 +10,9 @@ console.log("Running test suite: e2e (slow tests)");
 
 // INVESTIGATE
 // require("./install-npm.test.js");
-require("./reason.test.js");
+
+// Blocked by esy installer issue...
+// require("./reason.test.js");
 
 require("./esy.test.js");
 

--- a/test-e2e-slow/run-slow-tests.js
+++ b/test-e2e-slow/run-slow-tests.js
@@ -3,7 +3,7 @@
 const { execSync } = require("child_process");
 const os = require("os");
 
-const getLatestCommitMessage = () => {
+const getCommitMessage = () => {
     let travisCommit = process.env["TRAVIS_COMMIT_MESSAGE"];
     let appVeyorCommit = process.env["APPVEYOR_REPO_COMMIT_MESSAGE"]
 
@@ -16,7 +16,7 @@ const getLatestCommitMessage = () => {
     }
 }
 
-const latestCommit = getLatestCommit();
+const latestCommit = getCommitMessage();
 
 if (latestCommit.indexOf("@slowtest") === -1 && !process.env["ESY_SLOWTEST"]) {
     console.warn("Not running slowtests - commit message was: " + latestCommit);

--- a/test-e2e-slow/run-slow-tests.js
+++ b/test-e2e-slow/run-slow-tests.js
@@ -3,10 +3,10 @@
 const { execSync } = require("child_process");
 const os = require("os");
 
-const latestCommit = execSync("git log --oneline -n1").toString("utf8");
+const latestCommit = execSync("git log -n1").toString("utf8");
 
 if (latestCommit.indexOf("@slowtest") === -1 && !process.env["ESY_SLOWTEST"]) {
-    console.warn("Not running slowtests.");
+    console.warn("Not running slowtests - commit message was: " + latestCommit);
     process.exit(0);
 }
 

--- a/test-e2e-slow/run-slow-tests.js
+++ b/test-e2e-slow/run-slow-tests.js
@@ -1,6 +1,7 @@
 // @flow
 
 const { execSync } = require("child_process");
+const os = require("os");
 
 const latestCommit = execSync("git log --oneline -n1").toString("utf8");
 

--- a/test-e2e-slow/run-slow-tests.js
+++ b/test-e2e-slow/run-slow-tests.js
@@ -11,10 +11,8 @@ if (latestCommit.indexOf("@slowtest") === -1 && !process.env["ESY_SLOWTEST"]) {
 
 console.log("-- Running test suite: e2e (slow tests) --");
 
-// Needs retry logic:
-// require("./esy.test.js");
-
 require("./build-top-100-opam.test.js");
+require("./esy.test.js");
 
 // Reason test blocked by: https://github.com/facebook/reason/pull/2209
 // require("./reason.test.js");

--- a/test-e2e-slow/run-slow-tests.js
+++ b/test-e2e-slow/run-slow-tests.js
@@ -16,7 +16,9 @@ const getLatestCommitMessage = () => {
     }
 }
 
-if (getLatestCommitMessage().indexOf("@slowtest") === -1 && !process.env["ESY_SLOWTEST"]) {
+const latestCommit = getLatestCommit();
+
+if (latestCommit.indexOf("@slowtest") === -1 && !process.env["ESY_SLOWTEST"]) {
     console.warn("Not running slowtests - commit message was: " + latestCommit);
     process.exit(0);
 }

--- a/test-e2e-slow/run-slow-tests.js
+++ b/test-e2e-slow/run-slow-tests.js
@@ -14,6 +14,8 @@ console.log("-- Running test suite: e2e (slow tests) --");
 require("./esy.test.js");
 require("./build-top-100-opam.test.js");
 
-// TODO: Unblock these tests
+// Reason test blocked by: https://github.com/facebook/reason/pull/2209
 // require("./reason.test.js");
-// require("./install-npm.test.js");
+
+// Needs investigation:
+require("./install-npm.test.js");

--- a/test-e2e-slow/run-slow-tests.js
+++ b/test-e2e-slow/run-slow-tests.js
@@ -8,7 +8,11 @@ const latestCommit = execSync("git log --oneline -n1").toString("utf8");
 // NOMERGE: Always run slow tests in this branch
 console.log("Running test suite: e2e (slow tests)");
 
-require("./build-top-100-opam.test.js");
-require("./install-npm.test.js");
-require("./esy.test.js");
+// INVESTIGATE
+// require("./install-npm.test.js");
 require("./reason.test.js");
+
+require("./esy.test.js");
+
+require("./build-top-100-opam.test.js");
+

--- a/test-e2e-slow/setup.js
+++ b/test-e2e-slow/setup.js
@@ -26,7 +26,7 @@ function getTempDir() {
 const esyPrefixPath =
   process.env.TEST_ESY_PREFIX != null
     ? process.env.TEST_ESY_PREFIX
-    : path.join(getTempDir(), crypto.randomBytes(20).toString('hex'));
+    : path.join(getTempDir(), crypto.randomBytes(8).toString('hex'));
 
 function mkdir(path) {
   try {
@@ -37,7 +37,7 @@ function mkdir(path) {
 }
 
 function mkdirTemp() {
-  const p = path.join(getTempDir(), crypto.randomBytes(20).toString('hex'));
+  const p = path.join(getTempDir(), crypto.randomBytes(8).toString('hex'));
   fs.mkdirpSync(p);
   return p;
 }

--- a/test-e2e-slow/setup.js
+++ b/test-e2e-slow/setup.js
@@ -60,9 +60,10 @@ function createSandbox() /* : TestSandbox */ {
   let cwd = sandboxPath;
 
   function exec(...args /* : Array<string> */) {
-    const argsLine = args.map(arg => `'${arg.replace(/'/, '\\')}'`).join(' ');
-    console.log(`EXEC: ${argsLine}`);
-    childProcess.execSync(argsLine, {
+    const normalizedArgs = args.map(arg => arg.split("\\").join("/"));
+    const cmd = normalizedArgs.join(" ");
+    console.log(`EXEC: ${cmd}`);
+    childProcess.execSync(cmd, {
       cwd: cwd,
       env: {...process.env, ESY__PREFIX: esyPrefixPath},
       stdio: 'inherit',

--- a/test-e2e-slow/setup.js
+++ b/test-e2e-slow/setup.js
@@ -61,7 +61,7 @@ function createSandbox() /* : TestSandbox */ {
 
   function exec(...args /* : Array<string> */) {
     const argsLine = args.map(arg => `'${arg.replace(/'/, '\\')}'`).join(' ');
-    console.log(`EXEC: ${cmd}`);
+    console.log(`EXEC: ${argsLine}`);
     childProcess.execSync(argsLine, {
       cwd: cwd,
       env: {...process.env, ESY__PREFIX: esyPrefixPath},

--- a/test-e2e-slow/setup.js
+++ b/test-e2e-slow/setup.js
@@ -16,7 +16,9 @@ const esyCommand =
     : require.resolve('../bin/esy');
 
 function getTempDir() {
-  return isWindows ? os.tmpdir() : '/tmp';
+  // APPVEYOR TEST
+  const temp = "C:/esy-test-1";
+  return isWindows ? temp : '/tmp';
 }
 
 const esyPrefixPath =

--- a/test-e2e-slow/setup.js
+++ b/test-e2e-slow/setup.js
@@ -57,8 +57,10 @@ function createSandbox() /* : TestSandbox */ {
 
   function exec(...args /* : Array<string> */) {
     const argsLine = args.map(arg => `'${arg.replace(/'/, '\\')}'`).join(' ');
-    console.log(`EXEC: ${argsLine}`);
-    childProcess.execSync(argsLine, {
+    const normalizedArgs = args.map(arg => arg.split("\\").join("/"));
+    const cmd = normalizedArgs.join(" ");
+    console.log(`EXEC: ${cmd}`);
+    childProcess.execSync(cmd, {
       cwd: cwd,
       env: {...process.env, ESY__PREFIX: esyPrefixPath},
       stdio: 'inherit',

--- a/test-e2e-slow/setup.js
+++ b/test-e2e-slow/setup.js
@@ -28,7 +28,7 @@ const esyPrefixPath =
 
 function mkdir(path) {
   try {
-    fs.mkdirSync(path);
+    fs.mkdirpSync(path);
   } catch (e) {
     // doesn't matter if it exists
   }
@@ -36,7 +36,7 @@ function mkdir(path) {
 
 function mkdirTemp() {
   const p = path.join(getTempDir(), crypto.randomBytes(20).toString('hex'));
-  fs.mkdirSync(p);
+  fs.mkdirpSync(p);
   return p;
 }
 


### PR DESCRIPTION
Enable slow tests on Windows:
- Refactor slow tests to run via a node script
- Update / reorder top 100 cases
- Add 'retry' logic for esy install