### PR TITLE
Ignore VCS dirs when relocating sources and checking mtime

### DIFF
--- a/esy-build-package/Build.re
+++ b/esy-build-package/Build.re
@@ -88,6 +88,9 @@ module RelocateSourceLifecycle: LIFECYCLE = {
     let%bind () = mkdir(build.buildPath);
     let%bind () = {
       let ignore = [
+        ".git",
+        ".hg",
+        ".svn",
         "node_modules",
         "_esy",
         "_build",
@@ -413,10 +416,13 @@ let findSourceModTime = (build: build) => {
     `Sat(
       path =>
         switch (Path.basename(path)) {
-        | "node_modules" => Ok(false)
-        | "_esy" => Ok(false)
-        | "_release" => Ok(false)
-        | "_build" => Ok(false)
+        | ".git"
+        | ".hg"
+        | ".svn"
+        | "node_modules"
+        | "_esy"
+        | "_release"
+        | "_build"
         | "_install" => Ok(false)
         | fname when isHidden(fname) => Ok(false)
         | _ => Ok(true)


### PR DESCRIPTION
There's no point in doing that and including vcs dirs made those processes slower. We are going to ignore them from now on.

There's possibility we can break some package which is being linked and relocated but linked packages with relocation is so slow already, almost unusable.  I'd suggest to change to an `"unsafe"` build-type for those instead.