### PR TITLE
Windows - Bugfix: Generate .gitattributes in esy.lock folder

### DIFF
--- a/esy.lock/.gitattributes
+++ b/esy.lock/.gitattributes
@@ -1,3 +1,0 @@
-
-#Set files to binary mode, so that the newlines aren't 'CRLF'-ized on windows.
-* binary

--- a/esy.lock/.gitattributes
+++ b/esy.lock/.gitattributes
@@ -1,0 +1,3 @@
+
+#Set files to binary mode, so that the newlines aren't 'CRLF'-ized on windows.
+* binary

--- a/esyi/SolutionLock.ml
+++ b/esyi/SolutionLock.ml
@@ -261,7 +261,6 @@ let ofPath ~(sandbox : Sandbox.t) (path : Path.t) =
 
 let toPath ~sandbox ~(solution : Solution.t) (path : Path.t) =
   let open RunAsync.Syntax in
-  print_endline ("SolutionLock::toPath" ^ (Path.show path));
   Logs_lwt.debug (fun m -> m "SolutionLock.toPath %a" Path.pp path);%lwt
   let%bind () = Fs.rmPath path in
   let%bind root, node = lockOfSolution sandbox solution in

--- a/esyi/SolutionLock.ml
+++ b/esyi/SolutionLock.ml
@@ -68,7 +68,6 @@ let gitAttributesContents = {|
 * binary
 |}
 
-
 let ofPackage sandbox (pkg : Solution.Package.t) =
   let open RunAsync.Syntax in
   let%bind source =


### PR DESCRIPTION
__Issue:__ When upgrading to `esy@0.4.0`, our `esy` build is failing on Windows with some `\r` line ending issues. This is usually caused by CRLF auto-conversion by Windows git.

__Defect:__ Previously, we used a lock _file_, and normalized the newlines within strings in the JSON. However, we moved to a lock _directory_ approach in 0.4.0, and we put the actual files on disk. The problem is that, if the lock directory is checked-in to git, and checked out on Windows, the line endings may be converted from LF -> CRLF. This is likely because the `autocrlf` setting is on by default in git.

__Fix:__ We need to have explicit control over the line endings, because many of our scripts / packages run in a bash-like environment, which doesn't take kindly to `\r`s. To prevent users from running into this, we can drop a `.gitattributes` in the `esy.lock` folder to override the autocrlf setting and have git ignore the line endings.

I've also checked in a preliminary `.gitattributes` to assist #624 - if we don't have a gitattributes there, we won't be able to use esy@0.4.0 on Windows.