### PR TITLE
[WIP] Fix npm bin wrappers on Windows

### DIFF
--- a/esy-lib/System.ml
+++ b/esy-lib/System.ml
@@ -91,19 +91,9 @@ module Environment = struct
     | _, (Linux | Darwin | Unix | Unknown | Cygwin) -> ":"
     | _, Windows -> ";"
 
-  let current =
-    let f map item =
-      let idx = String.index item '=' in
-      let name = String.sub item 0 idx in
-      let value = String.sub item (idx + 1) (String.length item - idx - 1) in
-      StringMap.add name value map
-    in
-    let items = Unix.environment () in
-    Array.fold_left f StringMap.empty items
-
   let path =
     let sep = sep () in
-    match StringMap.find_opt "PATH" current with
+    match Sys.getenv_opt "PATH" with
     | Some path -> String.split_on_char sep.[0] path
     | None -> []
 

--- a/esyi/PnpJs.ml
+++ b/esyi/PnpJs.ml
@@ -232,7 +232,7 @@ const isDirRegExp = /\/$/;
 const isStrictRegExp = /^\.{0,2}\//;
 
 // Splits a require request into its components, or return null if the request is a file path
-const pathRegExp = /^(?!\.{0,2}(?:\/|$))((?:@@[^\/]+\/)?[^\/]+)\/?(.*|)$/;
+const pathRegExp = /^(?![A-Za-z]:)(?!\.{0,2}(?:\/|$))((?:@@[^\/]+\/)?[^\/]+)\/?(.*|)$/;
 
 // Keep a reference around ("module" is a common name in this context, so better rename it to something more significant)
 const pnpModule = module;

--- a/test-e2e/install/basic-npm.test.js
+++ b/test-e2e/install/basic-npm.test.js
@@ -137,6 +137,32 @@ describe(`Basic tests for npm packages`, () => {
     ).toBeFalsy();
   });
 
+  test(`it should wrap *.js file with`, async () => {
+    const p = await helpers.createTestSandbox();
+
+    await p.fixture(
+      helpers.packageJson({
+        name: 'root',
+        version: '1.0.0',
+        dependencies: {[`dep`]: 'path:dep'},
+      }),
+      helpers.dir(
+        'dep',
+        helpers.packageJson({
+          name: 'dep',
+          version: '1.0.0',
+          bin: 'dep.js',
+        }),
+        helpers.file('dep.js', `console.log("dep: HELLO");`),
+      ),
+    );
+
+    await p.esy('install');
+
+    const proc = await p.esy('dep');
+    expect(proc.stdout.toString().trim()).toBe('dep: HELLO');
+  });
+
   test(`node wrapper is installed`, async () => {
     const p = await helpers.createTestSandbox();
 


### PR DESCRIPTION
This handles `*.js` npm executables installation by generating `bash`/`cmd.exe` wrappers which execute pnp enabled node with the script.

Things remaining:
- [ ] Make sure non `*.js` npm executables are installed with `*.exe` suffix so that they are treated as executables by Windows.
- [ ] enable `basic-npm.test.js`