### PR TITLE
Azure CI - Windows: Add condition to only publish cache on master branch

### DIFF
--- a/.ci/build-windows.yml
+++ b/.ci/build-windows.yml
@@ -64,6 +64,7 @@ steps:
 
   - task: PublishBuildArtifacts@1
     displayName: 'Cache: Upload source tarballs'
+    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
     inputs:
         pathToPublish: 'C:\Users\VssAdministrator\.esy\source-tarballs'
         artifactName: 'build-cache-windows-source-tarballs'
@@ -75,6 +76,7 @@ steps:
 
   - task: PublishBuildArtifacts@1
     displayName: 'Cache: Upload install folder'
+    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
     inputs:
         pathToPublish: 'C:\Users\VssAdministrator\.esy\3_\i'
         artifactName: 'build-cache-windows-install'


### PR DESCRIPTION
On Windows, we've adding build caching in our Azure builds - the `DownloadBuildArtifact` is pretty fast (~2min, which is much faster than building the artifacts!).

However, the `PublishBuildArtifact` takes quite a bit of time  (~7 minutes for uploading the install folder, ~1 minute for uploading the source-tarballs folder). We only need / should do this on `master` builds - so this change adds a condition to only run cache on master.