### PR TITLE
FetchStorage: smarter check for lifecycle presence

### DIFF
--- a/esyi/FetchStorage.ml
+++ b/esyi/FetchStorage.ml
@@ -134,7 +134,10 @@ end = struct
       (StringMap.fold f cmds [])
     | Bin.Empty, _ -> []
 
-  let lifecycle pkgJson = pkgJson.scripts
+  let lifecycle pkgJson =
+    match pkgJson.scripts with
+    | Some {Lifecycle. postinstall = None; install = None;} -> None
+    | lifecycle -> lifecycle
 
 end
 


### PR DESCRIPTION
If we don't have neither `postinstall` nor `install` scripts defined we just return `None` in a "getter".