### PR TITLE
[WIP] Proper parser for yarn lockfile syntax

### DIFF
--- a/esy-yarn-lockfile/EsyYarnLockfile.ml
+++ b/esy-yarn-lockfile/EsyYarnLockfile.ml
@@ -3,6 +3,7 @@
  *)
 
 include Types
+include Printer
 
 let tokenize v =
   let lexbuf = Lexing.from_string v in
@@ -380,5 +381,80 @@ a:
     |};
     [%expect {|
       (Mapping ((a (Sequence ((String a) (String b) (String c)))))) |}]
+
+end)
+
+let%test_module _ = (module struct
+
+  let parsePrint s =
+    match parse s with
+    | Ok s -> Format.printf "%a@." pp s
+    | Error err -> Format.printf "ERROR: %s@." err
+
+  let%expect_test _ =
+    parsePrint {|
+a: 2
+    |};
+    [%expect {| a: 2 |}]
+
+  let%expect_test _ =
+    parsePrint {|
+a: 2
+c: d
+    |};
+    [%expect {|
+      a: 2
+      c: d |}]
+
+  let%expect_test _ =
+    parsePrint {|
+a:
+  c: d
+    |};
+    [%expect {|
+      a:
+        c: d |}]
+
+  let%expect_test _ =
+    parsePrint {|
+a:
+  c: d
+c: d
+    |};
+    [%expect {|
+      a:
+        c: d
+      c: d |}]
+
+  let%expect_test _ =
+    parsePrint {|
+a:
+  c:
+    c: d
+    |};
+    [%expect {|
+      a:
+        c:
+          c: d |}]
+
+  let%expect_test _ =
+    parsePrint {|
+a:
+  1
+  2
+  3
+    |};
+    [%expect {|
+      a:
+        1
+        2
+        3 |}]
+
+  let%expect_test _ =
+    parsePrint {|
+"key with space": "value with space"
+    |};
+    [%expect {|
+      "key with space": "value with space" |}]
 
 end)

