### PR TITLE
[WIP] Include mingw runtime path for esyRewritePrefixCommand.exe

### DIFF
--- a/esy-build-package/Build.re
+++ b/esy-build-package/Build.re
@@ -381,7 +381,7 @@ let commitBuildToStore = (config: Config.t, build: build) => {
     let env = Astring.String.Map.(
         add(
             "PATH",
-            p ++ ";" ++ Sys.getenv("PATH"),
+            Fpath.to_string(p) ++ ";" ++ Sys.getenv("PATH"),
             empty,
         )
     );

--- a/esy-build-package/Build.re
+++ b/esy-build-package/Build.re
@@ -377,9 +377,18 @@ let commitBuildToStore = (config: Config.t, build: build) => {
       Path.(build.stagePath / "_esy" / "storePrefix"),
     );
   let%bind () = {
+    let%bind p = EsyBash.getMingwRuntimePath();
+    let env = Astring.String.Map.(
+        add(
+            "PATH",
+            p ++ ";" ++ Sys.getenv("PATH"),
+            empty,
+        )
+    );
     let%bind cmd =
       EsyLib.NodeResolution.resolve("./esyRewritePrefixCommand.exe");
     Bos.OS.Cmd.run(
+      ~env,
       Cmd.(
         v(p(cmd))
         % "--orig-prefix"

--- a/esy-lib/RewritePrefix.ml
+++ b/esy-lib/RewritePrefix.ml
@@ -1,6 +1,7 @@
 let cmd = ref None
 
 let rewritePrefix ~origPrefix ~destPrefix path =
+  let open RunAsync.Syntax in
   Logs_lwt.debug (fun m ->
     m "rewritePrefix %a: %a -> %a"
     Path.pp path
@@ -12,7 +13,8 @@ let rewritePrefix ~origPrefix ~destPrefix path =
     | Some cmd -> cmd
     | None -> failwith "esy-rewrite-prefix command isn't configured"
   in
-  ChildProcess.run Cmd.(
+  let%bind env = EsyBashLwt.getMingwEnvironmentOverride () in
+  ChildProcess.run ~env Cmd.(
     cmd
     % "--orig-prefix" % p origPrefix
     % "--dest-prefix" % p destPrefix


### PR DESCRIPTION
This may not be necessary if we can get the static linking working - but if not, we can include the MingW runtime binaries (which are included with `esy-bash` anyway) in the PATH, so that we can reliably execute `esyRewritePrefixCommand.exe` w/o copying dlls.

We use a similiar strategy today for running the solver, since there is a similiar static linking issue w/ `mccs`.