### PR TITLE
Make esy.lock "git-safe"

### DIFF
--- a/esyi/SolutionLock.ml
+++ b/esyi/SolutionLock.ml
@@ -61,11 +61,15 @@ and node = {
 }
 
 let indexFilename = "index.json"
-let gitAttributesFilename = ".gitattributes"
 
 let gitAttributesContents = {|
-#Set files to binary mode, so that the newlines aren't 'CRLF'-ized on windows.
-* binary
+# Set eol to LF so files aren't converted to CRLF-eol on Windows.
+* text eol=lf
+|}
+
+let gitIgnoreContents = {|
+# Reset any possible .gitignore, we want all esy.lock to be un-ignored.
+!*
 |}
 
 let ofPackage sandbox (pkg : Solution.Package.t) =
@@ -268,4 +272,6 @@ let toPath ~sandbox ~(solution : Solution.t) (path : Path.t) =
   let lock = {checksum; node; root = Solution.Package.id root;} in
   let%bind () = Fs.createDir path in
   let%bind () = Fs.writeJsonFile ~json:(to_yojson lock) Path.(path / indexFilename) in
-  Fs.writeFile ~data:gitAttributesContents Path.(path / gitAttributesFilename)
+  let%bind () = Fs.writeFile ~data:gitAttributesContents Path.(path / ".gitattributes") in
+  let%bind () = Fs.writeFile ~data:gitIgnoreContents Path.(path / ".gitignore") in
+  return ()


### PR DESCRIPTION
1. Force esy.lock/.gitattributes to use LF eol for text files

   We had `* binary` previously but that breaks `git diff` as it doesn't
   show differences in `esy.lock`. Setting `eol=lf` also works.

2. Force esy.lock/.gitignore to un-ignore all files inside lock

   We don't want to depend on user's .gitignore above which likely to
   ignore `*.install` and break some of the opam metadata.

Ref #629