--- a/esy-yarn-lockfile/EsyYarnLockfile.ml
+++ b/esy-yarn-lockfile/EsyYarnLockfile.ml
@@ -216,91 +216,91 @@ let%test_module _ = (module struct
 
   let%expect_test "id:true" =
     printAst "id:true";
-    [%expect {| (Mapping ((id (Boolean true)))) |}]
+    [%expect {| (Mapping ((id (Scalar (Boolean true))))) |}]
 
   let%expect_test "id: true" =
     printAst "id: true";
-    [%expect {| (Mapping ((id (Boolean true)))) |}]
+    [%expect {| (Mapping ((id (Scalar (Boolean true))))) |}]
 
   let%expect_test "id :true" =
     printAst "id :true";
-    [%expect {| (Mapping ((id (Boolean true)))) |}]
+    [%expect {| (Mapping ((id (Scalar (Boolean true))))) |}]
 
   let%expect_test " id:true" =
     printAst " id:true";
-    [%expect {| (Mapping ((id (Boolean true)))) |}]
+    [%expect {| (Mapping ((id (Scalar (Boolean true))))) |}]
 
   let%expect_test "id:true " =
     printAst "id:true ";
-    [%expect {| (Mapping ((id (Boolean true)))) |}]
+    [%expect {| (Mapping ((id (Scalar (Boolean true))))) |}]
 
   let%expect_test "id: false" =
     printAst "id: false";
-    [%expect {| (Mapping ((id (Boolean false)))) |}]
+    [%expect {| (Mapping ((id (Scalar (Boolean false))))) |}]
 
   let%expect_test "id: id" =
     printAst "id: id";
-    [%expect {| (Mapping ((id (String id)))) |}]
+    [%expect {| (Mapping ((id (Scalar (String id))))) |}]
 
   let%expect_test "id: string" =
     printAst {|id: "string"|};
-    [%expect {| (Mapping ((id (String string)))) |}]
+    [%expect {| (Mapping ((id (Scalar (String string))))) |}]
 
   let%expect_test "id: 1" =
     printAst "id: 1";
-    [%expect {| (Mapping ((id (Number 1)))) |}]
+    [%expect {| (Mapping ((id (Scalar (Number 1))))) |}]
 
   let%expect_test "id: 1.5" =
     printAst "id: 1.5";
-    [%expect {| (Mapping ((id (Number 1.5)))) |}]
+    [%expect {| (Mapping ((id (Scalar (Number 1.5))))) |}]
 
   let%expect_test "\"string\": ok" =
     printAst "\"string\": ok";
-    [%expect {| (Mapping ((string (String ok)))) |}]
+    [%expect {| (Mapping ((string (Scalar (String ok))))) |}]
 
   let%expect_test "a:b\nc:d" =
     printAst "a:b\nc:d";
-    [%expect {| (Mapping ((a (String b)) (c (String d)))) |}]
+    [%expect {| (Mapping ((a (Scalar (String b))) (c (Scalar (String d))))) |}]
 
   let%expect_test "a:b\n" =
     printAst "a:b\n";
-    [%expect {| (Mapping ((a (String b)))) |}]
+    [%expect {| (Mapping ((a (Scalar (String b))))) |}]
 
   let%expect_test "\na:b" =
     printAst "\na:b";
-    [%expect {| (Mapping ((a (String b)))) |}]
+    [%expect {| (Mapping ((a (Scalar (String b))))) |}]
 
   let%expect_test "esy-store-path: \"/some/path\"" =
     printAst "esy-store-path: \"/some/path\"";
-    [%expect {| (Mapping ((esy-store-path (String /some/path)))) |}]
+    [%expect {| (Mapping ((esy-store-path (Scalar (String /some/path))))) |}]
 
   let%expect_test "esy-store-path: \"./some/path\"" =
     printAst "esy-store-path: \"./some/path\"";
-    [%expect {| (Mapping ((esy-store-path (String ./some/path)))) |}]
+    [%expect {| (Mapping ((esy-store-path (Scalar (String ./some/path))))) |}]
 
   let%expect_test "esy-store-path: ./some/path" =
     printAst "esy-store-path: ./some/path";
-    [%expect {| (Mapping ((esy-store-path (String ./some/path)))) |}]
+    [%expect {| (Mapping ((esy-store-path (Scalar (String ./some/path))))) |}]
 
   let%expect_test _ =
     printAst {|
       a: b
     |};
-    [%expect {| (Mapping ((a (String b)))) |}]
+    [%expect {| (Mapping ((a (Scalar (String b))))) |}]
 
   let%expect_test _ =
     printAst {|
 a: b
 c: d
     |};
-    [%expect {| (Mapping ((a (String b)) (c (String d)))) |}]
+    [%expect {| (Mapping ((a (Scalar (String b))) (c (Scalar (String d))))) |}]
 
   let%expect_test _ =
     printAst {|
 a:
   c: d
     |};
-    [%expect {| (Mapping ((a (Mapping ((c (String d))))))) |}]
+    [%expect {| (Mapping ((a (Mapping ((c (Scalar (String d)))))))) |}]
 
   let%expect_test _ =
     printAst {|
@@ -308,7 +308,7 @@ a:
   c: d
   e: f
     |};
-    [%expect {| (Mapping ((a (Mapping ((c (String d)) (e (String f))))))) |}]
+    [%expect {| (Mapping ((a (Mapping ((c (Scalar (String d))) (e (Scalar (String f)))))))) |}]
 
   let%expect_test _ =
     printAst {|
@@ -316,7 +316,7 @@ a:
   c: d
 e: f
     |};
-    [%expect {| (Mapping ((a (Mapping ((c (String d))))) (e (String f)))) |}]
+    [%expect {| (Mapping ((a (Mapping ((c (Scalar (String d)))))) (e (Scalar (String f))))) |}]
 
   let%expect_test _ =
     printAst {|
@@ -324,7 +324,7 @@ a:
   c:
     e: f
     |};
-    [%expect {| (Mapping ((a (Mapping ((c (Mapping ((e (String f)))))))))) |}]
+    [%expect {| (Mapping ((a (Mapping ((c (Mapping ((e (Scalar (String f))))))))))) |}]
 
   let%expect_test _ =
     printAst {|
@@ -337,7 +337,9 @@ a:
     [%expect {|
       (Mapping
        ((a
-         (Mapping ((c (Mapping ((e (Mapping ((g (String h)))))))) (x (String y))))))) |}]
+         (Mapping
+          ((c (Mapping ((e (Mapping ((g (Scalar (String h)))))))))
+           (x (Scalar (String y)))))))) |}]
 
   let%expect_test _ =
     printAst {|
@@ -349,8 +351,8 @@ x: y
     |};
     [%expect {|
       (Mapping
-       ((a (Mapping ((c (Mapping ((e (Mapping ((g (String h)))))))))))
-        (x (String y)))) |}]
+       ((a (Mapping ((c (Mapping ((e (Mapping ((g (Scalar (String h))))))))))))
+        (x (Scalar (String y))))) |}]
 
   let%expect_test _ =
     printAst {|

--- a/esy-yarn-lockfile/EsyYarnLockfile.mli
+++ b/esy-yarn-lockfile/EsyYarnLockfile.mli
@@ -33,3 +33,16 @@ module Decode : sig
   val mapping : 'a decoder -> (string * 'a) list decoder
   val seq : 'a scalarDecoder -> 'a list decoder
 end
