### PR TITLE
Fix npm install slowtest

### DIFF
--- a/test-e2e-slow/install-npm.test.js
+++ b/test-e2e-slow/install-npm.test.js
@@ -35,9 +35,6 @@ const cases = [
   },
   {
     name: 'babel-cli',
-    test: `
-      require('babel-core');
-    `,
   },
   {
     name: 'react-scripts',


### PR DESCRIPTION
We can't require babel-core with pnp.