### PR TITLE
Refactor "esy install" to be atomic

### DIFF
--- a/esy-lib/Fastreplacestring.ml
+++ b/esy-lib/Fastreplacestring.ml
@@ -1,0 +1,25 @@
+let rewritePrefix ~fastreplacestringCmd ~origPrefix ~destPrefix rootPath =
+  let open RunAsync.Syntax in
+  let rewritePrefixInFile path =
+    let cmd = Cmd.(fastreplacestringCmd % p path % p origPrefix % p destPrefix) in
+    ChildProcess.run cmd
+  in
+  let rewriteTargetInSymlink path =
+    let%bind link = Fs.readlink path in
+    match Path.remPrefix origPrefix link with
+    | Some basePath ->
+      let nextTargetPath = Path.(destPrefix // basePath) in
+      let%bind () = Fs.unlink path in
+      let%bind () = Fs.symlink ~src:nextTargetPath path in
+      return ()
+    | None -> return ()
+  in
+  let rewrite (path : Path.t) (stats : Unix.stats) =
+    match stats.st_kind with
+    | Unix.S_REG ->
+      rewritePrefixInFile path
+    | Unix.S_LNK ->
+      rewriteTargetInSymlink path
+    | _ -> return ()
+  in
+  Fs.traverse ~f:rewrite rootPath

--- a/esy-lib/RunAsync.ml
+++ b/esy-lib/RunAsync.ml
@@ -99,6 +99,19 @@ module List = struct
     in
     _waitAll xs
 
+  let limitWithConccurrency concurrency f =
+    match concurrency with
+    | None -> f
+    | Some concurrency ->
+      let queue = LwtTaskQueue.create ~concurrency () in
+      fun x -> LwtTaskQueue.submit queue (fun () -> f x)
+
+  let mapAndWait ?concurrency ~f xs =
+    waitAll (List.map ~f:(limitWithConccurrency concurrency f) xs)
+
+  let mapAndJoin ?concurrency ~f xs =
+    joinAll (List.map ~f:(limitWithConccurrency concurrency f) xs)
+
   let rec processSeq ~f =
     let open Syntax in
     function

--- a/esy-lib/RunAsync.mli
+++ b/esy-lib/RunAsync.mli
@@ -96,7 +96,25 @@ end
  * Work with lists of computations.
  *)
 module List : sig
