### PR TITLE
[WIP] Warn about unused resolutions

### DIFF
--- a/esy-lib/List.ml
+++ b/esy-lib/List.ml
@@ -9,6 +9,13 @@ let filterNone xs =
   in
   rev (loop xs [])
 
+let rec filter_map ~f = function
+    [] -> []
+  | a::l -> match f a with 
+            | Some r -> r :: filter_map ~f l
+            | None   -> filter_map ~f l
+
+
 let diff xs ys =
   filter ~f:(fun elem -> not (mem ~set:ys elem)) xs
 

--- a/esy/bin/esyCommand.ml
+++ b/esy/bin/esyCommand.ml
@@ -1194,7 +1194,19 @@ let solve {CommonOptions. installSandbox; _} () =
   let open RunAsync.Syntax in
   let%bind _ : Solution.t = getSandboxSolution installSandbox in
   let unused = Resolver.getUnusedResolutions installSandbox.resolver in
-  let%lwt () = Lwt_list.iter_p (fun name -> (Logs_lwt.warn (fun m -> m "Resolution '%s' is unused" name))) unused in
+  let%lwt () =
+    let log resolution =
+      Logs_lwt.warn (
+        fun m ->
+          m "resolution %a is unused (defined in %a)"
+          Fmt.(quote string)
+          resolution
+          ManifestSpec.pp
+          installSandbox.spec.manifest
+      )
+    in
+    Lwt_list.iter_s log unused
+  in
   return ()
 
 let fetch {CommonOptions. installSandbox = sandbox; _} () =

--- a/esy/bin/esyCommand.ml
+++ b/esy/bin/esyCommand.ml
@@ -1187,12 +1187,6 @@ let getSandboxSolution installSandbox =
   let%bind () =
     SolutionLock.toPath ~sandbox:installSandbox ~solution lockPath
   in
-  return solution
-
-let solve {CommonOptions. installSandbox; _} () =
-  let open EsyInstall in
-  let open RunAsync.Syntax in
-  let%bind _ : Solution.t = getSandboxSolution installSandbox in
   let unused = Resolver.getUnusedResolutions installSandbox.resolver in
   let%lwt () =
     let log resolution =
@@ -1207,6 +1201,12 @@ let solve {CommonOptions. installSandbox; _} () =
     in
     Lwt_list.iter_s log unused
   in
+  return solution
+
+let solve {CommonOptions. installSandbox; _} () =
+  let open EsyInstall in
+  let open RunAsync.Syntax in
+  let%bind _ : Solution.t = getSandboxSolution installSandbox in
   return ()
 
 let fetch {CommonOptions. installSandbox = sandbox; _} () =

--- a/esy/bin/esyCommand.ml
+++ b/esy/bin/esyCommand.ml
@@ -1190,8 +1190,11 @@ let getSandboxSolution installSandbox =
   return solution
 
 let solve {CommonOptions. installSandbox; _} () =
+  let open EsyInstall in
   let open RunAsync.Syntax in
   let%bind _ : Solution.t = getSandboxSolution installSandbox in
+  let unused = Resolver.getUnusedResolutions installSandbox.resolver in
+  let%lwt () = Lwt_list.iter_p (fun name -> (Logs_lwt.warn (fun m -> m "Resolution '%s' is unused" name))) unused in
   return ()
 
 let fetch {CommonOptions. installSandbox = sandbox; _} () =

--- a/esyi/Resolver.ml
+++ b/esyi/Resolver.ml
@@ -131,18 +131,17 @@ let setOCamlVersion ocamlVersion resolver =
   resolver.ocamlVersion <- Some ocamlVersion
 
 let setResolutions resolutions resolver =
-  (* First we set the resolutions *)
-  resolver.resolutions <- resolutions;
-  (* Then we set the usage of every resolution to 0 *)
-  List.iter
-    ~f:(fun r -> Hashtbl.add resolver.resolutionUsage r false)
-    (Resolutions.entries resolutions)
+  resolver.resolutions <- resolutions
   
+
 let getUnusedResolutions resolver =
-  Hashtbl.fold
-    (fun (res:Resolution.t) used unused -> if not used then (res.name)::unused else unused)
-    resolver.resolutionUsage
-    []
+  let nameIfUnused usage (resolution:Resolution.t) =
+    match Hashtbl.find_opt usage resolution with
+    | Some true -> None
+    | _         -> Some resolution.name
+  in
+  List.filter_map ~f:(nameIfUnused resolver.resolutionUsage) (Resolutions.entries resolver.resolutions)
+
 
 (* This function increments the resolution usage count of that resolution *)
 let markResolutionAsUsed resolver resolution =

--- a/esyi/Resolver.ml
+++ b/esyi/Resolver.ml
@@ -145,7 +145,7 @@ let getUnusedResolutions resolver =
     []
 
 (* This function increments the resolution usage count of that resolution *)
