### PR TITLE
Fix lock checksum in presence of resolutions

### DIFF
--- a/esyi/SolutionLock.ml
+++ b/esyi/SolutionLock.ml
@@ -186,7 +186,7 @@ let computeSandboxChecksum (sandbox : Sandbox.t) =
           errorf "unable to read package: %a" Package.Resolution.pp resolution
         | Ok pkg ->
           return (
-            Digest.string ""
+            digest
             |> hashDependencies
               ~dependencies:pkg.Package.dependencies
           )

--- a/test-e2e/complete/lock-invalidation.test.js
+++ b/test-e2e/complete/lock-invalidation.test.js
@@ -1,0 +1,281 @@
+// @flow
+
+const outdent = require('outdent');
+const path = require('path');
+const fs = require('fs-extra');
+const helpers = require('../test/helpers.js');
+
+const {file, dir, packageJson, dummyExecutable} = helpers;
+
+helpers.skipSuiteOnWindows();
+
+async function writeJson(filename, json) {
+  await fs.writeFile(filename, JSON.stringify(json, null, 2));
+}
+
+describe('lock invalidation', () => {
+  test('invalidation by adding/remove a dep in a root package', async () => {
+    let p = await helpers.createTestSandbox();
+
+    await p.fixture(
+      packageJson({
+        name: 'root',
+        dependencies: {a: '*'},
+      }),
+    );
+
+    await p.defineNpmPackage({
+      name: 'a',
+      version: '1.0.0',
+    });
+
+    await p.defineNpmPackage({
+      name: 'b',
+      version: '1.0.0',
+    });
+
+    // install
+
+    await p.esy('install');
+
+    expect(await helpers.readInstalledPackages(p.projectPath)).toEqual({
+      name: 'root',
+      version: 'link:./package.json',
+      dependencies: {
+        a: {name: 'a', version: '1.0.0', dependencies: {}},
+      },
+    });
+
+    // add dep & install
+
+    await writeJson(path.join(p.projectPath, 'package.json'), {
+      name: 'root',
+      dependencies: {a: '*', b: '*'},
+    });
+
+    await p.esy('install');
+
+    expect(await helpers.readInstalledPackages(p.projectPath)).toEqual({
+      name: 'root',
+      version: 'link:./package.json',
+      dependencies: {
+        a: {name: 'a', version: '1.0.0', dependencies: {}},
+        b: {name: 'b', version: '1.0.0', dependencies: {}},
+      },
+    });
+
+    // remove dep & install
+
+    await writeJson(path.join(p.projectPath, 'package.json'), {
+      name: 'root',
+      dependencies: {a: '*'},
+    });
+
+    await p.esy('install');
+
+    expect(await helpers.readInstalledPackages(p.projectPath)).toEqual({
+      name: 'root',
+      version: 'link:./package.json',
+      dependencies: {
+        a: {name: 'a', version: '1.0.0', dependencies: {}},
+      },
+    });
+  });
+
+  test('invalidation by adding/remove a dep in a linked package', async () => {
+    let p = await helpers.createTestSandbox();
+
+    await p.fixture(
+      packageJson({
+        name: 'root',
+        dependencies: {dep: '*'},
+        resolutions: {dep: 'link:./dep'},
+      }),
+      dir(
+        'dep',
+        packageJson({
+          name: 'dep',
+          dependencies: {a: '*'},
+        }),
+      ),
+    );
+
+    await p.defineNpmPackage({
+      name: 'a',
+      version: '1.0.0',
+    });
+
+    await p.defineNpmPackage({
+      name: 'b',
+      version: '1.0.0',
+    });
+
+    // install
+
+    await p.esy('install');
+
+    expect(await helpers.readInstalledPackages(p.projectPath)).toEqual({
+      name: 'root',
+      version: 'link:./package.json',
+      dependencies: {
+        dep: {
+          name: 'dep',
+          version: 'link:dep',
+          dependencies: {
+            a: {name: 'a', version: '1.0.0', dependencies: {}},
+          },
+        },
+      },
+    });
+
+    // add dep & install
+
+    await writeJson(path.join(p.projectPath, 'dep', 'package.json'), {
+      name: 'dep',
+      dependencies: {a: '*', b: '*'},
+    });
+
+    await p.esy('install');
+
+    expect(await helpers.readInstalledPackages(p.projectPath)).toEqual({
+      name: 'root',
+      version: 'link:./package.json',
+      dependencies: {
+        dep: {
+          name: 'dep',
+          version: 'link:dep',
+          dependencies: {
+            a: {name: 'a', version: '1.0.0', dependencies: {}},
+            b: {name: 'b', version: '1.0.0', dependencies: {}},
+          },
+        },
+      },
+    });
+
+    // remove dep & install
+
+    await writeJson(path.join(p.projectPath, 'dep', 'package.json'), {
+      name: 'root',
+      dependencies: {a: '*'},
+    });
+
+    await p.esy('install');
+
+    expect(await helpers.readInstalledPackages(p.projectPath)).toEqual({
+      name: 'root',
+      version: 'link:./package.json',
+      dependencies: {
+        dep: {
+          name: 'dep',
+          version: 'link:dep',
+          dependencies: {
+            a: {name: 'a', version: '1.0.0', dependencies: {}},
+          },
+        },
+      },
+    });
+  });
+
+  test('invalidation by adding/remove a dep in a root package (in a presence of resolutions)', async () => {
+    let p = await helpers.createTestSandbox();
+
+    await p.fixture(
+      packageJson({
+        name: 'root',
+        dependencies: {
+          a: '*',
+          dep: '*',
+        },
+        resolutions: {
+          dep: 'link:./dep',
+        },
+      }),
+      dir(
+        'dep',
+        packageJson({
+          name: 'dep',
+          dependencies: {},
+        }),
+      ),
+    );
+
+    await p.defineNpmPackage({
+      name: 'a',
+      version: '1.0.0',
+    });
+
+    await p.defineNpmPackage({
+      name: 'b',
+      version: '1.0.0',
+    });
+
+    // install
+
+    await p.esy('install');
+
+    expect(await helpers.readInstalledPackages(p.projectPath)).toEqual({
+      name: 'root',
+      version: 'link:./package.json',
+      dependencies: {
+        a: {name: 'a', version: '1.0.0', dependencies: {}},
+        dep: {
+          name: 'dep',
+          version: 'link:dep',
+          dependencies: {},
+        },
+      },
+    });
+
+    // add dep & install
+
+    await writeJson(path.join(p.projectPath, 'dep', 'package.json'), {
+      name: 'dep',
+      dependencies: {b: '*'},
+    });
+
+    await p.esy('install');
+
+    expect(await helpers.readInstalledPackages(p.projectPath)).toEqual({
+      name: 'root',
+      version: 'link:./package.json',
+      dependencies: {
+        a: {name: 'a', version: '1.0.0', dependencies: {}},
+        dep: {
+          name: 'dep',
+          version: 'link:dep',
+          dependencies: {
+            b: {name: 'b', version: '1.0.0', dependencies: {}},
+          },
+        },
+      },
+    });
+
+    // remove dep & install
+
+    await writeJson(path.join(p.projectPath, 'package.json'), {
+      name: 'root',
+      dependencies: {
+        dep: '*',
+      },
+      resolutions: {
+        dep: 'link:./dep',
+      },
+    });
+
+    await p.esy('install');
+
+    expect(await helpers.readInstalledPackages(p.projectPath)).toEqual({
+      name: 'root',
+      version: 'link:./package.json',
+      dependencies: {
+        dep: {
+          name: 'dep',
+          version: 'link:dep',
+          dependencies: {
+            b: {name: 'b', version: '1.0.0', dependencies: {}},
+          },
+        },
+      },
+    });
+  });
+});

--- a/test-e2e/complete/lock-invalidation.test.js
+++ b/test-e2e/complete/lock-invalidation.test.js
@@ -7,8 +7,6 @@ const helpers = require('../test/helpers.js');
 
 const {file, dir, packageJson, dummyExecutable} = helpers;
 
-helpers.skipSuiteOnWindows();
-
 async function writeJson(filename, json) {
   await fs.writeFile(filename, JSON.stringify(json, null, 2));
 }


### PR DESCRIPTION
Fixes #613

A silly bug: I didn't pass previously calculated part of checksum (for
dependencies/devDependencies of the root package) further when calculating
checksum for resolutions.

Added a test suite for that so it shouldn't happen again.