### PR TITLE
Windows: Fix postinstall for different drives

### DIFF
--- a/esyi/FetchStorage.ml
+++ b/esyi/FetchStorage.ml
@@ -240,9 +240,16 @@ let runLifecycleScript ?env ~lifecycleName pkg sourcePath script =
       | Windows -> Path.show sourcePath
       | _ -> Filename.quote (Path.show sourcePath)
     in
+    (* On Windows, cd by itself won't switch between drives *)
+    (* We'll add the /d flag to allow switching drives - *)
+    let changeDirCommand = match System.Platform.host with
+      | Windows -> "/d"
+      | _ -> ""
+    in
     let script =
       Printf.sprintf
-        "cd %s && %s"
+        "cd %s %s && %s"
+        changeDirCommand
         installationPath
         script
     in


### PR DESCRIPTION
__Issue:__ If your `esy` store and the project you're working on are on different drives (for example, working on `E:/esy` and my store lives in `C:/Users/bryphe/.esy`), the postinstall steps would fail with:
```
info esy-solve-cudf@0.1.10: running postinstall lifecycle
error command failed: node ./postinstall.js
      stderr:
               C:\Users\bryph\.esy\source\i\esy_solve_cudf-48474051a572d13bd2a1f8d0da8571a9\_esy\pnp.js:1118
    throw resolutionError;
    ^

Error: Couldn't find a suitable Node resolution for unqualified path "E:\esy2\postinstall.js"
    at makeError (C:\Users\bryph\.esy\source\i\esy_solve_cudf-48474051a572d13bd2a1f8d0da8571a9\_esy\pnp.js:54:17)
```

__Defect:__ Our wrapper script was running `cd C:/path-to-package-source` while the working directory is `E:/esy`. The `cd` command on Windows, by default, _does not switch drives_.

__Fix:__ we need to pass the `/d` flag on Windows to switch between drives if the working directory/home directory are in different paths.