### PR TITLE
Restore incremental builds for root package on Windows

### DIFF
--- a/esy-lib/Fs.ml
+++ b/esy-lib/Fs.ml
@@ -99,17 +99,6 @@ let unlink (path : Path.t) =
   let%lwt () = Lwt_unix.unlink path in
   RunAsync.return ()
 
-let readlink (path : Path.t) =
-  let path = Path.show path in
-  let%lwt link = Lwt_unix.readlink path in
-  RunAsync.return (Path.v link)
-
-let symlink ~src target =
-  let src = Path.show src in
-  let target = Path.show target in
-  let%lwt () = Lwt_unix.symlink src target in
-  RunAsync.return ()
-
 let rename ~src target =
   let src = Path.show src in
   let target = Path.show target in
@@ -353,6 +342,55 @@ let withTempFile ~data f =
       (* never fail on removing a temp file. *)
       try%lwt Lwt_unix.unlink path
       with Unix.Unix_error _ -> Lwt.return ())
+
+let readlink (path : Path.t) =
+  let open RunAsync.Syntax in
+  let path = Path.show path in
+  try%lwt
+    let%lwt link = Lwt_unix.readlink path in
+    return (Path.v link)
+  with Unix.Unix_error (err, _, _) ->
+    errorf "readlink %s: %s" path (Unix.error_message err)
+
+let readlinkOpt (path : Path.t) =
+  let open RunAsync.Syntax in
+  let path = Path.show path in
+  try%lwt
+    let%lwt link = Lwt_unix.readlink path
+    in return (Some (Path.v link))
+  with
+    | Unix.Unix_error (ENOENT, _, _) -> return None
+    | Unix.Unix_error (err, _, _) ->
+      errorf "readlink %s: %s" path (Unix.error_message err)
+
+let symlink ?(force=false) ~src dst =
+  let open RunAsync.Syntax in
+  let symlink' src dst =
+    let src = Path.show src in
+    let dst = Path.show dst in
+    try%lwt
+      let%lwt () = Lwt_unix.symlink src dst in
+      RunAsync.return ()
+    with Unix.Unix_error (err, _, _) ->
+      errorf "symlink %s -> %s: %s" src dst (Unix.error_message err)
+  in
+  if force
+  then
+    match%lwt readlinkOpt dst with
+    | Error _ ->
+      (* try rm path but ignore errors *)
+      let%lwt _: unit Run.t = rmPath dst in
+      symlink' src dst
+    | Ok None -> symlink' src dst
+    | Ok Some prevSrc ->
+      if Path.compare prevSrc src = 0
+      then
+        return ()
+      else
+        let%bind () = unlink dst in
+        symlink' src dst
+  else
+    symlink' src dst
 
 let realpath path =
   let open RunAsync.Syntax in

--- a/esy-lib/Fs.mli
+++ b/esy-lib/Fs.mli
@@ -20,8 +20,13 @@ val isDir : Path.t -> bool RunAsync.t
 
 val unlink : Path.t -> unit RunAsync.t
 
+(** readlink *)
 val readlink : Path.t -> Path.t RunAsync.t
-val symlink : src:Path.t -> Path.t -> unit RunAsync.t
+
+(** Link readlink but returns [None] if path doesn't not exist. *)
+val readlinkOpt : Path.t -> Path.t option RunAsync.t
+
+val symlink : ?force:bool -> src:Path.t -> Path.t -> unit RunAsync.t
 val rename : src:Path.t -> Path.t -> unit RunAsync.t
 
 val realpath : Path.t -> Path.t RunAsync.t

--- a/esy/Plan.ml
+++ b/esy/Plan.ml
@@ -673,9 +673,9 @@ let buildRoot ?quiet ?buildOnly ~cfg plan =
     let%bind () =
       let buildPath = Task.buildPath cfg task in
       let buildPathLink = EsyInstall.SandboxSpec.buildPath cfg.Config.spec in
-      let%bind () = Fs.rmPath buildPathLink in
-      let%bind () = Fs.symlink ~src:buildPath buildPathLink in
-      return ()
+      match System.Platform.host with
+      | Windows -> return ()
+      | _ -> Fs.symlink ~force:true ~src:buildPath buildPathLink
     in
     return ()
   | Some None


### PR DESCRIPTION
This restores incremental builds for root package on Windows.

It was broken due to build removing symlink from `_esy/default/build` which was
hanlded as a directory instead (not sure what's the exact reason but the target
was cygwin path rather than windows path).

This PR skips creating symlink on Windows completely which goes in line with
keeping Windows symlink-free (and thus require no admin privelegies).

Also this PR refactors build-symlink creation on Linux/macOS by moving this
code-path into `Fs.symlink ?force`.