### PR TITLE
Filter out test/doc dependencies for opam

### DIFF
--- a/esy/Manifest.ml
+++ b/esy/Manifest.ml
@@ -395,6 +395,15 @@ end = struct
 
       let dependsOfOpam opam =
         let f = OpamFile.OPAM.depends opam in
+        let f =
+          let env var =
+            match OpamVariable.Full.to_string var with
+            | "test" -> Some (OpamVariable.B false)
+            | "doc" -> Some (OpamVariable.B false)
+            | _ -> None
+          in
+          OpamFilter.partial_filter_formula env f
+        in
         let dependencies =
           listPackageNamesOfFormula
             ~build:true ~test:false ~post:true ~doc:false ~dev:false


### PR DESCRIPTION
Not sure why they weren't converted to opam 2.0 format but let's filter them
out.