### PR TITLE
Fix lock checksum to be sensitive to dependencies/devDependencies

### DIFF
--- a/esyi/SolutionLock.ml
+++ b/esyi/SolutionLock.ml
@@ -164,7 +164,9 @@ let computeSandboxChecksum (sandbox : Sandbox.t) =
     |> hashResolutions
       ~resolutions:sandbox.resolutions
     |> hashDependencies
-      ~dependencies:sandbox.dependencies
+      ~dependencies:sandbox.root.dependencies
+    |> hashDependencies
+      ~dependencies:sandbox.root.devDependencies
   in
 
   let%bind digest =


### PR DESCRIPTION
Previously if you move a dep from devDependencies to dependencies
lock checksum didn't detect this but it should because lock encodes
package graph.

The proper fix would be to disentange package graph from constraint
resolutions but this is not what we have today, instead we make checksum
sensitive to dependencies vs. devDependencies.