### PR TITLE
[WIP] Fix EACCESS on install

### DIFF
--- a/esy-lib/Fs.ml
+++ b/esy-lib/Fs.ml
@@ -7,40 +7,33 @@ let toRunAsync ?(desc="I/O failed") promise =
     let msg = Unix.error_message err in
     error (Printf.sprintf "%s: %s" desc msg)
 
+let readFile_windows path =
+  let fd = Unix.openfile path Unix.[O_RDONLY] 0o777 in
+  let ic = Unix.in_channel_of_descr fd in
+  let n = in_channel_length ic in
+  let s = really_input_string ic n in
+  Unix.close fd;
+  Lwt.return s
+
+let readFile_posix path =
+  let f ic = Lwt_io.read ic in
+  Lwt_io.with_file ~mode:Lwt_io.Input path f
+
 let readFile (path : Path.t) =
   let path = Path.show path in
   let desc = Printf.sprintf "Unable to read file %s" path in
-  let flags = match System.Platform.host with
-      | Windows -> Unix.[O_RDONLY]
-      | _ -> Unix.[O_RDONLY; O_NONBLOCK]
-  in
   toRunAsync ~desc (fun () -> 
-      let%lwt fd = Lwt_unix.openfile path flags 0o777 in
-      let%lwt () = Lwt_unix.wait_read fd in
-      let ic = Lwt_io.of_fd ~mode:Lwt_io.Input fd in
-      let%lwt s = Lwt_io.read ic in
-      let%lwt () = Lwt_unix.close fd in
-      Lwt.return s
+      match System.Platform.host with
+      | Windows -> readFile_windows path
+      | _ -> readFile_posix path
   )
 
 let writeFile ?perm ~data (path : Path.t) =
   let path = Path.show path in
   let desc = Printf.sprintf "Unable to write file %s" path in
-  let perm = match perm with
-      | Some x -> x
-      | _ -> 0o666
-  in
-  let flags = match System.Platform.host with
-      | Windows -> Unix.[O_WRONLY; O_CREAT; O_TRUNC]
-      | _ -> Unix.[O_WRONLY; O_CREAT; O_TRUNC; O_NONBLOCK]
-  in
   toRunAsync ~desc (fun () ->
-    let%lwt fd = Lwt_unix.openfile path flags perm in
-    let%lwt () = Lwt_unix.wait_write fd in
-    let oc = Lwt_io.of_fd ~mode:Lwt_io.Output fd in
-    let%lwt () = Lwt_io.write oc data in
-    let%lwt () = Lwt_io.flush oc in
-    Lwt_unix.close fd
+    let f oc = Lwt_io.write oc data in
+    Lwt_io.with_file ?perm ~mode:Lwt_io.Output path f
   )
 
 let openFile ~mode ~perm path =

--- a/test/Fs.ml
+++ b/test/Fs.ml
@@ -72,8 +72,8 @@ let%test "read/write file" =
     let test () =
         let f tempPath =
             let src = Path.(tempPath / "test.txt") in
-            let data1: string = "test-file-contents1" in
-            let data2: string = "test-file-contents2" in
+            let data1: string = "test-file-contents1\ntest1" in
+            let data2: string = "test-file-contents2\ntest2" in
 
             let%lwt _ = Fs.writeFile ~data:data1 src in
             let%lwt out1 = Fs.readFile src in


### PR DESCRIPTION
__Issue:__ We were seeing sporadic, intermittent `EACCESS` failures when renaming a `source` directory from the staging path to the install path.

Example error:
```
Info fetching: done
.... installing @opam/conf-m4@opam:1esy: internal error, uncaught exception:
     Unix.Unix_error(Unix.EACCES, "rename", "C:\\Users\\bryph\\.esy\\source\\s\\esy_ocaml__s__esy_installer-a6f22bd59ae8e31a9aa79eb3b966f1d8")
```

After some debugging, @andreypopp found that the code that reads the `package.json` file seemed to be holding a file handle, which was causing the `rename` operation to fail.

It seems that there is some issues with `Lwt_io.with_file` and the `O_NONBLOCK` flag on Windows - this is tracked and described here: https://github.com/ocsigen/lwt/issues/574 . 

Proposed workaround: We'll fall back to using the [synchronous] file I/O operations on Windows, for now. This is not ideal for performance, but allows us to unblock Windows in this step.

I believe there is still a way to get `Lwt` to work, but we'd need to drop to some lower primitives.
