### PR TITLE
Do not chmod symlinks when fixing permissions

### DIFF
--- a/esy-lib/Fs.ml
+++ b/esy-lib/Fs.ml
@@ -277,6 +277,8 @@ let rec rmPathLwt path =
     in
 
     Lwt_unix.rmdir pathS
+  | S_LNK ->
+    Lwt_unix.unlink pathS
   | _ ->
     let%lwt () = Lwt_unix.chmod pathS 0o640 in
     Lwt_unix.unlink pathS


### PR DESCRIPTION
We need to do `chmod` before unlinking files so that we can unlink
"read-only" files.

But we don't need to apply `chmod` on symlinks though as this will chmod
its target, not the link itself.

In case a link points to a directory this will remove `x` permission
from a directory and thus cause "Permission Errors" down the line.

cc @bryphe