### PR TITLE
Normalize env variables case under Windows

### DIFF
--- a/esy-build-package/Build.re
+++ b/esy-build-package/Build.re
@@ -378,18 +378,15 @@ let commitBuildToStore = (config: Config.t, build: build) => {
       Path.(build.stagePath / "_esy" / "storePrefix"),
     );
   let%bind () = {
-    let p = EsyBash.getMingwRuntimePath();
-    let%bind env = {
-      let%bind current = Bos.OS.Env.current();
-      let env =
-        Astring.String.Map.(
-          add(
-            "PATH",
-            Fpath.to_string(p) ++ ";" ++ Sys.getenv("PATH"),
-            current,
-          )
-        );
-      return(env);
+    let env = {
+      let current = System.Environment.current;
+      switch (System.Platform.host) {
+      | System.Platform.Windows =>
+        let mingw = EsyBash.getMingwRuntimePath();
+        let path = [Path.show(mingw), ...System.Environment.path];
+        EsyLib.StringMap.add("PATH", System.Environment.join(path), current);
+      | _ => current
+      };
     };
     let%bind cmd =
       EsyLib.NodeResolution.resolve("./esyRewritePrefixCommand.exe");

--- a/esy-lib/ChildProcess.ml
+++ b/esy-lib/ChildProcess.ml
@@ -14,32 +14,6 @@ let pp_env fmt env =
   | CustomEnv env ->
     Fmt.pf fmt "CustomEnv %a" (Astring.String.Map.pp Fmt.(pair string string)) env
 
-let currentEnv =
-  let parse item =
-    let idx = String.index item '=' in
-    let name = String.sub item 0 idx in
-    let value = String.sub item (idx + 1) (String.length item - idx - 1) in
-    name, value
-  in
-  (* Filter bash function which are being exported in env *)
-  let filter (name, _value) =
-    let starting = "BASH_FUNC_" in
-    let ending = "%%" in
-    not (
-      String.length name > String.length starting
-      && Str.first_chars name (String.length starting) = starting
-      && Str.last_chars name (String.length ending) = ending
-    )
-  in
-  let build env (name, value) =
-    if filter (name, value)
-    then StringMap.add name value env
-    else env
-  in
-  Unix.environment ()
-  |> Array.map parse
-  |> Array.fold_left build StringMap.empty
-
 let resolveCmdInEnv ~env prg =
   let path =
     let v = match StringMap.find_opt "PATH" env with
@@ -57,7 +31,7 @@ let prepareEnv env =
         Astring.String.Map.fold
           Astring.String.Map.add
           env
-          currentEnv
+          System.Environment.current
       in
       Some env
     | CustomEnv env -> Some env
@@ -135,7 +109,7 @@ let runOut ?(env=CurrentEnv) ?(resolveProgramInEnv=false) ?stdin ?stderr cmd =
         Astring.String.Map.fold
           Astring.String.Map.add
           env
-          currentEnv
+          System.Environment.current
       in
       Some env
     | CustomEnv env -> Some env

--- a/esy-lib/ChildProcess.mli
+++ b/esy-lib/ChildProcess.mli
@@ -9,7 +9,6 @@ type env =
 
 val pp_env : env Fmt.t
 
-val currentEnv : string Astring.String.Map.t
 val prepareEnv : env -> (string StringMap.t * string array) option
 
 (** Run command. *)

--- a/esy-lib/Environment.ml
+++ b/esy-lib/Environment.ml
@@ -250,6 +250,11 @@ let current =
   let parseEnv item =
     let idx = String.index item '=' in
     let name = String.sub item 0 idx in
+    let name =
+      match System.Platform.host with
+      | System.Platform.Windows -> String.uppercase_ascii name
+      | _ -> name
+    in
     let value = String.sub item (idx + 1) (String.length item - idx - 1) in
     {Binding. name; value = ExpandedValue value; origin = None;}
   in

--- a/esy-lib/System.ml
+++ b/esy-lib/System.ml
@@ -91,10 +91,23 @@ module Environment = struct
     | _, (Linux | Darwin | Unix | Unknown | Cygwin) -> ":"
     | _, Windows -> ";"
 
+  let split ?platform ?name value =
+    let sep = sep ?platform ?name () in
+    String.split_on_char sep.[0] value
+
+  let join ?platform ?name value =
+    let sep = sep ?platform ?name () in
+    String.concat sep value
+
   let current =
     let f map item =
       let idx = String.index item '=' in
       let name = String.sub item 0 idx in
+      let name =
+        match Platform.host with
+        | Platform.Windows -> String.uppercase_ascii name
+        | _ -> name
+      in
       let value = String.sub item (idx + 1) (String.length item - idx - 1) in
       StringMap.add name value map
     in
@@ -102,9 +115,9 @@ module Environment = struct
     Array.fold_left f StringMap.empty items
 
   let path =
-    let sep = sep () in
-    match StringMap.find_opt "PATH" current with
-    | Some path -> String.split_on_char sep.[0] path
+    let name = "PATH" in
+    match StringMap.find_opt name current with
+    | Some path -> split ~name path
     | None -> []
 
   let normalizeNewLines s =

--- a/esy-lib/System.mli
+++ b/esy-lib/System.mli
@@ -32,6 +32,15 @@ module Environment : sig
   (** Environment variable separator which is used for $PATH and etc *)
   val sep : ?platform:Platform.t -> ?name:string -> unit -> string
 
+  (** Split environment variable value in a cross platform way. *)
+  val split : ?platform:Platform.t -> ?name:string -> string -> string list
+
+  (** Join environment variable value in a cross plartform way. *)
+  val join : ?platform:Platform.t -> ?name:string -> string list -> string
+
+  (** Current environment. *)
+  val current : string StringMap.t
+
   (** Value of $PATH environment variable. *)
   val path : string list
 


### PR DESCRIPTION
On Windows env variable names are case insensitive (what a surprise!) we
normalize them to uppercase in both:

- `Environment.current` - "env as bindings" repr
- `System.Environment.current` - "env as map" repr

Also make sure we use `System.Environment.current` in `ChildProcess`.

Also need to fix the use of `Unix.environment` in `NpmRelease`, logged #591 for that.