### PR TITLE
Azure CI: Include windows in release

### DIFF
--- a/.ci/build-release.yml
+++ b/.ci/build-release.yml
@@ -56,7 +56,7 @@ phases:
         displayName: 'Publish Artifact: Windows'
         inputs:
           PathtoPublish: '_platformrelease'
-          ArtifactName: Windows
+          ArtifactName: platform-win32
 
   - phase: buildRelease
     displayName: Build Release
@@ -91,15 +91,13 @@ phases:
 
     #
     # Prepare windows platform release.
-    # TODO: re-enable
     #
 
-    # - task: DownloadBuildArtifacts@0
-    #   displayName: 'Download Windows Artifacts'
-    #   inputs:
-    #     artifactName: Windows
-    #     downloadPath: '_release'
-    #   continueOnError: true
+    - task: DownloadBuildArtifacts@0
+      displayName: 'Download Windows Artifacts'
+      inputs:
+        artifactName: platform-win32
+        downloadPath: '_release'
 
     # - script: 'mkdir _release/platform-windows-x64'
     #   displayName: 'Create _release/platform-windows-x64'

--- a/.ci/build-windows.yml
+++ b/.ci/build-windows.yml
@@ -41,6 +41,6 @@ steps:
     displayName: 'esy b dune runtest test'
     continueOnError: true
 
-  - script: "npm run release:make-platform-package"
-    displayName: "release:make-platform-package"
+  - script: "npm run platform-release"
+    displayName: "npm run platform-release"
     continueOnError: true

--- a/scripts/release-postinstall.js
+++ b/scripts/release-postinstall.js
@@ -114,7 +114,7 @@ switch (platform) {
       process.exit(1);
     }
 
-    copyPlatformBinaries('windows-x64');
+    copyPlatformBinaries('win32');
 
     console.log('Installing cygwin sandbox...');
     cp.execSync(`npm install esy-bash@0.2.3 --prefix ${__dirname}`);


### PR DESCRIPTION
This includes Windows in our final release bundling, so that the package we get is a composite of Linux, OSX, and now Windows.

Build is green! And I validated the release archive that windows is available and installable.