+
+type 'a encoder = 'a -> t
+type 'a scalarEncoder = 'a -> scalar
+
+module Encode : sig
+
+  val string : string scalarEncoder
+  val number : float scalarEncoder
+  val boolean : bool scalarEncoder
+
+  val scalar : 'a scalarEncoder -> 'a encoder
+  val seq : 'a scalarEncoder -> 'a list encoder
+end

--- a/esy-yarn-lockfile/EsyYarnLockfile.mli
+++ b/esy-yarn-lockfile/EsyYarnLockfile.mli
@@ -20,3 +20,13 @@ val parseExn : string -> t
 (** Same as {!val:parse} but raises {!exception:SyntaxError} *)
 
 val pp : t Fmt.t
+
+type 'a decoder = t -> ('a, string) result
+
+module Decode : sig
+  val string : string decoder
+  val number : float decoder
+  val boolean : bool decoder
+  val mapping : 'a decoder -> (string * 'a) list decoder
+  val seq : 'a decoder -> 'a list decoder
+end

--- a/esy-yarn-lockfile/EsyYarnLockfile.mli
+++ b/esy-yarn-lockfile/EsyYarnLockfile.mli
@@ -5,7 +5,7 @@
  *)
 type t =
   | Mapping of (string * t) list
-  | Sequence of scalar list
+  | Sequence of t list
   | Scalar of scalar
 
 and scalar =

--- a/esy-yarn-lockfile/EsyYarnLockfile.mli
+++ b/esy-yarn-lockfile/EsyYarnLockfile.mli
@@ -18,3 +18,5 @@ val parse : string -> (t, string) result
 
 val parseExn : string -> t
 (** Same as {!val:parse} but raises {!exception:SyntaxError} *)
+
+val pp : t Fmt.t

--- a/esy-yarn-lockfile/EsyYarnLockfile.mli
+++ b/esy-yarn-lockfile/EsyYarnLockfile.mli
@@ -5,7 +5,10 @@
  *)
 type t =
   | Mapping of (string * t) list
-  | Sequence of t list
+  | Sequence of scalar list
+  | Scalar of scalar
+
+and scalar =
   | Number of float
   | String of string
   | Boolean of bool

--- a/esy-yarn-lockfile/EsyYarnLockfile.mli
+++ b/esy-yarn-lockfile/EsyYarnLockfile.mli
@@ -5,6 +5,7 @@
  *)
 type t =
   | Mapping of (string * t) list
+  | Sequence of t list
   | Number of float
   | String of string
   | Boolean of bool

--- a/esy-yarn-lockfile/EsyYarnLockfile.mli
+++ b/esy-yarn-lockfile/EsyYarnLockfile.mli
@@ -5,7 +5,7 @@
  *)
 type t =
   | Mapping of (string * t) list
-  | Sequence of t list
+  | Sequence of scalar list
   | Scalar of scalar
 
 and scalar =
@@ -22,11 +22,14 @@ val parseExn : string -> t
 val pp : t Fmt.t
 
 type 'a decoder = t -> ('a, string) result
+type 'a scalarDecoder = scalar -> ('a, string) result
 
 module Decode : sig
-  val string : string decoder
-  val number : float decoder
-  val boolean : bool decoder
+  val string : string scalarDecoder
+  val number : float scalarDecoder
+  val boolean : bool scalarDecoder
+
+  val scalar : 'a scalarDecoder -> 'a decoder
   val mapping : 'a decoder -> (string * 'a) list decoder
