### PR TITLE
esy add: update lockfile with new checksum

### DIFF
--- a/esyi/SolutionLock.ml
+++ b/esyi/SolutionLock.ml
@@ -275,3 +275,13 @@ let toPath ~sandbox ~(solution : Solution.t) (path : Path.t) =
   let%bind () = Fs.writeFile ~data:gitAttributesContents Path.(path / ".gitattributes") in
   let%bind () = Fs.writeFile ~data:gitIgnoreContents Path.(path / ".gitignore") in
   return ()
+
+let unsafeUpdateChecksum ~sandbox path =
+  let open RunAsync.Syntax in
+  let%bind lock =
+    let%bind json = Fs.readJsonFile Path.(path / indexFilename) in
+    RunAsync.ofRun (Json.parseJsonWith of_yojson json)
+  in
+  let%bind checksum = computeSandboxChecksum sandbox in
+  let lock = {lock with checksum;} in
+  Fs.writeJsonFile ~json:(to_yojson lock) Path.(path / indexFilename)

--- a/esyi/SolutionLock.mli
+++ b/esyi/SolutionLock.mli
@@ -9,3 +9,7 @@ val ofPath :
   -> Fpath.t
   -> Solution.t option RunAsync.t
 
+val unsafeUpdateChecksum :
+  sandbox:Sandbox.t
+  -> Fpath.t
+  -> unit RunAsync.t

--- a/test-e2e/install/add.test.js
+++ b/test-e2e/install/add.test.js
@@ -27,7 +27,10 @@ describe('adding dependencies', function() {
       dependencies: {},
     });
 
-    await p.esy(`add new-dep`);
+    {
+      const {stderr} = await p.esy(`add new-dep`);
+      expect(stderr).toContain('info solving esy constraints: done');
+    }
 
     await expect(helpers.readInstalledPackages(p.projectPath)).resolves.toMatchObject({
       dependencies: {
@@ -44,6 +47,11 @@ describe('adding dependencies', function() {
     );
     const packageJson = JSON.parse(packageJsonData);
     expect(packageJson.dependencies['new-dep']).toEqual('^2.0.0');
+
+    {
+      const {stderr, stdout} = await p.esy(`install`);
+      expect(stderr).not.toContain('info solving esy constraints: done');
+    }
   });
 
   test(`simply add a new dep with constraint`, async () => {
@@ -86,6 +94,11 @@ describe('adding dependencies', function() {
     );
     const packageJson = JSON.parse(packageJsonData);
     expect(packageJson.dependencies['new-dep']).toEqual('^1.0.0');
+
+    {
+      const {stderr, stdout} = await p.esy(`install`);
+      expect(stderr).not.toContain('info solving esy constraints: done');
+    }
   });
 
   test(`adding multiple deps`, async () => {
@@ -133,5 +146,10 @@ describe('adding dependencies', function() {
     const packageJson = JSON.parse(packageJsonData);
     expect(packageJson.dependencies['new-dep']).toEqual('^1.0.0');
     expect(packageJson.dependencies['another-new-dep']).toEqual('^1.0.0');
+
+    {
+      const {stderr, stdout} = await p.esy(`install`);
+      expect(stderr).not.toContain('info solving esy constraints: done');
+    }
   });
 });


### PR DESCRIPTION
Fixes #640 by updating the lockfile checksum after we update sandbox
manifest.

I don't really like this fix hence the name

```
val unsafeUpdatechecksum : ...
```

in `SolutionLock`.

but it's the least disturbing and quickest way to fix this issue and
make `esy add` usable.

We will consider changing lock format to check versions for constraints
instead of storing a checksum. But not now.