### PR TITLE
Add 'dune-project' to sandbox write whitelist.

### DIFF
--- a/esy-build-package/Build.re
+++ b/esy-build-package/Build.re
@@ -266,6 +266,7 @@ let configureBuild = (~cfg: Config.t, plan: Plan.t) => {
           regex(sourcePath, [".*", "\\.merlin"]),
           regex(sourcePath, ["\\.merlin"]),
           regex(sourcePath, [".*\\.install"]),
+          regex(sourcePath, ["dune-project"]),
           Subpath(Path.show(buildPath)),
           Subpath(Path.show(stagePath)),
           Subpath("/private/tmp"),


### PR DESCRIPTION
New Dune projects might not have the `dune-project` file. Dune will attempt to create one in the project's root directory and fail with lack of permissions:

```
info esy 0.3.4
Info: creating file dune-project with this contents: (lang dune 1.4)
Error: exception Sys_error("dune-project: Operation not permitted")
...
```

This PR simply adds `<sourcePath>/dune-project` to the write whitelist.

CC @andreypopp (thanks for pointing me to the right place for this fix)