### PR TITLE
Read opam files from lock using absolute paths

### DIFF
--- a/esyi/OpamResolution.mli
+++ b/esyi/OpamResolution.mli
@@ -4,7 +4,14 @@ type t = {
   path : Path.t;
 }
 
-val lock : sandbox:SandboxSpec.t -> t -> t RunAsync.t
+module Lock : sig
+  type t
+
+  include S.JSONABLE with type t := t
+end
+
+val toLock : sandbox:SandboxSpec.t -> t -> Lock.t RunAsync.t
+val ofLock : sandbox:SandboxSpec.t -> Lock.t -> t RunAsync.t
 
 include S.JSONABLE with type t := t
 


### PR DESCRIPTION
When we load lock from `esy.lock` dir we now join paths to sandbox's path thus we make those absolute paths.

For some reason slowtests were failing on Linux when reading opam files using relative path. This seem to fix it but I still don't understand why - there's no code which does `chdir`.

Using absolute paths is still preferable so we are going to do it and keep an eye on future Linux failures.