### PR TITLE
Fix #389 - Part 1 - Add warning message

### DIFF
--- a/esy/bin/esyCommand.ml
+++ b/esy/bin/esyCommand.ml
@@ -1866,7 +1866,20 @@ let makeCommands ~sandbox () =
 
   defaultCommand, commands
 
+let checkSymlinks () =
+  if Unix.has_symlink () == false then begin
+    print_endline ("ERROR: Unable to create symlinks. Missing SeCreateSymbolicLinkPrivilege.");
+    print_endline ("");
+    print_endline ("Esy must be ran as an administrator on Windows, because it uses symbolic links.");
+    print_endline ("Open an elevated command shell by right-clicking and selecting 'Run as administrator', and try esy again.");
+    print_endline("");
+    print_endline ("For more info, see https://github.com/esy/esy/issues/389");
+    exit 1;
+  end
+
 let () =
+
+  let () = checkSymlinks () in
 
   let argv, commandName, sandbox =
     let argv = Array.to_list Sys.argv in


### PR DESCRIPTION
__Issue:__ When `esy` is run in an unprivileged environment without the `SeCreateSymbolicLinkPrivilege`, lots of things will break - because we depend on symlinks. The user will get obscure error messages that are difficult to figure out.

__Fix:__ As described in #389 , Windows is not very friendly to symlinks - but esy depends on it right now. Long-term, we could evaluate removing symlinks and replacing with a copy flow.

It turns out that the ocaml runtime can let us know if we are able to create symlinks via the unix `has_symlink` method: https://github.com/ocaml/ocaml/blob/28c337fecbebfc064c06ae0ba35a1107b0b58493/otherlibs/win32unix/symlink.c#L87

On Linux/Mac, this always returns true, but on Windows, this actually checks the permission to create symlinks. If this returns false, we return a more detailed error message about the issue and how to address it.

![image](https://user-images.githubusercontent.com/13532591/47330695-05dcdb80-d62e-11e8-9835-f5126cfaf3cd.png)
