### PR TITLE
Fix updating git clones under Windows and simplify EsyBash API

### DIFF
--- a/esy-build-package/Sandbox.re
+++ b/esy-build-package/Sandbox.re
@@ -89,7 +89,7 @@ module Windows = {
         Cmd.of_list(
           List.map(EsyLib.Path.normalizePathSlashes, commandAsList),
         );
-      let%bind augmentedEsyCommand =
+      let augmentedEsyCommand =
         EsyLib.EsyBash.toEsyBashCommand(
           ~env=Some(Fpath.to_string(environmentTempFile)),
           normalizedCommands,

--- a/esy-lib/Checksum.ml
+++ b/esy-lib/Checksum.ml
@@ -74,7 +74,7 @@ let checkFile ~path (checksum : t) =
     (* On Windows, the checksum tools packaged with Cygwin require cygwin-style paths *)
     RunAsync.ofBosError (
       let open Result.Syntax in
-      let%bind path = EsyBash.normalizePathForCygwin (Path.show path) in
+      let path = EsyBash.normalizePathForCygwin (Path.show path) in
       let%bind out = EsyBash.runOut Cmd.(cmd % path |> toBosCmd) in
       match Astring.String.cut ~sep:" " out with
       | Some (v, _) -> return v

--- a/esy-lib/Cmd.ml
+++ b/esy-lib/Cmd.ml
@@ -115,7 +115,7 @@ let resolveCmd path cmd =
   let allPaths = getAdditionalResolvePaths path in
   let find p =
     let p = Path.(v p / cmd) in
-    let%bind p = EsyBash.normalizePathForWindows p in
+    let p = EsyBash.normalizePathForWindows p in
     checkIfCommandIsAvailable p
     in
   let rec resolve =

--- a/esy-lib/EsyBash.re
+++ b/esy-lib/EsyBash.re
@@ -30,53 +30,43 @@ let getEsyBashRootPath = () => {
  * Helper method to get the `cygpath` utility path
  * Used for resolving paths
  */
-let getCygPath = () =>
-  Result.Syntax.(
-    {
-      let%bind rootPath = getEsyBashRootPath();
-      Ok(Fpath.(rootPath / ".cygwin" / "bin" / "cygpath.exe"));
-    }
-  );
+let getCygPath = () => {
+  let rootPath = getEsyBashRootPath();
+  switch (rootPath) {
+  | Ok(rootPath) => Fpath.(rootPath / ".cygwin" / "bin" / "cygpath.exe")
+  | Error(`Msg(err)) => failwith(err)
+  | Error(`CommandError(cmd, _)) =>
+    Exn.failf("command failed: %a", Bos.Cmd.pp, cmd)
+  };
+};
 
-let getBinPath = () =>
-  Result.Syntax.(
-    {
-      let%bind rootPath = getEsyBashRootPath();
-      Ok(
-        Fpath.(
-          rootPath
-          / ".cygwin"
-          / "bin"
-        ),
-      );
-    }
-  );
+let getBinPath = () => {
+  open Result.Syntax;
+  let%bind rootPath = getEsyBashRootPath();
+  Ok(Fpath.(rootPath / ".cygwin" / "bin"));
+};
 
-let getEsyBashPath = () =>
-  Result.Syntax.(
-    {
-      let%bind rootPath = getEsyBashRootPath();
-      Ok(Fpath.(rootPath / "re" / "_build" / "default" / "bin" / "EsyBash.exe"));
-    }
-  );
+let getEsyBashPath = () => {
+  open Result.Syntax;
+  let%bind rootPath = getEsyBashRootPath();
+  Ok(Fpath.(rootPath / "re" / "_build" / "default" / "bin" / "EsyBash.exe"));
+};
 
-let getMingwRuntimePath = () =>
-  Result.Syntax.(
-    {
-      let%bind rootPath = getEsyBashRootPath();
-      Ok(
-        Fpath.(
-          rootPath
-          / ".cygwin"
-          / "usr"
-          / "x86_64-w64-mingw32"
-          / "sys-root"
-          / "mingw"
-          / "bin"
-        ),
-      );
-    }
+let getMingwRuntimePath = () => {
+  open Result.Syntax;
+  let%bind rootPath = getEsyBashRootPath();
+  Ok(
+    Fpath.(
+      rootPath
+      / ".cygwin"
+      / "usr"
+      / "x86_64-w64-mingw32"
+      / "sys-root"
+      / "mingw"
+      / "bin"
+    ),
   );
+};
 
 /**
 * Helper utility to normalize paths to a cygwin style,
@@ -84,20 +74,18 @@ let getMingwRuntimePath = () =>
 * On non-Windows platforms, this is a noop
 */
 let normalizePathForCygwin = path =>
-  Result.Syntax.(
-    switch (System.Platform.host) {
-    | System.Platform.Windows =>
-      let%bind rootPath = getCygPath();
-      let ic =
-        Unix.open_process_in(
-          Fpath.to_string(rootPath) ++ " \"" ++ path ++ " \"",
-        );
-      let result = String.trim(input_line(ic));
-      let () = close_in(ic);
-      Ok(result);
-    | _ => Ok(path)
-    }
-  );
+  switch (System.Platform.host) {
+  | System.Platform.Windows =>
+    let rootPath = getCygPath();
+    let ic =
+      Unix.open_process_in(
+        Fpath.to_string(rootPath) ++ " \"" ++ path ++ " \"",
+      );
+    let result = String.trim(input_line(ic));
+    let () = close_in(ic);
+    result;
+  | _ => path
+  };
 
 let toEsyBashCommand = (~env=None, cmd) => {
   open Result.Syntax;
@@ -112,12 +100,7 @@ let toEsyBashCommand = (~env=None, cmd) => {
     let commands = Bos.Cmd.to_list(cmd);
     let%bind esyBashPath = getEsyBashPath();
     let allCommands = List.append(environmentFilePath, commands);
-    Ok(
-      Bos.Cmd.of_list([
-        Fpath.to_string(esyBashPath),
-        ...allCommands,
-      ]),
-    );
+    Ok(Bos.Cmd.of_list([Fpath.to_string(esyBashPath), ...allCommands]));
   | _ => Ok(cmd)
   };
 };
@@ -128,49 +111,43 @@ let toEsyBashCommand = (~env=None, cmd) => {
 * On non-windows platforms, this is a no-op
 */
 let normalizePathForWindows = (path: Fpath.t) =>
-  Result.Syntax.(
-    switch (System.Platform.host) {
-    | System.Platform.Windows =>
-      let pathAsString = Fpath.to_string(path);
-      switch (pathAsString.[0]) {
-      /* We assume that if the path coming in to normalize is a leading slash,
-       * it should be converted from a Unix path to a Windows path.
-       */
-      | '\\' =>
-        let%bind rootPath = getCygPath();
-        /* Use the `cygpath` utility with the `-w` flag to resolve to a Windows path */
-        let commandToRun =
-          String.trim(Fpath.to_string(rootPath))
-          ++ " -w "
-          ++ Path.normalizePathSlashes(Fpath.to_string(path));
-        let ic = Unix.open_process_in(commandToRun);
-        let result = Fpath.v(String.trim(input_line(ic)));
-        let () = close_in(ic);
-        Ok(result);
-      | _ => Ok(path)
-      };
-    | _ => Ok(path)
-    }
-  );
+  switch (System.Platform.host) {
+  | System.Platform.Windows =>
+    let pathAsString = Fpath.to_string(path);
+    switch (pathAsString.[0]) {
+    /* We assume that if the path coming in to normalize is a leading slash,
+     * it should be converted from a Unix path to a Windows path.
+     */
+    | '\\' =>
+      let rootPath = getCygPath();
+      /* Use the `cygpath` utility with the `-w` flag to resolve to a Windows path */
+      let commandToRun =
+        String.trim(Fpath.to_string(rootPath))
+        ++ " -w "
+        ++ Path.normalizePathSlashes(Fpath.to_string(path));
+      let ic = Unix.open_process_in(commandToRun);
+      let result = Fpath.v(String.trim(input_line(ic)));
+      let () = close_in(ic);
+      result;
+    | _ => path
+    };
+  | _ => path
+  };
 
 /**
  * Helper utility to run a command with 'esy-bash'.
  * On Windows, this runs the command in a Cygwin environment
  * On other platforms, this is equivalent to running the command directly with Bos.OS.Cmd.run
  */
-let run = cmd =>
-  Result.Syntax.(
-    {
-      let%bind augmentedCommand = toEsyBashCommand(cmd);
-      Bos.OS.Cmd.run(augmentedCommand);
-    }
-  );
+let run = cmd => {
+  open Result.Syntax;
+  let%bind augmentedCommand = toEsyBashCommand(cmd);
+  Bos.OS.Cmd.run(augmentedCommand);
+};
 
-let runOut = cmd =>
-  Result.Syntax.(
-    {
-      let%bind augmentedCommand = toEsyBashCommand(cmd);
-      let ret = Bos.OS.Cmd.(run_out(augmentedCommand));
-      Bos.OS.Cmd.to_string(ret);
-    }
-  );
+let runOut = cmd => {
+  open Result.Syntax;
+  let%bind augmentedCommand = toEsyBashCommand(cmd);
+  let ret = Bos.OS.Cmd.(run_out(augmentedCommand));
+  Bos.OS.Cmd.to_string(ret);
+};

--- a/esy-lib/EsyBash.rei
+++ b/esy-lib/EsyBash.rei
@@ -1,0 +1,48 @@
+let getMingwRuntimePath:
+  unit =>
+  result(
+    Fpath.t,
+    [> | `CommandError(Bos.Cmd.t, Bos.OS.Cmd.status) | `Msg(string)],
+  );
+
+let getBinPath:
+  unit =>
+  result(
+    Fpath.t,
+    [> | `CommandError(Bos.Cmd.t, Bos.OS.Cmd.status) | `Msg(string)],
+  );
+
+let toEsyBashCommand:
+  (~env: option(string)=?, Bos.Cmd.t) =>
+  result(
+    Bos.Cmd.t,
+    [> | `CommandError(Bos.Cmd.t, Bos.OS.Cmd.status) | `Msg(string)],
+  );
+
+let normalizePathForCygwin:
+  string =>
+  result(
+    string,
+    [> | `CommandError(Bos.Cmd.t, Bos.OS.Cmd.status) | `Msg(string)],
+  );
+
+let normalizePathForWindows:
+  Fpath.t =>
+  result(
+    Fpath.t,
+    [> | `CommandError(Bos.Cmd.t, Bos.OS.Cmd.status) | `Msg(string)],
+  );
+
+let run:
+  Bos.Cmd.t =>
+  result(
+    unit,
+    [> | `CommandError(Bos.Cmd.t, Bos.OS.Cmd.status) | `Msg(string)],
+  );
+
+let runOut:
+  Bos.Cmd.t =>
+  result(
+    string,
+    [> | `CommandError(Bos.Cmd.t, Bos.OS.Cmd.status) | `Msg(string)],
+  );

--- a/esy-lib/EsyBash.rei
+++ b/esy-lib/EsyBash.rei
@@ -1,37 +1,13 @@
-let getMingwRuntimePath:
-  unit =>
-  result(
-    Path.t,
-    [> | `CommandError(Bos.Cmd.t, Bos.OS.Cmd.status) | `Msg(string)],
-  );
+let getMingwRuntimePath: unit => Path.t;
+let getBinPath: unit => Path.t;
 
-let getBinPath:
-  unit =>
-  result(
-    Path.t,
-    [> | `CommandError(Bos.Cmd.t, Bos.OS.Cmd.status) | `Msg(string)],
-  );
-
-let toEsyBashCommand:
-  (~env: option(string)=?, Bos.Cmd.t) =>
-  result(
-    Bos.Cmd.t,
-    [> | `CommandError(Bos.Cmd.t, Bos.OS.Cmd.status) | `Msg(string)],
-  );
+let toEsyBashCommand: (~env: option(string)=?, Bos.Cmd.t) => Bos.Cmd.t;
 
 let normalizePathForCygwin: string => string;
 let normalizePathForWindows: Path.t => Path.t;
 
-let run:
-  Bos.Cmd.t =>
-  result(
-    unit,
-    [> | `CommandError(Bos.Cmd.t, Bos.OS.Cmd.status) | `Msg(string)],
-  );
+type error = [ | `CommandError(Bos.Cmd.t, Bos.OS.Cmd.status) | `Msg(string)];
 
-let runOut:
-  Bos.Cmd.t =>
-  result(
-    string,
-    [> | `CommandError(Bos.Cmd.t, Bos.OS.Cmd.status) | `Msg(string)],
-  );
+let run: Bos.Cmd.t => result(unit, [> error]);
+
+let runOut: Bos.Cmd.t => result(string, [> error]);

--- a/esy-lib/EsyBash.rei
+++ b/esy-lib/EsyBash.rei
@@ -1,14 +1,14 @@
 let getMingwRuntimePath:
   unit =>
   result(
-    Fpath.t,
+    Path.t,
     [> | `CommandError(Bos.Cmd.t, Bos.OS.Cmd.status) | `Msg(string)],
   );
 
 let getBinPath:
   unit =>
   result(
-    Fpath.t,
+    Path.t,
     [> | `CommandError(Bos.Cmd.t, Bos.OS.Cmd.status) | `Msg(string)],
   );
 
@@ -19,19 +19,8 @@ let toEsyBashCommand:
     [> | `CommandError(Bos.Cmd.t, Bos.OS.Cmd.status) | `Msg(string)],
   );
 
-let normalizePathForCygwin:
-  string =>
-  result(
-    string,
-    [> | `CommandError(Bos.Cmd.t, Bos.OS.Cmd.status) | `Msg(string)],
-  );
-
-let normalizePathForWindows:
-  Fpath.t =>
-  result(
-    Fpath.t,
-    [> | `CommandError(Bos.Cmd.t, Bos.OS.Cmd.status) | `Msg(string)],
-  );
+let normalizePathForCygwin: string => string;
+let normalizePathForWindows: Path.t => Path.t;
 
 let run:
   Bos.Cmd.t =>

--- a/esy-lib/EsyBashLwt.re
+++ b/esy-lib/EsyBashLwt.re
@@ -1,57 +1,29 @@
-let toRunAsyncCommand = cmd => {
-  let resolvedCommand = EsyBash.toEsyBashCommand(Cmd.toBosCmd(cmd));
-  switch (resolvedCommand) {
-  | Ok(v) => RunAsync.return(Cmd.ofBosCmd(v))
-  | Error(`Msg(line)) => RunAsync.error(line)
-  | _ => RunAsync.error("unknown error")
-  };
-};
-
-let getMingwRuntimePath = () => {
-  let runtimePath = EsyBash.getMingwRuntimePath();
-  switch (runtimePath) {
-  | Ok(v) => RunAsync.return(v)
-  | _ => RunAsync.error("Error locating mingw runtime path.")
-  };
-};
-
 let getMingwEnvironmentOverride = () =>
-  RunAsync.Syntax.(
-    switch (System.Platform.host) {
-    | Windows =>
-      let currentPath = Sys.getenv("PATH");
-      let%bind mingwRuntime = getMingwRuntimePath();
-      return(
-        ChildProcess.CurrentEnvOverride(
-          Astring.String.Map.(
-            add(
-              "PATH",
-              Fpath.to_string(mingwRuntime) ++ ";" ++ currentPath,
-              empty,
-            )
-          ),
-        ),
-      );
-    | _ => return(ChildProcess.CurrentEnv)
-    }
-  );
+  switch (System.Platform.host) {
+  | Windows =>
+    let currentPath = Sys.getenv("PATH");
+    let path = Path.show(EsyBash.getMingwRuntimePath()) ++ ";" ++ currentPath;
+    ChildProcess.CurrentEnvOverride(
+      Astring.String.Map.(add("PATH", path, empty)),
+    );
+  | _ => ChildProcess.CurrentEnv
+  };
+
+let toRunAsyncCommand = cmd =>
+  switch (Cmd.ofBosCmd(EsyBash.toEsyBashCommand(Cmd.toBosCmd(cmd)))) {
+  | Ok(cmd) => cmd
+  | Error(`Msg(msg)) =>
+    /* We just fail here assuming `EsyBash.toEsyBashCommand behave correctly.
+     * Otherwise we can't recover. */
+    Exn.fail(msg)
+  };
 
 /**
  * Helper utility to run a command with 'esy-bash', via Lwt.
  * This is meant to replace Lwt's with_process_full in the case
  * of executing bash commands */
-let with_process_full = (~env=?, cmd, f) =>
-  RunAsync.Syntax.(
-    {
-      let%bind res = toRunAsyncCommand(cmd);
-      switch (res) {
-      | Ok(v) =>
-        let tl = Cmd.getToolAndLine(v);
-        switch env {
-        | Some(env) => Lwt_process.with_process_full(~env, tl, f);
-        | None => Lwt_process.with_process_full(tl, f);
-        }
-      | _ => RunAsync.error("error running command: " ++ Cmd.show(cmd))
-      };
-    }
-  );
+let with_process_full = (~env=?, cmd, f) => {
+  let cmd = toRunAsyncCommand(cmd);
+  let tl = Cmd.getToolAndLine(cmd);
+  Lwt_process.with_process_full(~env?, tl, f);
+};

--- a/esy-lib/Git.ml
+++ b/esy-lib/Git.ml
@@ -107,7 +107,7 @@ module ShallowClone = struct
 
         let%bind remoteCommit = lsRemote ~ref:branch ~remote:source ()
         and localCommit =
-          let remote = Path.show dst in
+          let remote = EsyBash.normalizePathForCygwin (Path.show dst) in
           lsRemote ~remote () in
 
         if remoteCommit = localCommit

--- a/esy-lib/Git.ml
+++ b/esy-lib/Git.ml
@@ -29,7 +29,7 @@ let clone ?branch ?depth ~dst ~remote () =
   let%bind cmd = RunAsync.ofBosError (
     let open Cmd in
     let open Result.Syntax in
-    let%bind dest = EsyBash.normalizePathForCygwin (Path.show dst) in
+    let dest = EsyBash.normalizePathForCygwin (Path.show dst) in
     let cmd = v "git" % "clone" in
     let cmd = match branch with
       | Some branch -> cmd % "--branch" % branch
@@ -106,7 +106,9 @@ module ShallowClone = struct
       if%bind Fs.exists dst then
 
         let%bind remoteCommit = lsRemote ~ref:branch ~remote:source ()
-        and localCommit = lsRemote ~remote:(Path.show dst) () in
+        and localCommit =
+          let remote = Path.show dst in
+          lsRemote ~remote () in
 
         if remoteCommit = localCommit
         then return ()

--- a/esy-lib/Tarball.ml
+++ b/esy-lib/Tarball.ml
@@ -48,8 +48,8 @@ let unpackWithTar ?stripComponents ~dst filename =
   let unpack out = 
     let%bind cmd = RunAsync.ofBosError (
       let open Result.Syntax in
-      let%bind nf = EsyBash.normalizePathForCygwin (Path.show filename) in
-      let%bind normalizedOut = EsyBash.normalizePathForCygwin (Path.show out) in
+      let nf = EsyBash.normalizePathForCygwin (Path.show filename) in
+      let normalizedOut = EsyBash.normalizePathForCygwin (Path.show out) in
       return Cmd.(v "tar" % "xf" % nf % "-C" % normalizedOut)
     )
     in
@@ -86,8 +86,8 @@ let unpack ?stripComponents ~dst filename =
 let create ~filename ?outpath:(outpath=".") src =
   RunAsync.ofBosError (
     let open Result.Syntax in
-    let%bind nf = EsyBash.normalizePathForCygwin (Path.show filename) in
-    let%bind ns = EsyBash.normalizePathForCygwin (Path.show src) in
+    let nf = EsyBash.normalizePathForCygwin (Path.show filename) in
+    let ns = EsyBash.normalizePathForCygwin (Path.show src) in
     let cmd = Cmd.(v "tar" % "czf" % nf % "-C" % ns % outpath) in
     let%bind res = EsyBash.run (Cmd.toBosCmd cmd) in
     return res

--- a/esy/NpmRelease.ml
+++ b/esy/NpmRelease.ml
@@ -232,7 +232,7 @@ let make
           match System.Platform.host with
           | Windows ->
             let currentPath = Sys.getenv("PATH") in
-            let%bind userPath = RunAsync.ofBosError (EsyBash.getBinPath ()) in
+            let userPath = EsyBash.getBinPath () in
             let normalizedOcamlPath = ocamlopt |> Path.parent |> Path.showNormalized in
             let override =
               let sep = System.Environment.sep () in

--- a/esyi/Solver.ml
+++ b/esyi/Solver.ml
@@ -421,7 +421,7 @@ let solveDependencies ~root ~installed ~strategy dependencies solver =
     ) in
 
     try%lwt
-      let%bind env = EsyLib.EsyBashLwt.getMingwEnvironmentOverride () in
+      let env = EsyLib.EsyBashLwt.getMingwEnvironmentOverride () in
       ChildProcess.run ~env cmd
     with
     | Unix.Unix_error (err, _, _) ->

--- a/test/Curl.ml
+++ b/test/Curl.ml
@@ -22,16 +22,13 @@ let%test "curl download simple file" =
             (* This won't impact HTTP requests though - just our test using the local file system *)
             let url = EsyBash.normalizePathForCygwin (Path.show(fileToCurl)) in
 
-            match url with
-            | Error _ -> Lwt.return false
-            | Ok v ->
-                let%lwt _ = EsyLib.Curl.download ~output ("file://" ^ v) in
+            let%lwt _: unit EsyLib.Run.t = EsyLib.Curl.download ~output ("file://" ^ url) in
 
-                (* validate we were able to download it *) 
-                let%lwt result = Fs.exists (output) in
-                match result with
-                | Ok true -> Lwt.return true
-                | _ -> Lwt.return false
+            (* validate we were able to download it *) 
+            let%lwt result = Fs.exists (output) in
+            match result with
+            | Ok true -> Lwt.return true
+            | _ -> Lwt.return false
         in
         Fs.withTempDir f
     in


### PR DESCRIPTION
- Make sure we preprare paths for cygwin when updating git clones under windows.

  As we execute `git` via cygwin we need to make sure we pass appropriate paths
  there.

- Simplify EsyBash/EsyBashLwt API not to use result.

  We can't really recover from such errors and thus we failwith on them hard.