### PR TITLE
Fixes to sandbox overrides

### DIFF
--- a/esyi/Package.ml
+++ b/esyi/Package.ml
@@ -252,15 +252,7 @@ module NpmFormulaOverride = struct
     let req_of_yojson name json =
       let open Result.Syntax in
       let%bind spec = Json.Decode.string json in
-      let%bind spec =
-        let parseSpec =
-          if isOpamPackageName name
-          then VersionSpec.parserOpam
-          else VersionSpec.parserNpm
-        in
-        Parse.(parse parseSpec) spec
-      in
-      return (Req.make ~name ~spec)
+      Req.parse (name ^ "@" ^ spec)
     in
     StringMap.Override.of_yojson req_of_yojson
 

--- a/esyi/Resolver.ml
+++ b/esyi/Resolver.ml
@@ -342,8 +342,11 @@ let package ~(resolution : Resolution.t) resolver =
                   in
                   let formula = SemverVersion.Formula.ofDnfToCnf formula in
                   (List.map ~f:(List.map ~f) formula) @ edits
-                | VersionSpec.Opam _ ->
-                  failwith "cannot override with opam version"
+                | VersionSpec.Opam formula ->
+                  let f (c : OpamPackageVersion.Constraint.t) =
+                    {Package.Dep. name = req.name; req = Opam c}
+                  in
+                  (List.map ~f:(List.map ~f) formula) @ edits
                 | VersionSpec.NpmDistTag _ ->
                   failwith "cannot override opam with npm dist tag"
                 | VersionSpec.Source spec ->

--- a/esyi/SourceResolver.ml
+++ b/esyi/SourceResolver.ml
@@ -87,7 +87,11 @@ let ofPath ?manifest (path : Path.t)
         | ManifestSpec.Filename.Esy ->
           begin match Json.parseStringWith PackageOverride.of_yojson data with
           | Ok override -> return (Override override)
-          | Error _ -> return (Manifest {data; filename = fname; kind})
+          | Error err ->
+            Logs_lwt.debug (fun m ->
+              m "not an override %a: %a" Path.pp path Run.ppError err
+              );%lwt
+            return (Manifest {data; filename = fname; kind})
           end
         | ManifestSpec.Filename.Opam ->
           return (Manifest {data; filename = fname; kind})

--- a/esyi/SourceResolver.ml
+++ b/esyi/SourceResolver.ml
@@ -2,7 +2,23 @@ module PackageOverride = struct
   type t = {
     source : Source.t;
     override : Package.Overrides.override;
-  } [@@deriving of_yojson]
+  }
+
+  let of_yojson json =
+    let open Result.Syntax in
+    let%bind source =
+      Json.Decode.fieldWith
+        ~name:"source"
+        Source.relaxed_of_yojson
+        json
+    in
+    let%bind override =
+      Json.Decode.fieldWith
+      ~name:"override"
+      Package.Overrides.override_of_yojson
+      json
+    in
+    return {source; override;}
 
 end
 


### PR DESCRIPTION
- Relax source parsing (allow `./package.json` rather than `path:./package.json`)
- Fix overriding with opam dependencies
- Fix constraints parsing in dep overrides