### PR TITLE
Fix #584: Update windows path to match the process.platform path

### DIFF
--- a/scripts/create-release-package-json.js
+++ b/scripts/create-release-package-json.js
@@ -29,7 +29,7 @@ console.log(
         'postinstall.js',
         'platform-linux/',
         'platform-darwin/',
-        'platform-windows-x64/',
+        'platform-win32/',
         '_build/default/**/*.exe'
       ]
     },


### PR DESCRIPTION
The path in `create-release-package.json` was out-of-sync with where the windows build artifacts are downloaded. Looking at the Azure CI logs, they are download to `_release/platform-win32`, so this should bring them back in sync.