### PR TITLE
Correct handling for immutables builds with transient deps

### DIFF
--- a/esy-build-package/Build.re
+++ b/esy-build-package/Build.re
@@ -508,6 +508,7 @@ let build = (~buildOnly=true, ~force=false, ~cfg: Config.t, plan: Plan.t) => {
   let%bind (build, lifecycle) = configureBuild(~cfg, plan);
   Logs.debug(m => m("start %s", build.plan.id));
   let (module Lifecycle): (module LIFECYCLE) = lifecycle;
+  let rootPath = Lifecycle.getRootPath(build);
   let performBuild = () => {
     Logs.debug(m => m("building"));
     Logs.app(m =>
@@ -517,10 +518,10 @@ let build = (~buildOnly=true, ~force=false, ~cfg: Config.t, plan: Plan.t) => {
         build.plan.version,
       )
     );
+    Logs.app(m => m("# esy-build-package: pwd: %a", Fpath.pp, rootPath));
 
     let runBuildAndInstall = (build: build) => {
       let runEsyInstaller = installFilenames => {
-        let rootPath = Lifecycle.getRootPath(build);
         let findInstallFilenames = () => {
           let%bind items = Run.ls(rootPath);
           return(

--- a/esy-build-package/Sandbox.re
+++ b/esy-build-package/Sandbox.re
@@ -45,6 +45,9 @@ module Darwin = {
     open Run;
     let configData = renderConfig(config);
     let%bind configFilename = createTmpFile(configData);
+    Logs.debug(m =>
+      m("sandbox-exec config:@;<0 2>@[<v 2>%a@]", Fmt.lines, configData)
+    );
     let prepare = (~env, command) => {
       open Bos.OS.Cmd;
       let sandboxCommand =

--- a/esy-lib/SourceType.re
+++ b/esy-lib/SourceType.re
@@ -1,11 +1,14 @@
 [@deriving (show, ord)]
 type t =
   | Immutable
+  | ImmutableWithTransientDependencies
   | Transient;
 
 let of_yojson = (json: Json.t) =>
   switch (json) {
   | `String("immutable") => Ok(Immutable)
+  | `String("immutable-with-transient-dependencies") =>
+    Ok(ImmutableWithTransientDependencies)
   | `String("transient") => Ok(Transient)
   | _ => Error("invalid buildType")
   };
@@ -13,5 +16,7 @@ let of_yojson = (json: Json.t) =>
 let to_yojson = (sourceType: t) =>
   switch (sourceType) {
   | Immutable => `String("immutable")
+  | ImmutableWithTransientDependencies =>
+    `String("immutable-with-transient-dependencies")
   | Transient => `String("transient")
   };

--- a/esy-lib/SourceType.rei
+++ b/esy-lib/SourceType.rei
@@ -3,14 +3,17 @@
   Source type.
 
  */
+
 type t =
-  /** Immutable means sources don't change so we can build it once. */
-  | Immutable
-  /** Transient means sources can change so we should check for that and re-build */
-  | Transient;
+  | /** Sources don't change so we can build it once. */
+    Immutable
+  | /** Same as immutable but depends on transient builds. */
+    ImmutableWithTransientDependencies
+  | /** Sources can change. */
+    Transient;
 
 let pp: Fmt.t(t);
 let show: t => string;
 
-include S.COMPARABLE with type t := t
-include S.JSONABLE with type t := t
+include S.COMPARABLE with type t := t;
+include S.JSONABLE with type t := t;

--- a/esy/Plan.ml
+++ b/esy/Plan.ml
@@ -326,25 +326,25 @@ let make'
       Result.List.map ~f (Solution.allDependenciesBFS ~traverse pkg solution)
     in
 
-    let dist, sourcePath, sourceType =
+    let dist, sourceType =
       match pkg.source with
       | EsyInstall.Solution.Package.Install info ->
-        let source, _ = info.source in
-        let sourceType =
-          let hasTransientDeps =
-            let f = function
-              | _, Some {Task. sourceType = SourceType.Transient; _} -> true
-              | _, _ -> false
-            in
-            List.exists ~f dependencies
+        let hasTransientDeps =
+          let f = function
+            | _, Some {Task. sourceType = SourceType.Transient; _} -> true
+            | _, _ -> false
           in
+          List.exists ~f dependencies
+        in
+        let dist, _ = info.source in
+        let sourceType =
           if hasTransientDeps
-          then SourceType.Transient
+          then SourceType.ImmutableWithTransientDependencies
           else SourceType.Immutable
         in
-        Some source, location, sourceType
+        Some dist, sourceType
       | EsyInstall.Solution.Package.Link _ ->
-        None, location, SourceType.Transient
+        None, SourceType.Transient
     in
     let sourceType =
       if forceImmutable
@@ -355,7 +355,7 @@ let make'
     let name = PackageId.name pkgId in
     let version = PackageId.version pkgId in
     let id = buildId ~sandboxEnv ~id:pkgId ~dist ~build ~dependencies () in
-    let sourcePath = Scope.SandboxPath.ofPath buildCfg sourcePath in
+    let sourcePath = Scope.SandboxPath.ofPath buildCfg location in
 
     let exportedScope, buildScope =
 
@@ -703,6 +703,20 @@ let buildDependencies ?(concurrency=1) ~cfg plan id =
             BuildInfo.
             timeSpent;
             sourceModTime = Some mtime;
+          } in
+          return Changes.Yes
+        end
+      | SourceType.ImmutableWithTransientDependencies ->
+        begin match changesInDependencies with
+        | Changes.No ->
+          Logs_lwt.debug (fun m -> m "building %a: skipping" PackageId.pp task.Task.pkgId);%lwt
+          return Changes.No
+        | Changes.Yes ->
+          let%bind timeSpent = LwtTaskQueue.submit queue (run ~quiet:false task) in
+          let%bind () = BuildInfo.toFile infoPath {
+            BuildInfo.
+            timeSpent;
+            sourceModTime = None;
           } in
           return Changes.Yes
         end

--- a/esy/Scope.ml
+++ b/esy/Scope.ml
@@ -132,8 +132,8 @@ end = struct
 
   let storePath scope =
     match scope.sourceType with
-    | BuildManifest.SourceType.Immutable -> SandboxPath.store
-    | BuildManifest.SourceType.Transient -> SandboxPath.localStore
+    | Immutable -> SandboxPath.store
+    | ImmutableWithTransientDependencies | Transient -> SandboxPath.localStore
 
   let buildPath scope =
     let storePath = storePath scope in
@@ -160,7 +160,7 @@ end = struct
   let rootPath scope =
     match scope.build.buildType, scope.sourceType with
     | InSource, _  -> buildPath scope
-    | JbuilderLike, Immutable -> buildPath scope
+    | JbuilderLike, (Immutable | ImmutableWithTransientDependencies) -> buildPath scope
     | JbuilderLike, Transient -> scope.sourcePath
     | OutOfSource, _ -> scope.sourcePath
     | Unsafe, Immutable  -> buildPath scope
@@ -197,8 +197,8 @@ end = struct
     | "etc" -> p SandboxPath.(installPath / "etc")
     | "dev" -> b (
       match scope.sourceType with
-      | SourceType.Immutable -> false
-      | SourceType.Transient -> true)
+      | Immutable | ImmutableWithTransientDependencies -> false
+      | Transient -> true)
     | _ -> None
 
   let buildEnv scope =
@@ -471,8 +471,8 @@ let toOpamEnv ~ocamlVersion (scope : t) (name : OpamVariable.Full.t) =
     | _, "build-id" -> Some (string (PackageScope.id scope))
     | _, "dev" -> Some (bool (
       match PackageScope.sourceType scope with
-      | BuildManifest.SourceType.Immutable -> false
-      | BuildManifest.SourceType.Transient -> true))
+      | Immutable | ImmutableWithTransientDependencies -> false
+      | Transient -> true))
     | _, "prefix" -> Some (configPath installPath)
     | _, "bin" -> Some (configPath SandboxPath.(installPath / "bin"))
     | _, "sbin" -> Some (configPath SandboxPath.(installPath / "sbin"))


### PR DESCRIPTION
Previously we handled such builds as transients but this is not correct - `_build`-type builds are really not that correct to be performed on cached sources.

Also we can skip staleness check for such builds.

We introduce new source type called `ImmutableWithTransientDependencies` which is being built into local store but uses relocatio strategy not to pollute the source dir which is cached.