### PR TITLE
Automatically create empty task for root packages w/o esy config

### DIFF
--- a/esy/NpmRelease.ml
+++ b/esy/NpmRelease.ml
@@ -149,11 +149,7 @@ let make
   in
 
   let root = Package.id (Solution.root solution) in
-  let%bind rootTask =
-    match%bind RunAsync.ofRun (Plan.findTaskById plan root) with
-    | Some task -> return task
-    | None -> errorf "root package doesn't have esy configuration"
-  in
+  let rootTask = Plan.rootTask plan in
 
   (* Make sure all packages are built *)
   let%bind () =

--- a/esy/Plan.mli
+++ b/esy/Plan.mli
@@ -31,7 +31,7 @@ type t
 
 val findTaskById : t -> EsyInstall.PackageId.t -> Task.t option Run.t
 val findTaskByName : t -> string -> Task.t option option
-val rootTask : t -> Task.t option
+val rootTask : t -> Task.t
 val allTasks : t -> Task.t list
 
 val make :

--- a/test-e2e/complete/esy-sandbox.test.js
+++ b/test-e2e/complete/esy-sandbox.test.js
@@ -330,4 +330,49 @@ describe('complete workflow for esy sandboxes', () => {
       expect(stdout.trim()).toEqual('__dep__');
     }
   });
+
+  it('allows to define just dependencies', async () => {
+    const fixture = [
+      packageJson({
+        dependencies: {
+          dep: '*',
+        },
+      }),
+    ];
+    const p = await createTestSandbox();
+    await p.fixture(...fixture);
+
+    await p.defineNpmPackageOfFixture([
+      packageJson({
+        name: 'dep',
+        version: '1.0.0',
+        esy: {
+          install: [
+            'cp #{self.root / self.name}.js #{self.bin / self.name}.js',
+            helpers.buildCommand(p, '#{self.bin / self.name}.js'),
+          ],
+        },
+        dependencies: {
+          ocaml: '*',
+        },
+      }),
+      dummyExecutable('dep'),
+    ]);
+
+    await p.esy('install --skip-repository-update');
+    await p.esy('build');
+
+    {
+      const {stdout} = await p.esy('dep.cmd');
+      expect(stdout.trim()).toEqual('__dep__');
+    }
+    {
+      const {stdout} = await p.esy('b dep.cmd');
+      expect(stdout.trim()).toEqual('__dep__');
+    }
+    {
+      const {stdout} = await p.esy('x dep.cmd');
+      expect(stdout.trim()).toEqual('__dep__');
+    }
+  });
 });


### PR DESCRIPTION
If is useful to allow root packages not to have esy configuration at all:

- We can make packages which just define dependencies on other packages and thus
  construct only environment sandboxes:

  ```
  {
    "dependencies": {
      "ocaml": "*"
    }
  }
  ```

  The package above will define a sandbox which has `ocaml` toolchain in there.

- Make sure all commands work with non-esy packages, like `esy ls-builds` and
  others (even if they don't produce output).