### PR TITLE
Fix race condition with multiple packages at the root

### DIFF
--- a/esy-build-package/Build.re
+++ b/esy-build-package/Build.re
@@ -45,25 +45,8 @@ module type LIFECYCLE = {
 module OutOfSourceLifecycle: LIFECYCLE = {
   let getRootPath = build => build.sourcePath;
   let getAllowedToWritePaths = (_task, _sourcePath) => [];
-  let prepare = (~cfg as _, _build) => Ok();
-
-  let setupSymlinkToBuildDir = (~cfg: Config.t, build: build) => {
-    let target = build.buildPath;
-    let%bind () =
-      switch (lstat(cfg.buildPath)) {
-      | Ok(_) => rm(cfg.buildPath)
-      | Error(_) => ok
-      };
-    let%bind () = symlink(~target, cfg.buildPath);
-    ok;
-  };
-
-  let finalize = (~cfg, build: build) =>
-    if (isRoot(build)) {
-      setupSymlinkToBuildDir(~cfg, build);
-    } else {
-      ok;
-    };
+  let prepare = (~cfg as _, _build) => ok;
+  let finalize = (~cfg as _, _build) => ok;
 };
 
 /*

--- a/esy/EsyBuildPackageApi.ml
+++ b/esy/EsyBuildPackageApi.ml
@@ -42,7 +42,6 @@ let run
     let%bind stdout, stderr, log =
       match logPath with
       | Some logPath ->
-        let logPath = Scope.SandboxPath.toPath cfg.buildCfg logPath in
         let%lwt fd = Lwt_unix.openfile
           (Path.show logPath)
           Lwt_unix.[O_WRONLY; O_CREAT]

--- a/esy/EsyBuildPackageApi.mli
+++ b/esy/EsyBuildPackageApi.mli
@@ -9,7 +9,7 @@ val build :
   ?force:bool
   -> ?buildOnly:bool
   -> ?quiet:bool
-  -> ?logPath:Scope.SandboxPath.t
+  -> ?logPath:Path.t
   -> cfg:Config.t
   -> EsyBuildPackage.Plan.t
   -> unit RunAsync.t

--- a/esy/NpmRelease.ml
+++ b/esy/NpmRelease.ml
@@ -188,7 +188,7 @@ let make
         let%lwt () = Logs_lwt.app (fun m -> m "Skipping %s" task.id) in
         return ()
       else
-        let buildPath = Scope.SandboxPath.toPath cfg.buildCfg (Plan.Task.installPath task) in
+        let buildPath = Plan.Task.installPath cfg task in
         let outputPrefixPath = Path.(outputPath / "_export") in
         Plan.exportBuild ~cfg ~outputPrefixPath buildPath
     in

--- a/esy/Plan.mli
+++ b/esy/Plan.mli
@@ -15,7 +15,9 @@ module Task : sig
     platform : System.Platform.t;
   }
 
-  val installPath : t -> Scope.SandboxPath.t
+  val installPath : Config.t -> t -> Path.t
+  val buildPath : Config.t -> t -> Path.t
+  val sourcePath : Config.t -> t -> Path.t
 
   val renderExpression :
     cfg:Config.t
@@ -62,7 +64,7 @@ val build :
   ?force:bool
   -> ?quiet:bool
   -> ?buildOnly:bool
-  -> ?logPath:Scope.SandboxPath.t
+  -> ?logPath:Path.t
   -> cfg:Config.t
   -> t
   -> EsyInstall.PackageId.t
@@ -83,6 +85,11 @@ val buildDependencies :
   -> t
   -> EsyInstall.PackageId.t
   -> unit RunAsync.t
+
+val isBuilt :
+  cfg:Config.t
+  -> Task.t
+  -> bool RunAsync.t
 
 val buildEnv : EsyInstall.SandboxSpec.t -> t -> Task.t -> Scope.SandboxEnvironment.Bindings.t Run.t
 val commandEnv : EsyInstall.SandboxSpec.t -> t -> Task.t -> Scope.SandboxEnvironment.Bindings.t Run.t

--- a/esy/Plan.mli
+++ b/esy/Plan.mli
@@ -69,6 +69,14 @@ val build :
   -> unit RunAsync.t
 (** [build task ()] builds the [task]. *)
 
+val buildRoot :
+  ?force:bool
+  -> ?quiet:bool
+  -> ?buildOnly:bool
+  -> cfg:Config.t
+  -> t
+  -> unit RunAsync.t
+
 val buildDependencies :
   ?concurrency:int
   -> cfg:Config.t

--- a/esy/bin/esyCommand.ml
+++ b/esy/bin/esyCommand.ml
@@ -477,14 +477,8 @@ module SandboxInfo = struct
     | None -> errorf "package %s isn't built yet, run 'esy build'" pkgName
     | Some None -> errorf "package %s isn't built yet, run 'esy build'" pkgName
     | Some (Some task) ->
-      let installPath =
-        Scope.SandboxPath.toPath
-          copts.CommonOptions.cfg.buildCfg
-          (Plan.Task.installPath task)
-      in
-      let%bind built = Fs.exists installPath in
-      if built
-      then return installPath
+      if%bind Plan.isBuilt ~cfg:copts.CommonOptions.cfg task
+      then return (Plan.Task.installPath copts.CommonOptions.cfg task)
       else errorf "package %s isn't built yet, run 'esy build'" pkgName
 
   let ocamlfind = resolvePackage ~pkgName:"@opam/ocamlfind"
@@ -504,9 +498,7 @@ module SandboxInfo = struct
     let ocamlpath =
       match task with
       | Some task ->
-        Scope.SandboxPath.(Plan.Task.installPath task / "lib")
-        |> Scope.SandboxPath.toPath copts.CommonOptions.cfg.buildCfg
-        |> Path.show
+        Path.(Plan.Task.installPath copts.CommonOptions.cfg task / "lib" |> show)
       | None -> ""
     in
     let env =
@@ -565,8 +557,7 @@ module SandboxInfo = struct
     let query ~ocamlfind ~task copts lib =
       let open RunAsync.Syntax in
       let ocamlpath =
-        Scope.SandboxPath.(Plan.Task.installPath task / "lib")
-        |> Scope.SandboxPath.toPath copts.CommonOptions.cfg.buildCfg
+        Path.(Plan.Task.installPath copts.CommonOptions.cfg task / "lib")
       in
       let env =
         ChildProcess.CustomEnv Astring.String.Map.(
@@ -906,15 +897,9 @@ let exec (copts : CommonOptions.t) cmd () =
   let%bind () =
     let%bind plan = SandboxInfo.plan info in
     let task = Plan.rootTask plan in
-    let installPath =
-      Scope.SandboxPath.toPath
-        copts.cfg.buildCfg
-        (Plan.Task.installPath task)
-    in
-    if%bind Fs.exists installPath then
-      return ()
-    else
-      build ~buildOnly:false copts None ()
+    if%bind Plan.isBuilt ~cfg:copts.cfg task
+    then return ()
+    else build ~buildOnly:false copts None ()
   in
   makeExecCommand
     ~env:`SandboxEnv
@@ -1037,17 +1022,13 @@ let formatPackageInfo ~built:(built : bool)  (task : Plan.Task.t) =
   let line = Printf.sprintf "%s%s %s" task.name version status in
   return line
 
-let taskIsBuilt copts task =
-  let installPath = Plan.Task.installPath task in
-  Fs.exists (Scope.SandboxPath.toPath copts.CommonOptions.cfg.buildCfg installPath)
-
 let lsBuilds (copts : CommonOptions.t) includeTransitive () =
   let open RunAsync.Syntax in
 
   let%bind (info : SandboxInfo.t) = SandboxInfo.make copts in
 
   let computeTermNode task children =
-    let%bind built = taskIsBuilt copts task in
+    let%bind built = Plan.isBuilt ~cfg:copts.cfg task in
     let%bind line = formatPackageInfo ~built task in
     return (Some (TermTree.Node { line; children; }))
   in
@@ -1065,7 +1046,7 @@ let lsLibs copts includeTransitive () =
   let%bind builtIns = SandboxInfo.libraries ~ocamlfind copts in
 
   let computeTermNode (task: Plan.Task.t) children =
-    let%bind built = taskIsBuilt copts task in
+    let%bind built = Plan.isBuilt ~cfg:copts.cfg task in
     let%bind line = formatPackageInfo ~built task in
 
     let%bind libs =
@@ -1141,7 +1122,7 @@ let lsModules copts only () =
   in
 
   let computeTermNode (task: Plan.Task.t) children =
-    let%bind built = taskIsBuilt copts task in
+    let%bind built = Plan.isBuilt ~cfg:copts.cfg task in
     let%bind line = formatPackageInfo ~built task in
 
     let%bind libs =
@@ -1358,8 +1339,7 @@ let exportDependencies (copts : CommonOptions.t) () =
     | None -> return ()
     | Some task ->
       let%lwt () = Logs_lwt.app (fun m -> m "Exporting %s@%a" pkg.name Version.pp pkg.version) in
-      let buildPath = Scope.SandboxPath.toPath copts.cfg.buildCfg
-      (Plan.Task.installPath task) in
+      let buildPath = Plan.Task.installPath copts.CommonOptions.cfg task in
       if%bind Fs.exists buildPath
       then
         let outputPrefixPath = Path.(EsyRuntime.currentWorkingDir / "_export") in
@@ -1411,11 +1391,10 @@ let importDependencies (copts : CommonOptions.t) fromPath () =
   let importBuild (_direct, pkg) =
     match%bind RunAsync.ofRun (Plan.findTaskById plan pkg.Solution.Package.id) with
     | Some task ->
-      let installPath = Scope.SandboxPath.toPath copts.cfg.buildCfg (Plan.Task.installPath task) in
-      if%bind Fs.exists installPath
+      if%bind Plan.isBuilt ~cfg:copts.cfg task
       then return ()
       else (
-        let id = task.id in
+        let id = task.Plan.Task.id in
         let pathDir = Path.(fromPath / id) in
         let pathTgz = Path.(fromPath / (id ^ ".tar.gz")) in
         if%bind Fs.exists pathDir

--- a/esy/bin/esyCommand.ml
+++ b/esy/bin/esyCommand.ml
@@ -742,13 +742,12 @@ let build ?(buildOnly=true) (copts : CommonOptions.t) cmd () =
   in
   begin match cmd with
   | None ->
-    Plan.build
+    Plan.buildRoot
       ~cfg:copts.cfg
       ~force:true
       ~quiet:true
       ~buildOnly
       plan
-      root
   | Some cmd ->
     begin match%bind RunAsync.ofRun (Plan.findTaskById plan root) with
     | None -> return ()


### PR DESCRIPTION
Previsouly `esy-build-package` was setting up a symlink for a build dir to sandbox root but that caused problems as `esy-build-package` had wrong heueristics on what root package is (it tried to compare pkg root path to sandbox root path which breaks when we have multiple packages with the same root).

Now we move setting up a symlink to `esy` which knows better about which package is the real root.

This is also in line with making `esy-build-package` dumber.