### PR TITLE
Fix store init

### DIFF
--- a/test-e2e/export-import-build/basic.test.js
+++ b/test-e2e/export-import-build/basic.test.js
@@ -1,0 +1,89 @@
+// @flow
+
+const path = require('path');
+const del = require('del');
+const fs = require('fs-extra');
+
+const helpers = require('../test/helpers');
+const {packageJson, dir, file, dummyExecutable} = helpers;
+
+helpers.skipSuiteOnWindows('Needs investigation');
+
+it('export import build - from list', async () => {
+  const p = await helpers.createTestSandbox();
+  await p.fixture(
+    packageJson({
+      name: 'app',
+      version: '1.0.0',
+      license: 'MIT',
+      esy: {
+        build: ['ln -s #{dep.bin / dep.name}.cmd #{self.bin / self.name}.cmd'],
+      },
+      dependencies: {
+        dep: 'path:dep',
+      },
+    }),
+    dir(
+      'dep',
+      packageJson({
+        name: 'dep',
+        version: '1.0.0',
+        license: 'MIT',
+        esy: {
+          build: ['ln -s #{subdep.bin / subdep.name}.cmd #{self.bin / self.name}.cmd'],
+        },
+        dependencies: {
+          subdep: 'path:../subdep',
+        },
+      }),
+    ),
+    dir(
+      'subdep',
+      packageJson({
+        name: 'subdep',
+        version: '1.0.0',
+        license: 'MIT',
+        esy: {
+          buildsInSource: true,
+          build: [helpers.buildCommand(p, '#{self.name}.js')],
+          install: [
+            'cp #{self.name}.cmd #{self.bin / self.name}.cmd',
+            'cp #{self.name}.js #{self.bin / self.name}.js',
+          ],
+        },
+      }),
+      dummyExecutable('subdep'),
+    ),
+  );
+
+  await p.esy('install');
+  await p.esy('build');
+
+  await p.esy('export-dependencies');
+
+  const exportPath = path.join(p.projectPath, '_export');
+
+  expect(await fs.exists(exportPath)).toBeTruthy();
+
+  const items = await fs.readdir(exportPath);
+
+  await fs.remove(p.esyPrefixPath);
+
+  for (const item of items) {
+    const buildPath = path.join(exportPath, item);
+    await p.esy(`import-build ${buildPath}`);
+  }
+
+  {
+    const {stdout} = await p.esy('subdep.cmd');
+    expect(stdout.trim()).toBe('__subdep__');
+  }
+  {
+    const {stdout} = await p.esy('dep.cmd');
+    expect(stdout.trim()).toBe('__subdep__');
+  }
+  {
+    const {stdout} = await p.esy('x app.cmd');
+    expect(stdout.trim()).toBe('__subdep__');
+  }
+});


### PR DESCRIPTION
- Init store on `esy import-build` command.
- Make sure we init store when sandbox info is cached.