### PR TITLE
Remove OCAMLFIND_COMMANDS from build env

### DIFF
--- a/esy/Scope.ml
+++ b/esy/Scope.ml
@@ -230,7 +230,6 @@ end = struct
         "cur__etc", (p SandboxPath.(installPath / "etc"));
         "OCAMLFIND_DESTDIR", (p SandboxPath.(installPath / "lib"));
         "OCAMLFIND_LDCONF", "ignore";
-        "OCAMLFIND_COMMANDS", "ocamlc=ocamlc.opt ocamldep=ocamldep.opt ocamldoc=ocamldoc.opt ocamllex=ocamllex.opt ocamlopt=ocamlopt.opt";
       ]
     in
 

--- a/test-e2e/common/build-env.test.js
+++ b/test-e2e/common/build-env.test.js
@@ -65,7 +65,6 @@ describe('esy build-env', () => {
     expect(env.OCAMLPATH).toBeTruthy();
     expect(env.OCAMLFIND_LDCONF).toBeTruthy();
     expect(env.OCAMLFIND_DESTDIR).toBeTruthy();
-    expect(env.OCAMLFIND_COMMANDS).toBeTruthy();
     expect(env.MAN_PATH).toBeTruthy();
     expect(env.CAML_LD_LIBRARY_PATH).toBeTruthy();
 

--- a/test-e2e/common/command-env.test.js
+++ b/test-e2e/common/command-env.test.js
@@ -63,7 +63,6 @@ describe('esy command-env', () => {
     expect(env.OCAMLPATH).toBeTruthy();
     expect(env.OCAMLFIND_LDCONF).toBeTruthy();
     expect(env.OCAMLFIND_DESTDIR).toBeTruthy();
-    expect(env.OCAMLFIND_COMMANDS).toBeTruthy();
     expect(env.MAN_PATH).toBeTruthy();
     expect(env.CAML_LD_LIBRARY_PATH).toBeTruthy();
 


### PR DESCRIPTION
It was added long ago and I'm not sure why.

By default `bin/ocaml*` are symlinked to `bin/ocaml*.opt` if native toolchain is installed so I don't think we need it now.

Also on Windows there's a warning related to this env variable, see #594.