### PR TITLE
Windows: Installation fails & leads to corrupt cache

### DIFF
--- a/esyi/FetchStorage.ml
+++ b/esyi/FetchStorage.ml
@@ -26,7 +26,7 @@ module Dist = struct
         |> Digest.to_hex
         |> Path.safeSeg
       in
-      Path.(dist.sandbox.cfg.sourceInstallPath / (name ^ "-" ^ id))
+      Path.(dist.sandbox.cfg.sourceStagePath / (name ^ "-" ^ id))
 
   let sourceInstallPath dist =
     match dist.source with

--- a/esyi/FetchStorage.mli
+++ b/esyi/FetchStorage.mli
@@ -14,6 +14,7 @@ module Dist : sig
   val pkg : t -> Solution.Package.t
   val source : t -> Source.t
   val sourceInstallPath : t -> Path.t
+  val sourceStagePath : t -> Path.t
   val pp : Format.formatter -> t -> unit
 end
 
@@ -27,7 +28,11 @@ val fetch :
  *)
 
 val install :
-  Dist.t
+  prepareLifecycleEnv:(
+    Path.t
+    -> string Astring.String.Map.t
+    -> string Astring.String.Map.t RunAsync.t)
+  -> Dist.t
   -> unit RunAsync.t
 (**
  * Unpack fetched dist from storage into source cache and return path.

--- a/esyi/PnpJs.mli
+++ b/esyi/PnpJs.mli
@@ -9,8 +9,10 @@
  *)
 
 val render :
-  solution:Solution.t
+  basePath:Path.t
+  -> rootPath:Path.t
+  -> rootId:PackageId.t
+  -> solution:Solution.t
   -> installation:Installation.t
-  -> sandbox:SandboxSpec.t
   -> unit
   -> string


### PR DESCRIPTION
When running `esy install` on `hello-ocaml` from the master build, there are a few issues:

First, we see an error message: 
```
  Unix.Unix_error(Unix.EACCES, "rename", "C:\\Users\\bryph\\.esy\\source\\i\\esy_ocaml__s__substs-f8e6e3cbaecdb713df63e81582de9aaf")
     Raised at file "src/core/lwt.ml", line 2987, characters 20-29
     Called from file "src/unix/lwt_main.ml", line 26, characters 8-18
     Called from file "esy/bin/esyCommand.ml", line 10, characters 8-24
     Called from file "src/cmdliner_term.ml", line 27, characters 19-24
     Called from file "src/cmdliner.ml", line 27, characters 27-34
     Called from file "src/cmdliner.ml", line 106, characters 32-39
```
In addition, some other packages, like `ocamlfind`, are __missing their patch files__ (the source cache is corrupt, essentially).

In debugging this, I saw something strange - we were calling rename _on the same folder_:
```
-rename: C:\Users\bryph\.esy\source\i\esy_ocaml__s__substs-f8e6e3cbaecdb713df63e81582de9aaf -> C:\Users\bryph\.esy\source\i\esy_ocaml__s__substs-f8e6e3cbaecdb713df63e81582de9aaf
```

@jordwalke caught right away that this should be renaming from `staging` -> `install` (thanks Jordan!)

When I made that change life was good - the install was successful on Windows and the cache was working.