-  val seq : 'a decoder -> 'a list decoder
+  val seq : 'a scalarDecoder -> 'a list decoder
 end

--- a/esy-yarn-lockfile/EsyYarnLockfile.mli
+++ b/esy-yarn-lockfile/EsyYarnLockfile.mli
@@ -30,8 +30,15 @@ module Decode : sig
   val boolean : bool scalarDecoder
 
   val scalar : 'a scalarDecoder -> 'a decoder
-  val mapping : 'a decoder -> (string * 'a) list decoder
   val seq : 'a scalarDecoder -> 'a list decoder
+
+  type fields = t StringMap.t
+  type 'a fieldDecoder = fields -> ('a, string) result
+
+  val mapping : fields decoder
+
+  val field : string -> 'a decoder -> 'a fieldDecoder
+  val fieldOpt : string -> 'a decoder -> 'a option fieldDecoder
 end
 
 type 'a encoder = 'a -> t
@@ -45,4 +52,10 @@ module Encode : sig
 
   val scalar : 'a scalarEncoder -> 'a encoder
   val seq : 'a scalarEncoder -> 'a list encoder
+
+  type field
+
+  val mapping : field list -> t
+  val field : string -> 'a encoder -> 'a -> field
+  val fieldOpt : string -> 'a encoder -> 'a option -> field
 end

--- a/esy-yarn-lockfile/Lexer.mll
+++ b/esy-yarn-lockfile/Lexer.mll
@@ -52,6 +52,7 @@ rule read =
   | float    { NUMBER (float_of_string (Lexing.lexeme lexbuf)) }
   | '"'      { read_string (Buffer.create 16) lexbuf }
   | ':'      { COLON }
