### PR TITLE
Fix out of bound access in fastreplacestring

### DIFF
--- a/fastreplacestring/fastreplacestring.cpp
+++ b/fastreplacestring/fastreplacestring.cpp
@@ -37,7 +37,7 @@ int indexOf(const char *needle, size_t needleLen, const char *haystack,
 
   /* Searching */
   j = 0;
-  while (j <= haystackLen - needleLen - 1) {
+  while (j < haystackLen - needleLen) {
     if (hx == hy && memcmp(needle, haystack + j, needleLen) == 0) {
       return j;
     }

--- a/fastreplacestring/fastreplacestring.cpp
+++ b/fastreplacestring/fastreplacestring.cpp
@@ -37,7 +37,7 @@ int indexOf(const char *needle, size_t needleLen, const char *haystack,
 
   /* Searching */
   j = 0;
-  while (j <= haystackLen - needleLen) {
+  while (j <= haystackLen - needleLen - 1) {
     if (hx == hy && memcmp(needle, haystack + j, needleLen) == 0) {
       return j;
     }

--- a/fastreplacestring/fastreplacestring.cpp
+++ b/fastreplacestring/fastreplacestring.cpp
@@ -37,13 +37,13 @@ int indexOf(const char *needle, size_t needleLen, const char *haystack,
 
   /* Searching */
   j = 0;
-  while (j < haystackLen - needleLen) {
+  do {
     if (hx == hy && memcmp(needle, haystack + j, needleLen) == 0) {
       return j;
     }
     hy = REHASH(haystack[j], haystack[j + needleLen], hy);
     ++j;
-  }
+  } while (j < haystackLen - needleLen);
 
   return -1;
 }

--- a/fastreplacestring/test/fastreplacestringTest.ml
+++ b/fastreplacestring/test/fastreplacestringTest.ml
@@ -4,7 +4,12 @@ let filename = Filename.concat dirname "test.fastreplacestring"
 let%expect_test "it is working" =
   let () =
     let oc = open_out filename in
-    Printf.fprintf oc "someHeLlostring\nHeLlo at the beginning\nat the end HeLlo\n";
+    Printf.fprintf oc {|someHeLlostring
+HeLlo at the beginning
+at the end HeLlo
+HeLlo and HeLlo
+xHeLlo and HeLlox
+|};
     close_out oc;
   in
 
@@ -18,8 +23,13 @@ let%expect_test "it is working" =
   print_endline (input_line ic);
   print_endline (input_line ic);
   print_endline (input_line ic);
+  print_endline (input_line ic);
+  print_endline (input_line ic);
   close_in ic;
   [%expect {|
     someHELLOstring
     HELLO at the beginning
-    at the end HELLO |}]
+    at the end HELLO
+    HELLO and HELLO
+    xHELLO and HELLOx
+  |}]


### PR DESCRIPTION
We have seen segfaults on macOS/Azure and finally I was able to get a good repro with @opam/octavius.

Firing up the offending command with lldb have shown the problem with out of bound access (off by 1 error).

The fix is consistent with [1] and [2].

The original page which this algo refernces [3] has a typo apparently.

Thanks @IwanKaramazow for confirming the bug.

[1]: https://en.wikipedia.org/wiki/Rabin–Karp_algorithm
[2]: https://www.topcoder.com/community/competitive-programming/tutorials/introduction-to-string-searching-algorithms/
[3]: http://www-igm.univ-mlv.fr/~lecroq/string/node5.html