### PR TITLE
Tweak solver not to optimize for a number of packages installed

### DIFF
--- a/esyi/Solver.ml
+++ b/esyi/Solver.ml
@@ -3,7 +3,7 @@ module Resolutions = Package.Resolutions
 module Resolution = Package.Resolution
 
 module Strategy = struct
-  let trendy = "-count[staleness,solution],-removed,-notuptodate,-new"
+  let trendy = "-count[staleness,solution]"
   (* let minimalAddition = "-removed,-changed,-notuptodate" *)
 end
 


### PR DESCRIPTION
This removes:

- `-removed` and `-new` criterias as they don't make sense for initial
  installation (and this is what we have now in esy, we'll be using them
  for upgrade when we have that implemented).

- `-notuptodate` which optimizes for the minimum size of not up to date
  "virtual package"/"features" (from mccs sources). While we don't have
  "virtual" packages I suspect mccs still treat any package as "feature".

In my limited experiments I see more consistent and understandable
results with only `-count[staleness,solution]` criteria as optimizing
for the number of packages in sandbox isn't something most people care
about.