+  | '-'      { LI }
   | _        {
       let msg = Printf.sprintf "Unexpected char: '%s'" (Lexing.lexeme lexbuf) in
       raise (SyntaxError msg)

--- a/esy-yarn-lockfile/Parser.mly
+++ b/esy-yarn-lockfile/Parser.mly
@@ -30,6 +30,7 @@ value:
   | INDENT; v = mapping; DEDENT { v }
   | INDENT; v = seq; DEDENT { v }
   | INDENT; DEDENT { Types.Mapping [] }
+  | INDENT; v = value; DEDENT { v }
 
 scalar:
     TRUE { Boolean true }

--- a/esy-yarn-lockfile/Parser.mly
+++ b/esy-yarn-lockfile/Parser.mly
@@ -54,16 +54,9 @@ key:
 seq:
   items = seqitems { Types.Sequence items }
 
-seqitem:
-  LI; v = seqvalue; { v }
-
 seqitems:
     v = seqitem { [v] }
   | v = seqitem; NEWLINE; vs = seqitems  { v::vs }
 
-seqvalue:
-    item = item { Types.Mapping [item] }
-  | item = item; INDENT; items = items; DEDENT { Types.Mapping (item::items) }
-  | item = seqitem { Types.Sequence [item] }
-  | item = seqitem; INDENT; items = seqitems; DEDENT { Types.Sequence (item::items) }
-  | s = scalar { Scalar s }
+seqitem:
+  LI; v = scalar; { v }

--- a/esy-yarn-lockfile/Parser.mly
+++ b/esy-yarn-lockfile/Parser.mly
@@ -11,6 +11,8 @@
 
 %{
 
+  open Types
+
 %}
 
 %start start
@@ -20,17 +22,20 @@
 
 start:
   v = mapping; EOF { v }
-  | EOF { Types.Mapping [] }
+  | EOF { Mapping [] }
 
 value:
-    TRUE { Types.Boolean true }
-  | FALSE { Types.Boolean false }
-  | s = STRING { Types.String s }
-  | s = IDENTIFIER { Types.String s }
-  | n = NUMBER { Types.Number n }
+    v = scalar { Scalar v }
   | INDENT; v = mapping; DEDENT { v }
   | INDENT; v = seq; DEDENT { v }
   | INDENT; DEDENT { Types.Mapping [] }
+
+scalar:
+    TRUE { Boolean true }
+  | FALSE { Boolean false }
+  | s = STRING { String s }
+  | s = IDENTIFIER { String s }
+  | n = NUMBER { Number n }
 
 mapping:
   items = separated_nonempty_list(NEWLINE, item) { Types.Mapping items }
@@ -43,4 +48,4 @@ key:
   | s = STRING { s }
 
 seq:
-  items = separated_nonempty_list(NEWLINE, value) { Types.Sequence items }
+  items = separated_nonempty_list(NEWLINE, scalar) { Types.Sequence items }

--- a/esy-yarn-lockfile/Parser.mly
+++ b/esy-yarn-lockfile/Parser.mly
@@ -1,0 +1,46 @@
+%token <float> NUMBER
+%token <string> IDENTIFIER
+%token TRUE
+%token FALSE
+%token <string> STRING
+%token COLON
+%token INDENT
+%token DEDENT
+%token <int> NEWLINE
+%token EOF
+
+%{
+
+%}
+
+%start start
+%type <Types.t> start
+
+%%
+
+start:
+  v = mapping; EOF { v }
+  | EOF { Types.Mapping [] }
+
+value:
+    TRUE { Types.Boolean true }
+  | FALSE { Types.Boolean false }
+  | s = STRING { Types.String s }
+  | s = IDENTIFIER { Types.String s }
+  | n = NUMBER { Types.Number n }
+  | INDENT; v = mapping; DEDENT { v }
+  | INDENT; v = seq; DEDENT { v }
+  | INDENT; DEDENT { Types.Mapping [] }
+
+mapping:
+  items = separated_nonempty_list(NEWLINE, item) { Types.Mapping items }
+
+item:
+  key = key; COLON; value = value; { (key, value) }
+
+key:
+  s = IDENTIFIER { s }
+  | s = STRING { s }
+
+seq:
+  items = separated_nonempty_list(NEWLINE, value) { Types.Sequence items }

--- a/esy-yarn-lockfile/Printer.ml
+++ b/esy-yarn-lockfile/Printer.ml
@@ -23,5 +23,8 @@ let rec pp fmt (v : t) =
     in
     Fmt.(vbox (list ~sep:(unit "@;") ppItem)) fmt items
   | Sequence items ->
-    Fmt.(vbox (list ~sep:(unit "@;") ppScalar)) fmt items
+    let ppItem fmt v =
+      Fmt.pf fmt "- %a" pp v
+    in
+    Fmt.(vbox (list ~sep:(unit "@;") ppItem)) fmt items
   | Scalar scalar -> ppScalar fmt scalar

--- a/esy-yarn-lockfile/Printer.ml
+++ b/esy-yarn-lockfile/Printer.ml
@@ -1,0 +1,27 @@
+open Types
+
+let ppStringQuotedIfNeeded fmt s =
+  if String.contains s ' '
+  then Fmt.(quote string) fmt s
+  else Fmt.string fmt s
+
+let ppScalar fmt (v : scalar) =
+  match v with
+  | Number n -> Fmt.float fmt n
+  | String s -> ppStringQuotedIfNeeded fmt s
+  | Boolean true -> Fmt.pf fmt "true"
+  | Boolean false -> Fmt.pf fmt "false"
+
+let rec pp fmt (v : t) =
+  match v with
+  | Mapping items ->
+    let ppItem fmt (k, v) =
+      match v with
+      | Scalar scalar -> Fmt.pf fmt "%a: %a" ppStringQuotedIfNeeded k ppScalar scalar
+      | Mapping _ -> Fmt.pf fmt "%s:@;<0 2>@[<v 2>%a@]" k pp v
+      | Sequence _ -> Fmt.pf fmt "%s:@;<0 2>@[<v 2>%a@]" k pp v
+    in
+    Fmt.(vbox (list ~sep:(unit "@;") ppItem)) fmt items
+  | Sequence items ->
+    Fmt.(vbox (list ~sep:(unit "@;") ppScalar)) fmt items
+  | Scalar scalar -> ppScalar fmt scalar

--- a/esy-yarn-lockfile/Printer.ml
+++ b/esy-yarn-lockfile/Printer.ml
@@ -24,7 +24,7 @@ let rec pp fmt (v : t) =
     Fmt.(vbox (list ~sep:(unit "@;") ppItem)) fmt items
   | Sequence items ->
     let ppItem fmt v =
-      Fmt.pf fmt "- %a" pp v
+      Fmt.pf fmt "- %a" ppScalar v
     in
     Fmt.(vbox (list ~sep:(unit "@;") ppItem)) fmt items
   | Scalar scalar -> ppScalar fmt scalar

--- a/esy-yarn-lockfile/Types.ml
+++ b/esy-yarn-lockfile/Types.ml
@@ -16,7 +16,7 @@ type token =
 
 type t =
   | Mapping of (string * t) list
-  | Sequence of t list
+  | Sequence of scalar list
   | Scalar of scalar
   [@@deriving (show, eq, sexp)]
 

--- a/esy-yarn-lockfile/Types.ml
+++ b/esy-yarn-lockfile/Types.ml
@@ -1,3 +1,5 @@
+open Ppx_sexp_conv_lib.Conv
+
 type token =
   | NUMBER of float
   | IDENTIFIER of string
@@ -5,20 +7,18 @@ type token =
   | FALSE
   | STRING of string
   | COLON
-  | COMMA
-  | NEWLINE
+  | NEWLINE of int
+  | INDENT
+  | DEDENT
   | EOF
-  [@@deriving (show, eq)]
-
-type tokens =
-  token list
-  [@@deriving (show, eq)]
+  [@@deriving (show, eq, sexp)]
 
 type t =
   | Mapping of (string * t) list
+  | Sequence of t list
   | Number of float
   | String of string
   | Boolean of bool
-  [@@deriving (show, eq)]
+  [@@deriving (show, eq, sexp)]
 
 exception SyntaxError of string

--- a/esy-yarn-lockfile/Types.ml
+++ b/esy-yarn-lockfile/Types.ml
@@ -10,12 +10,13 @@ type token =
   | NEWLINE of int
   | INDENT
   | DEDENT
+  | LI
   | EOF
   [@@deriving (show, eq, sexp)]
 
 type t =
   | Mapping of (string * t) list
-  | Sequence of scalar list
+  | Sequence of t list
   | Scalar of scalar
   [@@deriving (show, eq, sexp)]
 

--- a/esy-yarn-lockfile/Types.ml
+++ b/esy-yarn-lockfile/Types.ml
@@ -15,10 +15,13 @@ type token =
 
 type t =
   | Mapping of (string * t) list
-  | Sequence of t list
+  | Sequence of scalar list
+  | Scalar of scalar
+  [@@deriving (show, eq, sexp)]
+
+and scalar =
   | Number of float
   | String of string
   | Boolean of bool
-  [@@deriving (show, eq, sexp)]
 
 exception SyntaxError of string

--- a/esy-yarn-lockfile/dune
+++ b/esy-yarn-lockfile/dune
@@ -1,8 +1,14 @@
 (library
   (name EsyYarnLockfile)
-  (preprocess (pps ppx_inline_test ppx_let ppx_deriving.std))
+  (inline_tests)
+  (preprocess (pps ppx_inline_test ppx_expect ppx_sexp_conv ppx_let ppx_deriving.std))
   (flags (:standard (-w -39) "-open" "EsyLib"))
   (libraries EsyLib ppx_deriving.std)
 )
 
 (ocamllex (modules Lexer))
+
+(menhir
+  (flags "--explain" "--external-tokens" "Types")
+  (modules Parser)
+  )

--- a/esy/EsyRc.ml
+++ b/esy/EsyRc.ml
@@ -14,7 +14,7 @@ let ofPath path =
     | EsyYarnLockfile.Mapping items ->
       let f acc item =
         match acc, item with
-        | Ok { prefixPath = None }, ("esy-prefix-path", EsyYarnLockfile.String value) ->
+        | Ok { prefixPath = None }, ("esy-prefix-path", EsyYarnLockfile.Scalar (String value)) ->
           let open Result.Syntax in
           let%bind value = Path.ofString value in
           let value = if Path.isAbs value

--- a/esyi/dune
+++ b/esyi/dune
@@ -4,6 +4,7 @@
   (flags (:standard (-w -39) "-open" "EsyLib"))
   (libraries
             EsyLib
+            EsyYarnLockfile
             angstrom
             str
             cudf


### PR DESCRIPTION
We already had one in `esy-yarn-lockfile` package but it wasn't incomplete and
ad-hoc (was only suitable for parsing `.esyrc`, which we used it for).

We want to use such syntax for a lockfile as it's less noisy than JSON and
easier to review.

- [x] Rewrite parser to use menhir
- [x] Add nested mappings and sequences of scalars
- [x] Add pretty printer
- [x] Add decoder protocol
- [x] Add encoder protocol
- [ ] Port `esy.lock/index` to use this