### PR TITLE
CI: Increase slowtest time

### DIFF
--- a/test-e2e-slow/build-top-100-opam.test.js
+++ b/test-e2e-slow/build-top-100-opam.test.js
@@ -156,7 +156,7 @@ function selectCases(array) {
 }
 
 const startTime = new Date();
-const runtimeLimit = 17 * 60 * 1000;
+const runtimeLimit = 60 * 60 * 1000;
 
 setup();
 


### PR DESCRIPTION
We currently cap our slowtest time (specifically, the top 100 tests) to ~17 minutes to give all the other tests time to complete. On Windows, that doesn't really give us much time to test - the ocaml compiler takes >10 minutes to build. 

This change bumps this time up - we no longer are constrained by the 60 minute time limit since Azure CI actually has a 360 minute time limit with #566 