### PR TITLE
Add DistPath.t

### DIFF
--- a/esy/BuildManifest.ml
+++ b/esy/BuildManifest.ml
@@ -366,7 +366,7 @@ let ofInstallationLocation ~cfg (pkg : Solution.Package.t) (loc : Installation.l
     let%bind res =
       DistResolver.resolve
         ~cfg:cfg.Config.installCfg
-        ~root:cfg.spec.SandboxSpec.path
+        ~sandbox:cfg.spec
         dist
     in
     let overrides = Overrides.merge pkg.overrides res.DistResolver.overrides in
@@ -390,6 +390,7 @@ let ofInstallationLocation ~cfg (pkg : Solution.Package.t) (loc : Installation.l
         let%bind manifest =
           Overrides.foldWithBuildOverrides
             ~cfg:cfg.Config.installCfg
+            ~sandbox:cfg.spec
             ~f:applyOverride
             ~init:manifest
             overrides
@@ -399,6 +400,7 @@ let ofInstallationLocation ~cfg (pkg : Solution.Package.t) (loc : Installation.l
       let%bind manifest =
         Overrides.foldWithBuildOverrides
           ~cfg:cfg.Config.installCfg
+          ~sandbox:cfg.spec
           ~f:applyOverride
           ~init:manifest
           overrides
@@ -415,6 +417,7 @@ let ofInstallationLocation ~cfg (pkg : Solution.Package.t) (loc : Installation.l
       let%bind manifest =
         Overrides.foldWithBuildOverrides
           ~cfg:cfg.Config.installCfg
+          ~sandbox:cfg.spec
           ~f:applyOverride
           ~init:manifest
           pkg.overrides
@@ -430,6 +433,7 @@ let ofInstallationLocation ~cfg (pkg : Solution.Package.t) (loc : Installation.l
           let%bind manifest =
             Overrides.foldWithBuildOverrides
               ~cfg:cfg.Config.installCfg
+              ~sandbox:cfg.spec
               ~f:applyOverride
               ~init:manifest
               pkg.overrides
@@ -443,6 +447,7 @@ let ofInstallationLocation ~cfg (pkg : Solution.Package.t) (loc : Installation.l
             let%bind manifest =
               Overrides.foldWithBuildOverrides
                 ~cfg:cfg.Config.installCfg
+                ~sandbox:cfg.spec
                 ~f:applyOverride
                 ~init:manifest
                 pkg.overrides

--- a/esy/bin/esyCommand.ml
+++ b/esy/bin/esyCommand.ml
@@ -1412,7 +1412,7 @@ let show (copts : CommonOptions.t) _asJson req () =
   let open EsyInstall in
   let open RunAsync.Syntax in
   let%bind (req : Req.t) = RunAsync.ofStringError (Req.parse req) in
-  let%bind resolver = Resolver.make ~cfg:copts.cfg.installCfg ~root:copts.spec.path () in
+  let%bind resolver = Resolver.make ~cfg:copts.cfg.installCfg ~sandbox:copts.spec () in
   let%bind resolutions =
     RunAsync.contextf (
       Resolver.resolve ~name:req.name ~spec:req.spec resolver

--- a/esyi/Dist.ml
+++ b/esyi/Dist.ml
@@ -17,7 +17,7 @@ type t =
       manifest : ManifestSpec.Filename.t option;
     }
   | LocalPath of {
-      path : Path.t;
+      path : DistPath.t;
       manifest : ManifestSpec.t option;
     }
   | NoSource
@@ -50,8 +50,8 @@ let show' ~showPath = function
     Printf.sprintf "path:%s/%s" (showPath path) (ManifestSpec.show manifest)
   | NoSource -> "no-source:"
 
-let show = show' ~showPath:Path.show
-let showPretty = show' ~showPath:Path.showPretty
+let show = show' ~showPath:DistPath.show
+let showPretty = show' ~showPath:DistPath.showPretty
 
 let pp fmt src =
   Fmt.pf fmt "%s" (show src)
@@ -117,7 +117,7 @@ module Parse = struct
         | Error _ ->
           path, None
       in
-      make path manifest
+      make (DistPath.ofPath path) manifest
     in
 
     let path =

--- a/esyi/Dist.mli
+++ b/esyi/Dist.mli
@@ -15,7 +15,7 @@ type t =
       manifest : ManifestSpec.Filename.t option;
     }
   | LocalPath of {
-      path : Path.t;
+      path : DistPath.t;
       manifest : ManifestSpec.t option;
     }
   | NoSource

--- a/esyi/DistPath.ml
+++ b/esyi/DistPath.ml
@@ -1,0 +1,16 @@
+include Path
+
+let ofPath p = (normalizeAndRemoveEmptySeg p)
+
+let toPath base p = normalizeAndRemoveEmptySeg (base // p)
+
+let rebase ~base p = normalizeAndRemoveEmptySeg (base // p)
+
+let render path = normalizePathSlashes (show path)
+
+let show = render
+let showPretty path = Path.(normalizePathSlashes (showPretty path))
+
+let to_yojson path = `String (render path)
+
+let sexp_of_t path = Sexplib0.Sexp.Atom (render path)

--- a/esyi/DistPath.mli
+++ b/esyi/DistPath.mli
@@ -1,0 +1,28 @@
+(**
+
+  This represents symbolic paths used in dists/sources/source-specs.
+
+  They are always rendered using forward slashes (/), unix-like.
+
+  [DistPath.t] values are relative to some base [Path.t] value.
+
+ *)
+
+type t
+
+include S.JSONABLE with type t := t
+include S.COMPARABLE with type t := t
+
+val v : string -> t
+
+val toPath : Path.t -> t -> Path.t
+(** [toPath base p] converts [p] to [Path.t] by rebasing on top of [base]. *)
+
+val ofPath : Path.t -> t
+
+val rebase : base:t -> t -> t
+
+val sexp_of_t : t -> Sexplib0.Sexp.t
+
+val show : t -> string
+val showPretty : t -> string

--- a/esyi/DistResolver.mli
+++ b/esyi/DistResolver.mli
@@ -29,7 +29,7 @@ and manifest = {
 val resolve :
   ?overrides:Package.Overrides.t
   -> cfg:Config.t
-  -> root:Path.t
+  -> sandbox:SandboxSpec.t
   -> Dist.t
   -> resolution RunAsync.t
 (**

--- a/esyi/DistStorage.mli
+++ b/esyi/DistStorage.mli
@@ -9,6 +9,7 @@ type archive
 
 val fetch :
   cfg : Config.t
+  -> sandbox:SandboxSpec.t
   -> Dist.t
   -> archive Run.t RunAsync.t
 (** Fetch source. *)
@@ -22,6 +23,7 @@ val unpack :
 
 val fetchAndUnpack :
   cfg : Config.t
+  -> sandbox:SandboxSpec.t
   -> dst : Path.t
   -> Dist.t
   -> unit RunAsync.t
@@ -29,5 +31,6 @@ val fetchAndUnpack :
 
 val fetchAndUnpackToCache :
   cfg:Config.t
+  -> sandbox:SandboxSpec.t
   -> Dist.t
   -> Fpath.t RunAsync.t

--- a/esyi/Package.mli
+++ b/esyi/Package.mli
@@ -182,6 +182,7 @@ module Overrides : sig
 
   val foldWithInstallOverrides :
     cfg:Config.t
+    -> sandbox:SandboxSpec.t
     -> f:('v -> Override.install -> 'v)
     -> init:'v
     -> t
@@ -189,12 +190,17 @@ module Overrides : sig
 
   val foldWithBuildOverrides :
     cfg:Config.t
+    -> sandbox:SandboxSpec.t
     -> f:('v -> Override.build -> 'v)
     -> init:'v
     -> t
     -> 'v RunAsync.t
 
-  val files : cfg:Config.t -> t -> File.t list RunAsync.t
+  val files :
+    cfg:Config.t
+    -> sandbox:SandboxSpec.t
+    -> t
+    -> File.t list RunAsync.t
 
   val toList : t -> Override.t list
 
@@ -254,7 +260,7 @@ type t = {
 
 and source =
   | Link of {
-      path : Path.t;
+      path : DistPath.t;
       manifest : ManifestSpec.t option;
     }
   | Install of {

--- a/esyi/PackageJson.ml
+++ b/esyi/PackageJson.ml
@@ -41,7 +41,7 @@ let rebaseDependencies source reqs =
     | (Source.Dist LocalPath {path = basePath; _}
       | Source.Link {path = basePath; _}),
       VersionSpec.Source (SourceSpec.LocalPath {path; manifest;}) ->
-      let path = Path.(basePath // path |> normalizeAndRemoveEmptySeg) in
+      let path = DistPath.rebase ~base:basePath path in
       let spec = VersionSpec.Source (SourceSpec.LocalPath {path; manifest;}) in
       return (Req.make ~name:req.name ~spec)
     | _, VersionSpec.Source (SourceSpec.LocalPath _) ->

--- a/esyi/Req.ml
+++ b/esyi/Req.ml
@@ -271,7 +271,7 @@ let%test_module "parsing" = (module struct
     {
       name = "pkg";
       spec = VersionSpec.Source (SourceSpec.LocalPath {
-        path = Path.v "some/file";
+        path = DistPath.v "some/file";
         manifest = None;
       });
     };

--- a/esyi/Resolver.mli
+++ b/esyi/Resolver.mli
@@ -4,7 +4,7 @@ type t
 (** Make new resolver *)
 val make :
   cfg:Config.t
-  -> root:Path.t
+  -> sandbox:SandboxSpec.t
   -> unit
   -> t RunAsync.t
 

--- a/esyi/Sandbox.ml
+++ b/esyi/Sandbox.ml
@@ -15,7 +15,7 @@ let ocamlReqAny =
 let ofMultiplOpamFiles ~cfg ~spec _projectPath (paths : Path.t list) =
   let open RunAsync.Syntax in
 
-  let%bind resolver = Resolver.make ~cfg ~root:spec.path () in
+  let%bind resolver = Resolver.make ~cfg ~sandbox:spec () in
 
   let%bind opams =
 
@@ -59,7 +59,7 @@ let ofMultiplOpamFiles ~cfg ~spec _projectPath (paths : Path.t list) =
   in
 
   let source = Source.Link {
-    path = Path.v ".";
+    path = DistPath.v ".";
     manifest = None;
   } in
   let version = Version.Source source in
@@ -76,7 +76,7 @@ let ofMultiplOpamFiles ~cfg ~spec _projectPath (paths : Path.t list) =
         originalVersion = None;
         originalName = None;
         source = Package.Link {
-          path = Path.v ".";
+          path = DistPath.v ".";
           manifest = None;
         };
         overrides = Package.Overrides.empty;
@@ -118,7 +118,7 @@ let ofMultiplOpamFiles ~cfg ~spec _projectPath (paths : Path.t list) =
       originalVersion = None;
       originalName = None;
       source = Package.Link {
-        path = Path.v ".";
+        path = DistPath.v ".";
         manifest = None;
       };
       overrides = Package.Overrides.empty;
@@ -157,7 +157,7 @@ let ofSource ~cfg ~spec source =
   in
 
   let%bind resolver =
-    Resolver.make ~cfg ~root:spec.path ()
+    Resolver.make ~cfg ~sandbox:spec ()
   in
 
   match%bind Resolver.package ~resolution resolver with

--- a/esyi/SolutionLock.ml
+++ b/esyi/SolutionLock.ml
@@ -1,6 +1,6 @@
 type source =
   | Link of {
-      path : Path.t;
+      path : DistPath.t;
       manifest : ManifestSpec.t option;
     }
   | Install of {
@@ -14,7 +14,7 @@ let source_to_yojson source =
   | Link { path; manifest } ->
     assoc [
       field "type" string "link";
-      field "path" Path.to_yojson path;
+      field "path" DistPath.to_yojson path;
       fieldOpt "manifest" ManifestSpec.to_yojson manifest;
     ]
   | Install { source = source, mirrors; opam } ->
@@ -37,7 +37,7 @@ let source_of_yojson json =
     let%bind opam = fieldOptWith ~name:"opam" OpamResolution.Lock.of_yojson json in
     Ok (Install {source; opam;})
   | "link" ->
-    let%bind path = fieldWith ~name:"path" Path.of_yojson json in
+    let%bind path = fieldWith ~name:"path" DistPath.of_yojson json in
     let%bind manifest = fieldOptWith ~name:"manifest" ManifestSpec.of_yojson json in
     Ok (Link {path; manifest;})
   | typ -> errorf "unknown source type: %s" typ

--- a/esyi/Solver.ml
+++ b/esyi/Solver.ml
@@ -438,7 +438,7 @@ let solveDependencies ~root ~installed ~strategy dependencies solver =
     originalVersion = None;
     originalName = root.originalName;
     source = Package.Link {
-      path = Path.v ".";
+      path = DistPath.v ".";
       manifest = None;
     };
     overrides = Package.Overrides.empty;

--- a/esyi/Source.ml
+++ b/esyi/Source.ml
@@ -6,7 +6,7 @@ type t =
   [@@deriving ord, sexp_of]
 
 and link = {
-  path : Path.t;
+  path : DistPath.t;
   manifest : ManifestSpec.t option;
 }
 
@@ -41,8 +41,8 @@ let show' ~showPath = function
   | Link {path; manifest = Some manifest;} ->
     Printf.sprintf "link:%s/%s" (showPath path) (ManifestSpec.show manifest)
 
-let show = show' ~showPath:Path.show
-let showPretty = show' ~showPath:Path.showPretty
+let show = show' ~showPath:DistPath.show
+let showPretty = show' ~showPath:DistPath.showPretty
 
 let pp fmt src =
   Fmt.pf fmt "%s" (show src)
@@ -67,7 +67,7 @@ module Parse = struct
         | Error _ ->
           path, None
       in
-      make path manifest
+      make (DistPath.ofPath path) manifest
     in
 
     let path =

--- a/esyi/Source.mli
+++ b/esyi/Source.mli
@@ -3,7 +3,7 @@ type t =
   | Link of link
 
 and link = {
-  path : Path.t;
+  path : DistPath.t;
   manifest : ManifestSpec.t option;
 }
 

--- a/esyi/SourceSpec.ml
+++ b/esyi/SourceSpec.ml
@@ -17,7 +17,7 @@ type t =
       manifest : ManifestSpec.Filename.t option;
     }
   | LocalPath of {
-      path : Path.t;
+      path : DistPath.t;
       manifest : ManifestSpec.t option;
     }
   | NoSource
@@ -48,9 +48,9 @@ let show = function
     Printf.sprintf "archive:%s" url
 
   | LocalPath {path; manifest = None;} ->
-    Printf.sprintf "path:%s" (Path.show path)
+    Printf.sprintf "path:%s" (DistPath.show path)
   | LocalPath {path; manifest = Some manifest;} ->
-    Printf.sprintf "path:%s/%s" (Path.show path) (ManifestSpec.show manifest)
+    Printf.sprintf "path:%s/%s" (DistPath.show path) (ManifestSpec.show manifest)
 
   | NoSource -> "no-source:"
 
@@ -144,7 +144,7 @@ module Parse = struct
         | Error _ ->
           path, None
       in
-      make path manifest
+      make (DistPath.ofPath path) manifest
     in
     (make <$> path)
 

--- a/esyi/SourceSpec.mli
+++ b/esyi/SourceSpec.mli
@@ -20,7 +20,7 @@ type t =
       manifest : ManifestSpec.Filename.t option;
     }
   | LocalPath of {
-      path : Path.t;
+      path : DistPath.t;
       manifest : ManifestSpec.t option;
     }
   | NoSource

--- a/test-e2e/install/link.test.js
+++ b/test-e2e/install/link.test.js
@@ -240,7 +240,7 @@ describe(`installing linked packages`, () => {
       dependencies: {
         dep: {
           name: 'dep',
-          version: `link:..${path.sep}..`,
+          version: `link:../..`,
         },
       },
     });


### PR DESCRIPTION
We use `DistPath.t` instead of `Path.t` to represent references to local packages (`path:` or `link:`):

All `DistPath.t` are represented in a normalized when put into JSON and/or string form:

  - trailing empty segment is removed
  - leading `./` is removed if present
  - Windows style `\` separators are replaced with `/` Unix style
    separators