-  val foldLeft : f:('a -> 'b -> 'a t) -> init:'a -> 'b list -> 'a t
+
+  val foldLeft :
+    f:('a -> 'b -> 'a t)
+    -> init:'a
+    -> 'b list
+    -> 'a t
+
+  val mapAndWait :
+    ?concurrency:int
+    -> f:('a -> unit t)
+    -> 'a list
+    -> unit t
+
+  val mapAndJoin :
+    ?concurrency:int
+    -> f:('a -> 'b t)
+    -> 'a list
+    -> 'b list t
+
   val waitAll : unit t list -> unit t
   val joinAll : 'a t list -> 'a list t
   val processSeq :

--- a/esy/Plan.ml
+++ b/esy/Plan.ml
@@ -686,30 +686,11 @@ let execEnv _sandbox plan task =
   |> Scope.env ~includeBuildEnv:false
 
 let rewritePrefix ~cfg ~origPrefix ~destPrefix rootPath =
-  let open RunAsync.Syntax in
-  let rewritePrefixInFile path =
-    let cmd = Cmd.(cfg.Config.fastreplacestringCmd % p path % p origPrefix % p destPrefix) in
-    ChildProcess.run cmd
-  in
-  let rewriteTargetInSymlink path =
-    let%bind link = Fs.readlink path in
-    match Path.remPrefix origPrefix link with
-    | Some basePath ->
-      let nextTargetPath = Path.(destPrefix // basePath) in
-      let%bind () = Fs.unlink path in
-      let%bind () = Fs.symlink ~src:nextTargetPath path in
-      return ()
-    | None -> return ()
-  in
-  let rewrite (path : Path.t) (stats : Unix.stats) =
-    match stats.st_kind with
-    | Unix.S_REG ->
-      rewritePrefixInFile path
-    | Unix.S_LNK ->
-      rewriteTargetInSymlink path
-    | _ -> return ()
-  in
-  Fs.traverse ~f:rewrite rootPath
+  Fastreplacestring.rewritePrefix
+    ~fastreplacestringCmd:cfg.Config.fastreplacestringCmd
+    ~origPrefix
+    ~destPrefix
+    rootPath
 
 let exportBuild ~cfg ~outputPrefixPath buildPath =
   let open RunAsync.Syntax in

--- a/esy/bin/esyCommand.ml
+++ b/esy/bin/esyCommand.ml
@@ -240,6 +240,7 @@ module CommonOptions = struct
             return Cmd.(v (p cmd))
           in
           EsyInstall.Config.make
+            ~fastreplacestringCmd:EsyRuntime.fastreplacestringCmd
             ~esySolveCmd
             ~skipRepositoryUpdate
             ?cachePath

--- a/esyi/Config.re
+++ b/esyi/Config.re
@@ -1,7 +1,9 @@
 type t = {
   esySolveCmd: Cmd.t,
-  cacheTarballsPath: Path.t,
-  cacheSourcesPath: Path.t,
+  fastreplacestringCmd: Cmd.t,
+  sourceArchivePath: Path.t,
+  sourceStagePath: Path.t,
+  sourceInstallPath: Path.t,
   opamArchivesIndexPath: Path.t,
   esyOpamOverride: checkout,
   opamRepository: checkout,
@@ -39,6 +41,7 @@ let make =
       ~esyOpamOverride=?,
       ~solveTimeout=60.0,
       ~esySolveCmd,
+      ~fastreplacestringCmd,
       ~skipRepositoryUpdate,
       (),
     ) =>
@@ -56,19 +59,25 @@ let make =
           ),
         );
 
-      let cacheTarballsPath =
-        switch (cacheTarballsPath) {
-        | Some(path) => path
-        | None => Path.(cachePath / "source-tarballs")
-        };
-      let%bind () = Fs.createDir(cacheTarballsPath);
-
-      let cacheSourcesPath =
+      let sourcePath =
         switch (cacheSourcesPath) {
         | Some(path) => path
         | None => Path.(cachePath / "source")
         };
-      let%bind () = Fs.createDir(cacheTarballsPath);
+      let%bind () = Fs.createDir(sourcePath);
+
+      let sourceArchivePath =
+        switch (cacheTarballsPath) {
+        | Some(path) => path
+        | None => Path.(sourcePath / "a")
+        };
+      let%bind () = Fs.createDir(sourceArchivePath);
+
+      let sourceStagePath = Path.(sourcePath / "s");
+      let%bind () = Fs.createDir(sourceStagePath);
+
+      let sourceInstallPath = Path.(sourcePath / "i");
+      let%bind () = Fs.createDir(sourceInstallPath);
 
       let opamArchivesIndexPath = Path.(cachePath / "opam-urls.txt");
 
@@ -89,8 +98,10 @@ let make =
 
       return({
         esySolveCmd,
-        cacheTarballsPath,
-        cacheSourcesPath,
+        fastreplacestringCmd,
+        sourceArchivePath,
+        sourceStagePath,
+        sourceInstallPath,
         opamArchivesIndexPath,
         opamRepository,
         esyOpamOverride,

--- a/esyi/Config.rei
+++ b/esyi/Config.rei
@@ -2,8 +2,10 @@
 
 type t = {
   esySolveCmd: Cmd.t,
-  cacheTarballsPath: Path.t,
-  cacheSourcesPath: Path.t,
+  fastreplacestringCmd: Cmd.t,
+  sourceArchivePath: Path.t,
+  sourceStagePath: Path.t,
+  sourceInstallPath: Path.t,
   opamArchivesIndexPath: Path.t,
   esyOpamOverride: checkout,
   opamRepository: checkout,
@@ -31,6 +33,7 @@ let make:
     ~esyOpamOverride: checkoutCfg=?,
     ~solveTimeout: float=?,
     ~esySolveCmd: Cmd.t,
+    ~fastreplacestringCmd: Cmd.t,
     ~skipRepositoryUpdate: bool,
     unit
   ) =>

--- a/esyi/Fetch.ml
+++ b/esyi/Fetch.ml
@@ -54,7 +54,7 @@ let fetch ~(sandbox : Sandbox.t) (solution : Solution.t) =
         FetchStorage.fetch ~sandbox pkg
       in
       RunAsync.List.mapAndJoin
-        ~concurrency:8
+        ~concurrency:40
         ~f:fetch
         (Package.Set.elements pkgs)
     in
@@ -73,7 +73,7 @@ let fetch ~(sandbox : Sandbox.t) (solution : Solution.t) =
   let%bind installation =
     let installation =
       let f id dist installation =
-        Installation.add id (Dist.sourcePath dist) installation
+        Installation.add id (Dist.sourceInstallPath dist) installation
       in
       let init =
         Installation.empty

--- a/esyi/Fetch.ml
+++ b/esyi/Fetch.ml
@@ -5,180 +5,6 @@ module Dist = FetchStorage.Dist
 let nodeCmd =
   Cmd.resolveCmd System.Environment.path "node"
 
-module PackageJson = struct
-
-  module Scripts = struct
-    type t = {
-      postinstall : (string option [@default None]);
-      install : (string option [@default None]);
-    }
-    [@@deriving of_yojson { strict = false }]
-
-    let empty = {postinstall = None; install = None}
-  end
-
-  module Bin = struct
-    type t =
-      | Empty
-      | One of string
-      | Many of string StringMap.t
-
-    let of_yojson =
-      let open Result.Syntax in
-      function
-      | `String cmd ->
-        let cmd = String.trim cmd in
-        begin match cmd with
-        | "" -> return Empty
-        | cmd -> return (One cmd)
-        end
-      | `Assoc items ->
-        let%bind items =
-          let f cmds (name, json) =
-            match json with
-            | `String cmd -> return (StringMap.add name cmd cmds)
-            | _ -> error "expected a string"
-          in
-          Result.List.foldLeft ~f ~init:StringMap.empty items
-        in
-        return (Many items)
-      | _ -> error "expected a string or an object"
-  end
-
-  type t = {
-    name : string option [@default None];
-    bin : (Bin.t [@default Bin.Empty]);
-    scripts : (Scripts.t [@default Scripts.empty]);
-    esy : (Json.t option [@default None]);
-  } [@@deriving of_yojson { strict = false }]
-
-  let ofDir path =
-    let open RunAsync.Syntax in
-    let filename = Path.(path / "package.json") in
-    if%bind Fs.exists filename
-    then
-      let%bind json = Fs.readJsonFile filename in
-      let%bind manifest = RunAsync.ofRun (Json.parseJsonWith of_yojson json) in
-      return (Some manifest)
-    else
-      return None
-
-  let packageCommands (sourcePath : Path.t) manifest =
-    let makePathToCmd cmdPath = Path.(sourcePath // v cmdPath |> normalize) in
-    match manifest.bin, manifest.name with
-    | Bin.One cmd, Some name ->
-      [name, makePathToCmd cmd]
-    | Bin.One cmd, None ->
-      let cmd = makePathToCmd cmd in
-      let name = Path.basename cmd in
-      [name, cmd]
-    | Bin.Many cmds, _ ->
-      let f name cmd cmds = (name, makePathToCmd cmd)::cmds in
-      (StringMap.fold f cmds [])
-    | Bin.Empty, _ -> []
-
-end
-
-module Install = struct
-
-  type t = {
-    path : Path.t;
-    sourcePath : Path.t;
-    pkg : Package.t;
-    isDirectDependencyOfRoot : bool;
-    status: FetchStorage.status;
-  }
-
-  let pp fmt installation =
-    Fmt.pf fmt "%a at %a"
-      Package.pp installation.pkg
-      Path.pp installation.path
-end
-
-let runLifecycleScript ?env ~install ~lifecycleName script =
-  let%lwt () = Logs_lwt.debug
-    (fun m ->
-      m "Fetch.runLifecycleScript ~env:%a ~pkg:%a ~lifecycleName:%s"
-      (Fmt.option ChildProcess.pp_env) env
-      Package.pp install.Install.pkg
-      lifecycleName
-    )
-  in
-
-  let%lwt () = Logs_lwt.app
-    (fun m ->
-      m "%a: running %a lifecycle"
-      Package.pp install.Install.pkg
-      Fmt.(styled `Bold string) lifecycleName
-    )
-  in
-
-  let readAndCloseChan ic =
-    Lwt.finalize
-      (fun () -> Lwt_io.read ic)
-      (fun () -> Lwt_io.close ic)
-  in
-
-  let f p =
-    let%lwt stdout = readAndCloseChan p#stdout
-    and stderr = readAndCloseChan p#stderr in
-    match%lwt p#status with
-    | Unix.WEXITED 0 ->
-      RunAsync.return ()
-    | _ ->
-      Logs_lwt.err (fun m -> m
-        "@[<v>command failed: %s@\nstderr:@[<v 2>@\n%s@]@\nstdout:@[<v 2>@\n%s@]@]"
-        script stderr stdout
-      );%lwt
-      RunAsync.error "error running command"
-  in
-
-  try%lwt
-    (* We don't need to wrap the install path on Windows in quotes *)
-    let installationPath =
-      match System.Platform.host with
-      | Windows -> Path.show install.path
-      | _ -> Filename.quote (Path.show install.path)
-    in
-    let script =
-      Printf.sprintf
-        "cd %s && %s"
-        installationPath
-        script
-    in
-    let cmd =
-      match System.Platform.host with
-      | Windows -> ("", [|"cmd.exe";("/c " ^ script)|])
-      | _ -> ("/bin/bash", [|"/bin/bash";"-c";script|])
-    in
-    let env =
-      let open Option.Syntax in
-      let%bind env = env in
-      let%bind _, env = ChildProcess.prepareEnv env in
-      return env
-    in
-    Lwt_process.with_process_full ?env cmd f
-  with
-  | Unix.Unix_error (err, _, _) ->
-    let msg = Unix.error_message err in
-    RunAsync.error msg
-  | _ ->
-    RunAsync.error "error running subprocess"
-
-let runLifecycle ?env pkgJson install =
-  let open RunAsync.Syntax in
-  let%bind () =
-    match pkgJson.PackageJson.scripts.install with
-    | Some cmd -> runLifecycleScript ?env ~install ~lifecycleName:"install" cmd
-    | None -> return ()
-  in
-  let%bind () =
-    match pkgJson.PackageJson.scripts.postinstall with
-    | Some cmd -> runLifecycleScript ?env ~install ~lifecycleName:"postinstall" cmd
-    | None -> return ()
-  in
-  return ()
-
 let isInstalled ~(sandbox : Sandbox.t) (solution : Solution.t) =
   let open RunAsync.Syntax in
   let installationPath = SandboxSpec.installationPath sandbox.spec in
@@ -196,21 +22,6 @@ let isInstalled ~(sandbox : Sandbox.t) (solution : Solution.t) =
         return false
     in
     Solution.fold ~f ~init:(return true) solution
-
-let installBinWrapper ~binPath (name, origPath) =
-  let open RunAsync.Syntax in
-  Logs_lwt.debug (fun m ->
-    m "Fetch:installBinWrapper: %a / %s -> %a"
-    Path.pp origPath name Path.pp binPath
-  );%lwt
-  if%bind Fs.exists origPath
-  then (
-    let%bind () = Fs.chmod 0o777 origPath in
-    Fs.symlink ~src:origPath Path.(binPath / name)
-  ) else (
-    Logs_lwt.warn (fun m -> m "missing %a defined as binary" Path.pp origPath);%lwt
-    return ()
-  )
 
 let fetch ~(sandbox : Sandbox.t) (solution : Solution.t) =
   let open RunAsync.Syntax in
@@ -230,11 +41,6 @@ let fetch ~(sandbox : Sandbox.t) (solution : Solution.t) =
     return (Package.Set.remove root all, root)
   in
 
-  let directDependenciesOfRoot =
-    let deps = Solution.dependencies root solution in
-    Package.Set.of_list deps
-  in
-
   (* Fetch all package distributions *)
   let%bind dists =
     let report, finish = Cli.createProgressReporter ~name:"fetching" () in
@@ -245,31 +51,18 @@ let fetch ~(sandbox : Sandbox.t) (solution : Solution.t) =
           let status = Format.asprintf "%a" Package.pp pkg in
           report status
         in
-        let%bind dist = FetchStorage.fetch ~sandbox pkg in
-        let%bind status, path = FetchStorage.install ~sandbox dist in
-        Logs_lwt.debug (fun m ->
-          m "fetched: %a -> %a" Package.pp pkg Path.pp path);%lwt
-        let%bind pkgJson = PackageJson.ofDir path in
-        let install = {
-          Install.
-          pkg;
-          sourcePath = path;
-          path;
-          isDirectDependencyOfRoot = Package.Set.mem pkg directDependenciesOfRoot;
-          status;
-        } in
-        let id = Dist.id dist in
-        return (id, (dist, install, pkgJson))
+        FetchStorage.fetch ~sandbox pkg
       in
       RunAsync.List.mapAndJoin
         ~concurrency:8
         ~f:fetch
         (Package.Set.elements pkgs)
     in
+
     let%lwt () = finish () in
 
     let dists =
-      let f dists (id, v) = PackageId.Map.add id v dists in
+      let f dists dist = PackageId.Map.add (Dist.id dist) dist dists in
       List.fold_left ~f ~init:PackageId.Map.empty dists
     in
 
@@ -279,14 +72,8 @@ let fetch ~(sandbox : Sandbox.t) (solution : Solution.t) =
   (* Produce _esy/<sandbox>/installation.json *)
   let%bind installation =
     let installation =
-      let f id (dist, install, _pkgJson) installation =
-        let loc =
-          let source = Dist.source dist in
-          match source with
-          | Source.LocalPathLink {path; manifest = _} -> Path.(sandbox.spec.path // path)
-          | _ -> install.Install.sourcePath;
-        in
-        Installation.add id loc installation
+      let f id dist installation =
+        Installation.add id (Dist.sourcePath dist) installation
       in
       let init =
         Installation.empty
@@ -339,42 +126,6 @@ let fetch ~(sandbox : Sandbox.t) (solution : Solution.t) =
         return ()
     in
 
-    let env =
-      let override =
-        let path = (Path.show binPath)::System.Environment.path in
-        let sep = System.Environment.sep ~name:"PATH" () in
-        Astring.String.Map.(
-          empty
-          |> add "PATH" (String.concat sep path)
-        )
-      in
-      ChildProcess.CurrentEnvOverride override
-    in
-
-    let process install pkgJson =
-      let%bind () =
-        Logs_lwt.debug (fun m -> m "Fetch:runLifecycle:%a" Package.pp install.Install.pkg);%lwt
-        RunAsync.contextf
-          (runLifecycle
-            ~env
-            pkgJson
-            install)
-          "running lifecycle %a"
-          Install.pp install
-
-      in
-
-      let%bind () =
-        Logs_lwt.debug (fun m -> m "Fetch:installBinWrappers:%a" Package.pp install.Install.pkg);%lwt
-        RunAsync.List.mapAndWait
-          ~concurrency:8
-          ~f:(installBinWrapper ~binPath)
-          (PackageJson.packageCommands install.Install.sourcePath pkgJson)
-      in
-
-      return ()
-    in
-
     let seen = ref Package.Set.empty in
 
     let rec visit pkg =
@@ -398,14 +149,7 @@ let fetch ~(sandbox : Sandbox.t) (solution : Solution.t) =
         in
 
         match isRoot, PackageId.Map.find_opt (Solution.Package.id pkg) dists with
-        | false, Some (
-            _dist,
-            ({Install. status = FetchStorage.Fresh; _ } as install),
-            Some ({PackageJson. esy = None; _} as pkgJson)
-          ) ->
-          process install pkgJson
-        | false, Some (_, {status = FetchStorage.Cached;_}, _) -> return ()
-        | false, Some (_, {status = FetchStorage.Fresh;_}, _) -> return ()
+        | false, Some dist -> FetchStorage.install dist
         | false, None -> errorf "dist not found: %a" Package.pp pkg
         | true, _ -> return ()
       )

--- a/esyi/FetchStorage.ml
+++ b/esyi/FetchStorage.ml
@@ -303,7 +303,10 @@ let installBinWrapper ~binPath (name, origPath) =
   if%bind Fs.exists origPath
   then (
     let%bind () = Fs.chmod 0o777 origPath in
-    Fs.symlink ~src:origPath Path.(binPath / name)
+    let destPath = Path.(binPath / name) in
+    if%bind Fs.exists destPath
+    then return ()
+    else Fs.symlink ~src:origPath destPath
   ) else (
     Logs_lwt.warn (fun m -> m "missing %a defined as binary" Path.pp origPath);%lwt
     return ()

--- a/esyi/FetchStorage.ml
+++ b/esyi/FetchStorage.ml
@@ -2,15 +2,126 @@ module String = Astring.String
 
 module Dist = struct
   type t = {
+    sandbox : Sandbox.t;
     source : Source.t;
     sourceInStorage : SourceStorage.source option;
     pkg : Solution.Package.t;
   }
 
   let id dist = Solution.Package.id dist.pkg
+  let pkg dist = dist.pkg
   let source dist = dist.source
+
+  let sourcePath dist =
+    match dist.source with
+    | Source.LocalPathLink link ->
+      Path.(dist.sandbox.spec.path // link.path |> normalize)
+    | _ ->
+      let name = Path.safeSeg dist.pkg.name in
+      let id =
+        Source.show dist.source
+        |> Digest.string
+        |> Digest.to_hex
+        |> Path.safeSeg
+      in
+      Path.(dist.sandbox.cfg.cacheSourcesPath / (name ^ "-" ^ id))
+
   let pp fmt dist =
     Fmt.pf fmt "%s@%a" dist.pkg.name Version.pp dist.pkg.version
+end
+
+module PackageJson : sig
+  type t
+
+  type scripts = {
+    postinstall : string option;
+    install : string option;
+  }
+
+  val ofDir : Path.t -> t option RunAsync.t
+
+  val bin : sourcePath:Path.t -> t -> (string * Path.t) list
+  val scripts : t -> scripts
+
+end = struct
+
+  module Scripts = struct
+    type t = {
+      postinstall : (string option [@default None]);
+      install : (string option [@default None]);
+    }
+    [@@deriving of_yojson { strict = false }]
+
+    let empty = {postinstall = None; install = None}
+  end
+
+  type scripts = Scripts.t = {
+    postinstall : string option;
+    install : string option;
+  }
+
+  module Bin = struct
+    type t =
+      | Empty
+      | One of string
+      | Many of string StringMap.t
+
+    let of_yojson =
+      let open Result.Syntax in
+      function
+      | `String cmd ->
+        let cmd = String.trim cmd in
+        begin match cmd with
+        | "" -> return Empty
+        | cmd -> return (One cmd)
+        end
+      | `Assoc items ->
+        let%bind items =
+          let f cmds (name, json) =
+            match json with
+            | `String cmd -> return (StringMap.add name cmd cmds)
+            | _ -> error "expected a string"
+          in
+          Result.List.foldLeft ~f ~init:StringMap.empty items
+        in
+        return (Many items)
+      | _ -> error "expected a string or an object"
+  end
+
+  type t = {
+    name : string option [@default None];
+    bin : (Bin.t [@default Bin.Empty]);
+    scripts : (Scripts.t [@default Scripts.empty]);
+    esy : (Json.t option [@default None]);
+  } [@@deriving of_yojson { strict = false }]
+
+  let ofDir path =
+    let open RunAsync.Syntax in
+    let filename = Path.(path / "package.json") in
+    if%bind Fs.exists filename
+    then
+      let%bind json = Fs.readJsonFile filename in
+      let%bind manifest = RunAsync.ofRun (Json.parseJsonWith of_yojson json) in
+      return (Some manifest)
+    else
+      return None
+
+  let bin ~sourcePath pkgJson =
+    let makePathToCmd cmdPath = Path.(sourcePath // v cmdPath |> normalize) in
+    match pkgJson.bin, pkgJson.name with
+    | Bin.One cmd, Some name ->
+      [name, makePathToCmd cmd]
+    | Bin.One cmd, None ->
+      let cmd = makePathToCmd cmd in
+      let name = Path.basename cmd in
+      [name, cmd]
+    | Bin.Many cmds, _ ->
+      let f name cmd cmds = (name, makePathToCmd cmd)::cmds in
+      (StringMap.fold f cmds [])
+    | Bin.Empty, _ -> []
+
+  let scripts pkgJson = pkgJson.scripts
+
 end
 
 let fetch ~sandbox (pkg : Solution.Package.t) =
@@ -20,7 +131,8 @@ let fetch ~sandbox (pkg : Solution.Package.t) =
     match sources with
     | source::rest ->
       begin match%bind SourceStorage.fetch ~cfg:sandbox.Sandbox.cfg source with
-      | Ok sourceInStorage -> return {Dist. pkg; source; sourceInStorage = Some sourceInStorage;}
+      | Ok sourceInStorage ->
+        return {Dist. sandbox; pkg; source; sourceInStorage = Some sourceInStorage;}
       | Error err -> fetch' ((source, err)::errs) rest
       end
     | [] ->
@@ -41,14 +153,16 @@ let fetch ~sandbox (pkg : Solution.Package.t) =
   match pkg.source with
   | Solution.Package.Link {path; manifest; overrides = _;} ->
     return {
-      Dist. pkg;
+      Dist.
+      sandbox;
+      pkg;
       source = Source.LocalPathLink {path;manifest;};
       sourceInStorage = None;
     }
   | Solution.Package.Install {source = main, mirrors; _} ->
     fetch' [] (main::mirrors)
 
-let unpack ~sandbox ~path ~overrides ~files ~opam dist =
+let unpack ~path ~overrides ~files ~opam dist =
   let open RunAsync.Syntax in
 
   (*
@@ -77,7 +191,7 @@ let unpack ~sandbox ~path ~overrides ~files ~opam dist =
       in
       let%bind () =
         SourceStorage.unpack
-          ~cfg:sandbox.Sandbox.cfg
+          ~cfg:dist.sandbox.Sandbox.cfg
           ~dst:tempPath
           sourceInStorage
       in
@@ -93,33 +207,155 @@ let unpack ~sandbox ~path ~overrides ~files ~opam dist =
 
   return ()
 
-let path ~cfg dist =
-  let name = Path.safeSeg dist.Dist.pkg.name in
-  let id =
-    Source.show dist.Dist.source
-    |> Digest.string
-    |> Digest.to_hex
-    |> Path.safeSeg
+let runLifecycleScript ?env ~lifecycleName pkg sourcePath script =
+  let%lwt () = Logs_lwt.app
+    (fun m ->
+      m "%a: running %a lifecycle"
+      Solution.Package.pp pkg
+      Fmt.(styled `Bold string) lifecycleName
+    )
   in
-  Path.(cfg.Config.cacheSourcesPath / (name ^ "-" ^ id))
 
-type status =
-  | Cached
-  | Fresh
+  let readAndCloseChan ic =
+    Lwt.finalize
+      (fun () -> Lwt_io.read ic)
+      (fun () -> Lwt_io.close ic)
+  in
 
-let install ~sandbox dist =
+  let f p =
+    let%lwt stdout = readAndCloseChan p#stdout
+    and stderr = readAndCloseChan p#stderr in
+    match%lwt p#status with
+    | Unix.WEXITED 0 ->
+      RunAsync.return ()
+    | _ ->
+      Logs_lwt.err (fun m -> m
+        "@[<v>command failed: %s@\nstderr:@[<v 2>@\n%s@]@\nstdout:@[<v 2>@\n%s@]@]"
+        script stderr stdout
+      );%lwt
+      RunAsync.error "error running command"
+  in
+
+  try%lwt
+    (* We don't need to wrap the install path on Windows in quotes *)
+    let installationPath =
+      match System.Platform.host with
+      | Windows -> Path.show sourcePath
+      | _ -> Filename.quote (Path.show sourcePath)
+    in
+    let script =
+      Printf.sprintf
+        "cd %s && %s"
+        installationPath
+        script
+    in
+    let cmd =
+      match System.Platform.host with
+      | Windows -> ("", [|"cmd.exe";("/c " ^ script)|])
+      | _ -> ("/bin/bash", [|"/bin/bash";"-c";script|])
+    in
+    let env =
+      let open Option.Syntax in
+      let%bind env = env in
+      let%bind _, env = ChildProcess.prepareEnv env in
+      return env
+    in
+    Lwt_process.with_process_full ?env cmd f
+  with
+  | Unix.Unix_error (err, _, _) ->
+    let msg = Unix.error_message err in
+    RunAsync.error msg
+  | _ ->
+    RunAsync.error "error running subprocess"
+
+let runLifecycleScripts ~binPath pkg sourcePath pkgJson =
+  let open RunAsync.Syntax in
+  let env =
+    let override =
+      let path = (Path.show binPath)::System.Environment.path in
+      let sep = System.Environment.sep ~name:"PATH" () in
+      Astring.String.Map.(
+        empty
+        |> add "PATH" (String.concat ~sep path)
+      )
+    in
+    ChildProcess.CurrentEnvOverride override
+  in
+
+  let scripts = PackageJson.scripts pkgJson in
+
+  let%bind () =
+    match scripts.install with
+    | Some cmd -> runLifecycleScript ~env ~lifecycleName:"install" pkg sourcePath cmd
+    | None -> return ()
+  in
+
+  let%bind () =
+    match scripts.postinstall with
+    | Some cmd -> runLifecycleScript ~env ~lifecycleName:"postinstall" pkg sourcePath cmd
+    | None -> return ()
+  in
+
+  return ()
+
+let installBinWrapper ~binPath (name, origPath) =
+  let open RunAsync.Syntax in
+  Logs_lwt.debug (fun m ->
+    m "Fetch:installBinWrapper: %a / %s -> %a"
+    Path.pp origPath name Path.pp binPath
+  );%lwt
+  if%bind Fs.exists origPath
+  then (
+    let%bind () = Fs.chmod 0o777 origPath in
+    Fs.symlink ~src:origPath Path.(binPath / name)
+  ) else (
+    Logs_lwt.warn (fun m -> m "missing %a defined as binary" Path.pp origPath);%lwt
+    return ()
+  )
+
+let install dist =
   (** TODO: need to sync here so no two same tasks are running at the same time *)
   let open RunAsync.Syntax in
   RunAsync.contextf (
-    match dist.Dist.pkg.source with
-    | Solution.Package.Link {path; _} ->
-      return (Fresh, Path.(sandbox.Sandbox.spec.path // path))
-    | Solution.Package.Install { overrides; files; opam; _ } ->
-      let path = path ~cfg:sandbox.Sandbox.cfg dist in
-      if%bind Fs.exists path
-      then return (Cached, path)
-      else (
-        let%bind () = unpack ~sandbox ~overrides ~files ~path ~opam dist in
-        return (Fresh, path)
-      )
+
+    let%bind binPath =
+      let binPath = SandboxSpec.binPath dist.sandbox.Sandbox.spec in
+      let%bind () = Fs.createDir binPath in
+      return binPath
+    in
+
+    let%bind sourcePath, pkgJson =
+      match dist.Dist.pkg.source with
+      | Solution.Package.Link {path; _} ->
+        let%bind pkgJson = PackageJson.ofDir path in
+        let sourcePath = Path.(dist.sandbox.Sandbox.spec.path // path) in
+        return (sourcePath, pkgJson)
+      | Solution.Package.Install { overrides; files; opam; _ } ->
+        let sourcePath = Dist.sourcePath dist in
+        if%bind Fs.exists sourcePath
+        then
+          let%bind pkgJson = PackageJson.ofDir sourcePath in
+          return (sourcePath, pkgJson)
+        else (
+          let%bind () = unpack ~overrides ~files ~path:sourcePath ~opam dist in
+          let%bind pkgJson = PackageJson.ofDir sourcePath in
+          let%bind () =
+            match pkgJson with
+            | Some pkgJson -> runLifecycleScripts ~binPath dist.pkg sourcePath pkgJson
+            | None -> return ()
+          in
+          return (sourcePath, pkgJson)
+        )
+    in
+
+    (* link bin wrappers *)
+    let%bind () =
+      match pkgJson with
+      | Some pkgJson ->
+        let bin = PackageJson.bin ~sourcePath pkgJson in
+        RunAsync.List.mapAndWait ~f:(installBinWrapper ~binPath) bin
+      | None -> return ()
+    in
+
+    return ()
   ) "installing %a" Dist.pp dist

--- a/esyi/FetchStorage.ml
+++ b/esyi/FetchStorage.ml
@@ -75,12 +75,16 @@ let unpack ~sandbox ~path ~overrides ~files ~opam dist =
           EsyLinkFile.{source = dist.Dist.source; overrides; opam;}
           tempPath
       in
-      let%bind () = SourceStorage.unpack ~cfg:sandbox.Sandbox.cfg ~dst:tempPath sourceInStorage in
       let%bind () =
-        let f file =
-          Package.File.writeToDir ~destinationDir:tempPath file
-        in
-        List.map ~f files |> RunAsync.List.waitAll
+        SourceStorage.unpack
+          ~cfg:sandbox.Sandbox.cfg
+          ~dst:tempPath
+          sourceInStorage
+      in
+      let%bind () =
+        RunAsync.List.mapAndWait
+          ~f:(Package.File.writeToDir ~destinationDir:tempPath)
+          files
       in
 
       let%bind () = Fs.rename ~src:tempPath path in

--- a/esyi/FetchStorage.mli
+++ b/esyi/FetchStorage.mli
@@ -6,7 +6,9 @@
 module Dist : sig
   type t
   val id : t -> PackageId.t
+  val pkg : t -> Solution.Package.t
   val source : t -> Source.t
+  val sourcePath : t -> Path.t
   val pp : Format.formatter -> t -> unit
 end
 
@@ -19,14 +21,9 @@ val fetch :
  * return it.
  *)
 
-type status =
-  | Cached
-  | Fresh
-
 val install :
-  sandbox : Sandbox.t
-  -> Dist.t
-  -> (status * Path.t) RunAsync.t
+  Dist.t
+  -> unit RunAsync.t
 (**
  * Unpack fetched dist from storage into source cache and return path.
  *)

--- a/esyi/FetchStorage.mli
+++ b/esyi/FetchStorage.mli
@@ -8,7 +8,7 @@ module Dist : sig
   val id : t -> PackageId.t
   val pkg : t -> Solution.Package.t
   val source : t -> Source.t
-  val sourcePath : t -> Path.t
+  val sourceInstallPath : t -> Path.t
   val pp : Format.formatter -> t -> unit
 end
 

--- a/esyi/PnpJs.ml
+++ b/esyi/PnpJs.ml
@@ -877,6 +877,11 @@ exports.setup = function setup() {
   };
 
   process.versions.pnp = String(exports.VERSIONS.std);
+
+  if (process.env.ESY__NODE_BIN_PATH != null) {
+    const delimiter = require('path').delimiter;
+    process.env.PATH = `${process.env.ESY__NODE_BIN_PATH}${delimiter}${process.env.PATH}`;
+  }
 };
 
 exports.setupCompatibilityLayer = () => {

--- a/esyi/Solver.ml
+++ b/esyi/Solver.ml
@@ -334,18 +334,13 @@ let add ~(dependencies : Dependencies.t) solver =
   and addDependencies (dependencies : Dependencies.t) =
     match dependencies with
     | Dependencies.NpmFormula reqs ->
-      RunAsync.List.waitAll (
-        let f (req : Req.t) = addDependency req in
-        List.map ~f reqs
-      )
+      let f (req : Req.t) = addDependency req in
+      RunAsync.List.mapAndWait ~f reqs
 
     | Dependencies.OpamFormula _ ->
-      RunAsync.List.waitAll (
-        let f (req : Req.t) = addDependency req
-        in
-        let reqs = Dependencies.toApproximateRequests dependencies in
-        List.map ~f reqs
-      )
+      let f (req : Req.t) = addDependency req in
+      let reqs = Dependencies.toApproximateRequests dependencies in
+      RunAsync.List.mapAndWait ~f reqs
 
   and addDependency (req : Req.t) =
     let%lwt () =

--- a/esyi/SourceStorage.ml
+++ b/esyi/SourceStorage.ml
@@ -6,7 +6,7 @@ let sourceTarballPath ~cfg source =
     |> Digest.string
     |> Digest.to_hex
   in
-  Path.(cfg.Config.cacheTarballsPath // v id |> addExt "tgz")
+  Path.(cfg.Config.sourceArchivePath // v id |> addExt "tgz")
 
 let fetchSourceIntoPath source path =
   let open RunAsync.Syntax in

--- a/esyi/SourceStorage.ml
+++ b/esyi/SourceStorage.ml
@@ -20,7 +20,7 @@ let fetchSourceIntoPath source path =
       Fs.copyPath ~src ~dst
     in
     let%bind () =
-      RunAsync.List.waitAll (List.map ~f:copy names)
+      RunAsync.List.mapAndWait ~f:copy names
     in
     return (Ok ())
 


### PR DESCRIPTION
This PR improves installation phase of `esy install` command by making sure we do all the work atomically. Previously if package's postinstall/install lifecycle failed the next `esy install` invocation didn't try to redo it, now we correctly track which packages were installed correctly and which were failed.