### PR TITLE
[WIP] Generate command-exec.bat

### DIFF
--- a/esy-command-expression/EsyCommandExpression.mli
+++ b/esy-command-expression/EsyCommandExpression.mli
@@ -57,7 +57,7 @@ type scope = string option * string -> Value.t option
 
 (** Render command expression into a string given the [scope]. *)
 val render :
-  ?pathSep:string
+  ?platform:System.Platform.t
   -> ?colon:string
   -> scope:scope
   -> string

--- a/esy-command-expression/dune
+++ b/esy-command-expression/dune
@@ -1,5 +1,6 @@
 (library
   (name EsyCommandExpression)
+  (inline_tests)
   (preprocess (pps ppx_inline_test lwt_ppx ppx_let ppx_deriving_yojson ppx_deriving.std))
   (flags (:standard (-w -39) "-open" "EsyLib"))
   (libraries EsyLib)

--- a/esy-lib/Environment.ml
+++ b/esy-lib/Environment.ml
@@ -191,10 +191,9 @@ let escapeSingleQuote value =
   Str.global_replace re "''" value
 
 let renderToShellSource
-    ?(header="# Environment")
+    ?(header="Environment")
     ?(platform=System.Platform.host)
     (bindings : string Binding.t list) =
-  let open Run.Syntax in
   let emptyLines = function
     | [] -> true
     | _ -> false
@@ -208,29 +207,29 @@ let renderToShellSource
     else
       lines
     in
-    let%bind line = match value with
+    let line = match value with
     | Value value ->
       let value = escapeDoubleQuote value in
-      Ok (Printf.sprintf "export %s=\"%s\"" name value)
+      Printf.sprintf "export %s=\"%s\"" name value
     | ExpandedValue value ->
       let value = escapeSingleQuote value in
-      Ok (Printf.sprintf "export %s=\'%s\'" name value)
+      Printf.sprintf "export %s=\'%s\'" name value
     | Prefix value ->
       let sep = System.Environment.sep ~platform ~name () in
       let value = escapeDoubleQuote value in
-      Ok (Printf.sprintf "export %s=\"%s%s$%s\"" name value sep name)
+      Printf.sprintf "export %s=\"%s%s$%s\"" name value sep name
     | Suffix value ->
       let sep = System.Environment.sep ~platform ~name () in
       let value = escapeDoubleQuote value in
-      Ok (Printf.sprintf "export %s=\"$%s%s%s\"" name name sep value)
+      Printf.sprintf "export %s=\"$%s%s%s\"" name name sep value
     in
-    Ok (line::lines, origin)
+    line::lines, origin
   in
-  let%bind lines, _ = Run.List.foldLeft ~f ~init:([], None) bindings in
-  return (header ^ "\n" ^ (lines |> List.rev |> String.concat "\n"))
+  let lines, _ = List.fold_left ~f ~init:([], None) bindings in
+  "# " ^ header ^ "\n" ^ (lines |> List.rev |> String.concat "\n")
 
 let renderToBatchSource
-    ?(header=":: Environment")
+    ?(header="Environment")
     ?(platform=System.Platform.host)
     (bindings : string Binding.t list) =
   let emptyLines = function
@@ -265,7 +264,7 @@ let renderToBatchSource
     line::lines, origin
   in
   let lines, _ = List.fold_left ~f ~init:([], None) bindings in
-  header ^ "\n" ^ (lines |> List.rev |> String.concat "\n")
+  ":: " ^ header ^ "\n" ^ (lines |> List.rev |> String.concat "\n")
 
 let renderToList ?(platform=System.Platform.host) bindings =
   let f {Binding.name; value; origin = _} =

--- a/esy-lib/Environment.ml
+++ b/esy-lib/Environment.ml
@@ -42,7 +42,7 @@ module type S = sig
 
     val empty : t
     val render : ctx -> t -> string Binding.t list
-    val eval : ?platform : System.Platform.t -> ?init : env -> t -> (env, string) result
+    val eval : platform : System.Platform.t -> ?init : env -> t -> (env, string) result
     val map : f:(string -> string) -> t -> t
 
     include S.COMPARABLE with type t := t
@@ -124,7 +124,7 @@ end = struct
       in
       List.map ~f bindings
 
-    let eval ?(platform=System.Platform.host) ?(init=StringMap.empty) bindings =
+    let eval ~platform ?(init=StringMap.empty) bindings =
       let open Result.Syntax in
 
       let f env binding =
@@ -138,7 +138,7 @@ end = struct
           let value = V.show value in
           let%bind value =
             match platform with
-            | Windows -> EsyShellExpansion.renderBatch ~scope value
+            | System.Platform.Windows -> EsyShellExpansion.renderBatch ~scope value
             | _ -> EsyShellExpansion.render ~scope value
           in
           let value = V.v value in

--- a/esy-lib/Environment.ml
+++ b/esy-lib/Environment.ml
@@ -264,7 +264,7 @@ let renderToBatchSource
     line::lines, origin
   in
   let lines, _ = List.fold_left ~f ~init:([], None) bindings in
-  ":: " ^ header ^ "\n" ^ (lines |> List.rev |> String.concat "\n")
+  ":: " ^ header ^ "\n" ^ (lines |> List.rev |> String.concat "\r\n")
 
 let renderToList ?(platform=System.Platform.host) bindings =
   let f {Binding.name; value; origin = _} =

--- a/esy-lib/Environment.ml
+++ b/esy-lib/Environment.ml
@@ -240,7 +240,7 @@ let renderToBatchSource
     let lines = if prevOrigin <> origin || emptyLines lines then
       let header = match origin with
       | Some origin -> Printf.sprintf "\n::\n:: %s\n::" origin
-      | None -> "\n::\n:: Built-in\n#"
+      | None -> "\n::\n:: Built-in\n::"
       in header::lines
     else
       lines
@@ -255,16 +255,16 @@ let renderToBatchSource
     | Prefix value ->
       let sep = System.Environment.sep ~platform ~name () in
       let value = escapeDoubleQuote value in
-      Printf.sprintf "@SET %s=\"%s%s$%s\"" name value sep name
+      Printf.sprintf "@SET %s=%s%s%%%s%%" name value sep name
     | Suffix value ->
       let sep = System.Environment.sep ~platform ~name () in
       let value = escapeDoubleQuote value in
-      Printf.sprintf "@SET %s=\"$%s%s%s\"" name name sep value
+      Printf.sprintf "@SET %s=%%%s%%%s%s" name name sep value
     in
     line::lines, origin
   in
   let lines, _ = List.fold_left ~f ~init:([], None) bindings in
-  ":: " ^ header ^ "\n" ^ (lines |> List.rev |> String.concat "\r\n")
+  ":: " ^ header ^ "\n" ^ (lines |> List.rev |> String.concat "\n")
 
 let renderToList ?(platform=System.Platform.host) bindings =
   let f {Binding.name; value; origin = _} =

--- a/esy-lib/Environment.ml
+++ b/esy-lib/Environment.ml
@@ -190,6 +190,10 @@ let escapeSingleQuote value =
   let re = Str.regexp "'" in
   Str.global_replace re "''" value
 
+let escapePercent value =
+  let re = Str.regexp "%" in
+  Str.global_replace re "^%" value
+
 let renderToShellSource
     ?(header="Environment")
     ?(platform=System.Platform.host)
@@ -247,18 +251,15 @@ let renderToBatchSource
     in
     let line = match value with
     | Value value ->
-      let value = escapeDoubleQuote value in
-      Printf.sprintf "@SET %s=\"%s\"" name value
+      Printf.sprintf "@SET %s=%s" name value
     | ExpandedValue value ->
-      let value = escapeSingleQuote value in
-      Printf.sprintf "@SET %s=\'%s\'" name value
+      let value = escapePercent value in
+      Printf.sprintf "@SET %s=%s" name value
     | Prefix value ->
       let sep = System.Environment.sep ~platform ~name () in
-      let value = escapeDoubleQuote value in
       Printf.sprintf "@SET %s=%s%s%%%s%%" name value sep name
     | Suffix value ->
       let sep = System.Environment.sep ~platform ~name () in
-      let value = escapeDoubleQuote value in
       Printf.sprintf "@SET %s=%%%s%%%s%s" name name sep value
     in
     line::lines, origin

--- a/esy-lib/Environment.mli
+++ b/esy-lib/Environment.mli
@@ -58,7 +58,7 @@ val renderToShellSource :
   ?header:string
   -> ?platform : System.Platform.t
   -> Bindings.t
-  -> string Run.t
+  -> string
 (** Render environment bindings as shell export statements. *)
 
 val renderToBatchSource :

--- a/esy-lib/Environment.mli
+++ b/esy-lib/Environment.mli
@@ -39,7 +39,7 @@ module type S = sig
 
     val empty : t
     val render : ctx -> t -> string Binding.t list
-    val eval : ?platform : System.Platform.t -> ?init : env -> t -> (env, string) result
+    val eval : platform : System.Platform.t -> ?init : env -> t -> (env, string) result
     val map : f:(string -> string) -> t -> t
 
     include S.COMPARABLE with type t := t

--- a/esy-lib/Environment.mli
+++ b/esy-lib/Environment.mli
@@ -61,6 +61,13 @@ val renderToShellSource :
   -> string Run.t
 (** Render environment bindings as shell export statements. *)
 
+val renderToBatchSource :
+  ?header:value
+  -> ?platform:System.Platform.t
+  -> Bindings.t
+  -> string
+(** Render environment bindings as batch set statements. *)
+
 val renderToList :
   ?platform : System.Platform.t
   -> Bindings.t

--- a/esy-shell-expansion/BatchLexer.mll
+++ b/esy-shell-expansion/BatchLexer.mll
@@ -11,18 +11,9 @@
 let id          = ['a'-'z' 'A'-'Z' '_'] ['a'-'z' 'A'-'Z' '0'-'9' '_']*
 
 rule read result state = parse
- | '$' (id as id) {
+ | '^' '%'       { read ((String "^%")::result) `Init lexbuf}
+ | '%' (id as id) '%' {
       let item = Var (id, None) in
-      let result = finalizeString result state in
-      read (item::result) `Init lexbuf
-    }
- | '$' '{' (id as id) '}' {
-      let item = Var (id, None) in
-      let result = finalizeString result state in
-      read (item::result) `Init lexbuf
-    }
- | '$' '{' (id as id) ':' '-' ([^ '}' ]+ as default) '}' {
-      let item = Var (id, Some default) in
       let result = finalizeString result state in
       read (item::result) `Init lexbuf
     }

--- a/esy-shell-expansion/EsyShellExpansion.ml
+++ b/esy-shell-expansion/EsyShellExpansion.ml
@@ -47,7 +47,7 @@ let render' ~(scope : scope) parseExn v =
       begin match scope name, default with
       | Some v, _
       | None, Some v -> renderTokens (v::segments) restTokens
-      | _, _ -> Error ("unable to resolve: $" ^ name)
+      | None, None -> renderTokens segments restTokens
       end
   in
 

--- a/esy-shell-expansion/EsyShellExpansion.mli
+++ b/esy-shell-expansion/EsyShellExpansion.mli
@@ -15,8 +15,13 @@
 type scope = string -> string option
 
 val render :
-  ?fallback:string option
-  -> scope:scope
+  scope:scope
   -> string
   -> (string, string) result
 (** Render string by expanding all shell parameters found. *)
+
+val renderBatch :
+  scope:scope
+  -> string
+  -> (string, string) result
+(** Render string by expanding all batch parameters found. *)

--- a/esy-shell-expansion/dune
+++ b/esy-shell-expansion/dune
@@ -1,9 +1,10 @@
 (library
   (name EsyShellExpansion)
+  (inline_tests)
   (preprocess (pps ppx_inline_test ppx_let ppx_deriving.std))
   (flags (:standard (-w -39)))
   (libraries ppx_deriving.std)
 )
 
-(ocamllex (modules Lexer))
+(ocamllex (modules Lexer BatchLexer))
 

--- a/esy/NpmRelease.ml
+++ b/esy/NpmRelease.ml
@@ -208,7 +208,7 @@ let make
     (* Emit wrappers for released binaries *)
     let%bind () =
       let bindings = Scope.SandboxEnvironment.Bindings.render cfg.buildCfg bindings in
-      let%bind env = RunAsync.ofStringError (Environment.Bindings.eval bindings) in
+      let%bind env = RunAsync.ofStringError (Environment.Bindings.eval ~platform:System.Platform.host bindings) in
 
       let generateBinaryWrapper stagePath name =
         let resolveBinInEnv ~env prg =

--- a/esy/Plan.ml
+++ b/esy/Plan.ml
@@ -419,7 +419,8 @@ let make'
     let%bind buildEnv =
       let%bind bindings = Scope.env ~includeBuildEnv:true buildScope in
       Run.context
-        (Run.ofStringError (Scope.SandboxEnvironment.Bindings.eval bindings))
+        (Run.ofStringError (
+          Scope.SandboxEnvironment.Bindings.eval ~platform:System.Platform.host bindings))
         "evaluating environment"
     in
 

--- a/esy/Scope.ml
+++ b/esy/Scope.ml
@@ -287,7 +287,7 @@ let make
     finalEnv = (
       let defaultPath =
           match platform with
-          | Windows -> "$PATH;/usr/local/bin;/usr/bin;/bin;/usr/sbin;/sbin"
+          | Windows -> "%PATH%;/usr/local/bin;/usr/bin;/bin;/usr/sbin;/sbin"
           | _ -> "$PATH:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
       in
       SandboxEnvironment.[
@@ -327,15 +327,6 @@ let exposeUserEnvWith makeBinding name scope =
   {scope with finalEnv}
 
 let renderCommandExpr ?environmentVariableName scope expr =
-  let pathSep =
-    match scope.platform with
-    | System.Platform.Unknown
-    | System.Platform.Darwin
-    | System.Platform.Linux
-    | System.Platform.Unix
-    | System.Platform.Windows
-    | System.Platform.Cygwin -> "/"
-  in
   let envSep =
     System.Environment.sep ~platform:scope.platform ?name:environmentVariableName ()
   in
@@ -355,7 +346,13 @@ let renderCommandExpr ?environmentVariableName scope expr =
     | None, "os" -> Some (EsyCommandExpression.string (System.Platform.show scope.platform))
     | None, _ -> None
   in
-  Run.ofStringError (EsyCommandExpression.render ~pathSep ~colon:envSep ~scope:lookup expr)
+  Run.ofStringError (
+    EsyCommandExpression.render
+      ~platform:scope.platform
+      ~colon:envSep
+      ~scope:lookup
+      expr
+  )
 
 let makeEnvBindings bindings scope =
   let open Run.Syntax in

--- a/esy/bin/esyCommand.ml
+++ b/esy/bin/esyCommand.ml
@@ -340,7 +340,7 @@ module SandboxInfo = struct
             let commandExec, commandExecFilename =
               match System.Platform.host with
               | Windows ->
-                "@ECHO off\r\n@SETLOCAL\r\n" ^ commandEnv ^ "\r\n%*", "command-exec.bat"
+                "@ECHO off\n@SETLOCAL\n" ^ commandEnv ^ "\n\n%*", "command-exec.bat"
               | _ -> "#!/bin/bash\n" ^ commandEnv ^ "\nexec \"$@\"", "command-exec"
             in
             let%bind () =

--- a/esy/bin/esyCommand.ml
+++ b/esy/bin/esyCommand.ml
@@ -782,7 +782,7 @@ let makeEnvCommand ~computeEnv ~header copts asJson packagePath () =
       let header = header task in
       if asJson
       then
-        let%bind env = Run.ofStringError (Environment.Bindings.eval env) in
+        let%bind env = Run.ofStringError (Environment.Bindings.eval ~platform:System.Platform.host env) in
         return (
           env
           |> Environment.to_yojson
@@ -877,7 +877,7 @@ let makeExecCommand
       env
     in
     let env = Environment.current @ env in
-    let%bind env = Environment.Bindings.eval env in
+    let%bind env = Environment.Bindings.eval ~platform:System.Platform.host env in
     return (ChildProcess.CustomEnv env)
   ) in
 


### PR DESCRIPTION
rel #586

It works from the `cmd.exe`:
```
C:\Users\IEUser\hello-ocaml>node_modules\.cache\_esy\build\bin\command-exec.bat ocamlmerlin-server -help
Usage: ocamlmerlin-server <frontend> <arguments...>
Select the merlin frontend to execute. Valid values are:

- 'old-protocol' executes the merlin frontend from previous version.
  It is a top level reading and writing commands in a JSON form.

- 'single' is a simpler frontend that reads input from stdin,
  processes a single query and outputs result on stdout.

- 'server' works like 'single', but uses a background process to
  speedup processing.
If no frontend is specified, it defaults to 'old-protocol' for
compatibility with existing editors.
```

But VS Code OCaml extension doesn't seem to work, though it doesn't fail either!

I don't think we need `command-env.bat` do we? Instead we should generate batch scripts as output for `command-env` / command.