-let didUse resolver resolution =
+let markResolutionAsUsed resolver resolution =
   Hashtbl.replace resolver.resolutionUsage resolution true
 
 let sourceMatchesSpec resolver spec source =
@@ -611,7 +611,7 @@ let resolve ?(fullMetadata=false) ~(name : string) ?(spec : VersionSpec.t option
   match Resolutions.find resolver.resolutions name with
   | Some resolution -> 
     (* increment usage counter for that resolution so that we know it was used *)
-    didUse resolver resolution;
+    markResolutionAsUsed resolver resolution;
     return [resolution]
   | None ->
     let spec =

--- a/esyi/Resolver.mli
+++ b/esyi/Resolver.mli
@@ -10,6 +10,9 @@ val make :
 
 val setOCamlVersion : Version.t -> t -> unit
 val setResolutions : Package.Resolutions.t -> t -> unit
+val getUnusedResolutions : t -> string list
+
+
 
 (**
  * Resolve package request into a list of resolutions

--- a/test-e2e/install/resolutions.test.js
+++ b/test-e2e/install/resolutions.test.js
@@ -342,9 +342,8 @@ describe(`Installing with resolutions`, () => {
 
     const result = await p.esy(`install`);
 
-    console.log(result.stderr);
-
     expect(result.stderr.includes('warn resolution "unused" is unused (defined in package.json)')).toBe(true);
+    expect(result.stderr.includes('warn resolution "dep" is unused (defined in package.json)')).toBe(false);
 
   })
 

--- a/test-e2e/install/resolutions.test.js
+++ b/test-e2e/install/resolutions.test.js
@@ -322,6 +322,31 @@ describe(`Installing with resolutions`, () => {
     });
   });
 
+  test(`should display a warning in case of unused resolutions`, async () => {
+    const p = await helpers.createTestSandbox();
+
+    await p.defineNpmPackage({
+      name: 'dep',
+      version: `2.0.0`,
+    });
+
+    await p.fixture(
+      helpers.packageJson({
+        name: 'root',
+        version: '1.0.0',
+        esy: {},
+        dependencies: {dep: `1.0.0`},
+        resolutions: {dep: `2.0.0`, unused: `1.0.0`},
+      }),
+    );
+
+    const result = await p.esy(`install`);
+
+    expect(result.stderr.includes("warn Resolution 'unused' is unused")).toBe(true);
+
+  })
+
+
   test(`resolutions overrides could inject linked packages to non local packages`, async () => {
     const p = await helpers.createTestSandbox();
 

--- a/test-e2e/install/resolutions.test.js
+++ b/test-e2e/install/resolutions.test.js
@@ -322,7 +322,7 @@ describe(`Installing with resolutions`, () => {
     });
   });
 
-  test(`should display a warning in case of unused resolutions`, async () => {
+  test(`should display a warning in case of unused resolutions during install`, async () => {
     const p = await helpers.createTestSandbox();
 
     await p.defineNpmPackage({
@@ -341,6 +341,30 @@ describe(`Installing with resolutions`, () => {
     );
 
     const result = await p.esy(`install`);
+
+    expect(result.stderr.includes('warn resolution "unused" is unused (defined in package.json)')).toBe(true);
+    expect(result.stderr.includes('warn resolution "dep" is unused (defined in package.json)')).toBe(false);
+
+  })
+
+  test(`should display a warning in case of unused resolutions during add`, async () => {
+    const p = await helpers.createTestSandbox();
+
+    await p.defineNpmPackage({
+      name: 'dep',
+      version: `2.0.0`,
+    });
+
+    await p.fixture(
+      helpers.packageJson({
+        name: 'root',
+        version: '1.0.0',
+        esy: {},
+        resolutions: {dep: `2.0.0`, unused: `1.0.0`},
+      }),
+    );
+
+    const result = await p.esy(`add dep`);
 
     expect(result.stderr.includes('warn resolution "unused" is unused (defined in package.json)')).toBe(true);
     expect(result.stderr.includes('warn resolution "dep" is unused (defined in package.json)')).toBe(false);

--- a/test-e2e/install/resolutions.test.js
+++ b/test-e2e/install/resolutions.test.js
@@ -342,7 +342,9 @@ describe(`Installing with resolutions`, () => {
 
     const result = await p.esy(`install`);
 
-    expect(result.stderr.includes("warn Resolution 'unused' is unused")).toBe(true);
+    console.log(result.stderr);
+
+    expect(result.stderr.includes('warn resolution "unused" is unused (defined in package.json)')).toBe(true);
 
   })
 


### PR DESCRIPTION
This branch should allow esy to warn the user about unused resolutions.

I'm only checking for unused resolution when calling solve, I believe it means there will be no warning when a lock file exist. Should we give a warning somewhere else ?

fix #614 