### PR TITLE
Do not parse devDependencies out npm hosted packages

### DIFF
--- a/esyi/PackageJson.mli
+++ b/esyi/PackageJson.mli
@@ -1,5 +1,6 @@
 val packageOfJson :
   ?parseResolutions:bool
+  -> ?parseDevDependencies:bool
   -> ?source:Source.t
   -> name:string
   -> version:Version.t

--- a/esyi/Resolver.ml
+++ b/esyi/Resolver.ml
@@ -175,6 +175,7 @@ let packageOfSource ~allowEmptyPackage ~name ~overrides (source : Source.t) reso
         let%bind json = Json.parse data in
         PackageJson.packageOfJson
           ~parseResolutions:true
+          ~parseDevDependencies:true
           ~name
           ~version:(Version.Source source)
           ~source


### PR DESCRIPTION
We only need to parse devDependencies when we install them and we don't
install them when package is resolved from npm registry to we can skip it.

Fixes #507.