### PR TITLE
Allow to refer to packages by their names

### DIFF
--- a/esy/Plan.ml
+++ b/esy/Plan.ml
@@ -556,8 +556,9 @@ let make
 
 let findTaskById plan id =
   match PackageId.Map.find_opt id plan.tasks with
-  | None -> Run.return None
-  | Some task -> Run.return task
+  | None -> None
+  | Some None -> None
+  | Some Some task -> Some task
 
 let findTaskByName plan name =
   let f _id pkg =
@@ -565,7 +566,7 @@ let findTaskByName plan name =
   in
   match Solution.find f plan.solution with
   | None -> None
-  | Some (id, _) -> Some (PackageId.Map.find id plan.tasks)
+  | Some (id, _) -> PackageId.Map.find id plan.tasks
 
 let findTaskByNameVersion plan name version =
   let compare = [%derive.ord: string * Version.t] in
@@ -574,7 +575,7 @@ let findTaskByNameVersion plan name version =
   in
   match Solution.find f plan.solution with
   | None -> None
-  | Some (id, _) -> Some (PackageId.Map.find id plan.tasks)
+  | Some (id, _) -> PackageId.Map.find id plan.tasks
 
 let rootTask plan =
   let id = (Solution.root plan.solution).id in

--- a/esy/Plan.mli
+++ b/esy/Plan.mli
@@ -31,9 +31,10 @@ end
 type t
 (** A collection of tasks. *)
 
-val findTaskById : t -> EsyInstall.PackageId.t -> Task.t option Run.t
-val findTaskByName : t -> string -> Task.t option option
-val findTaskByNameVersion : t -> string -> EsyInstall.Version.t -> Task.t option option
+val findTaskById : t -> EsyInstall.PackageId.t -> Task.t option
+val findTaskByName : t -> string -> Task.t option
+val findTaskByNameVersion : t -> string -> EsyInstall.Version.t -> Task.t option
+
 val rootTask : t -> Task.t
 val allTasks : t -> Task.t list
 

--- a/esy/bin/esyCommand.ml
+++ b/esy/bin/esyCommand.ml
@@ -602,15 +602,6 @@ let resolvedPathTerm =
   let print = Path.pp in
   Arg.conv ~docv:"PATH" (parse, print)
 
-(* let pkgPathTerm = *)
-(*   let open Cmdliner in *)
-(*   let doc = "Path to package." in *)
-(*   Arg.( *)
-(*     value *)
-(*     & pos 0  (some resolvedPathTerm) None *)
-(*     & info [] ~doc *)
-(*   ) *)
-
 let pkgIdTerm =
   let open Cmdliner in
   let pkgIdConv =
@@ -629,10 +620,7 @@ let pkgIdTerm =
     & info [] ~doc
   )
 
-let withBuildTaskById
-    ~(info : SandboxInfo.t)
-    id
-    f =
+let withTask info id f =
   let open RunAsync.Syntax in
   let%bind plan = SandboxInfo.plan info in
   match id with
@@ -657,7 +645,7 @@ let buildPlan copts id () =
     print_endline data;
     return ()
   in
-  withBuildTaskById ~info id f
+  withTask info id f
 
 let buildShell (copts : CommonOptions.t) packagePath () =
   let open RunAsync.Syntax in
@@ -683,7 +671,8 @@ let buildShell (copts : CommonOptions.t) packagePath () =
     | Unix.WEXITED n
     | Unix.WSTOPPED n
     | Unix.WSIGNALED n -> exit n
-  in withBuildTaskById ~info packagePath f
+  in
+  withTask info packagePath f
 
 let buildPackage (copts : CommonOptions.t) packagePath () =
   let open RunAsync.Syntax in
@@ -704,7 +693,7 @@ let buildPackage (copts : CommonOptions.t) packagePath () =
       plan
       task.Plan.Task.pkgId
   in
-  withBuildTaskById ~info packagePath f
+  withTask info packagePath f
 
 let build ?(buildOnly=true) (copts : CommonOptions.t) cmd () =
   let open RunAsync.Syntax in
@@ -768,7 +757,8 @@ let makeEnvCommand ~computeEnv ~header copts asJson packagePath () =
       ) in
     let%lwt () = Lwt_io.print source in
     return ()
-  in withBuildTaskById ~info packagePath f
+  in
+  withTask info packagePath f
 
 let buildEnv =
   let header (task : Plan.Task.t) =

--- a/esy/bin/esyCommand.ml
+++ b/esy/bin/esyCommand.ml
@@ -6,6 +6,55 @@ module SolutionLock = EsyInstall.SolutionLock
 module Version = EsyInstall.Version
 module PackageId = EsyInstall.PackageId
 
+type pkgRef =
+  | PkgByName of string
+  | PkgByNameVersion of string * Version.t
+  | PkgById of PackageId.t
+
+let pp_pkgRef fmt pkgRef =
+  match pkgRef with
+  | PkgById id -> EsyInstall.PackageId.pp fmt id
+  | PkgByName name -> Fmt.string fmt name
+  | PkgByNameVersion (name, version) -> Fmt.pf fmt "%s@%a" name Version.pp version
+
+let pkgRefTerm =
+  let open Cmdliner in
+  let open Result.Syntax in
+  let parse v =
+    let split = Astring.String.cut ~sep:"@" in
+    let rec parsename v =
+      match split v with
+      | Some ("", v) ->
+        let name, rest = parsename v in
+        "@" ^ name, rest
+      | Some (name, rest) ->
+        name, Some rest
+      | None -> v, None
+    in
+    match parsename v with
+    | name, Some ""
+    | name, None -> return (PkgByName name)
+    | name, Some rest ->
+      begin match split rest with
+      | Some (version, digest) ->
+        let%bind version = Version.parse version in
+        return (PkgById (PackageId.make name version (Some digest)))
+      | None ->
+        let%bind version = Version.parse rest in
+        return (PkgByNameVersion (name, version))
+      end
+  in
+  let pkgIdConv =
+    let parse v = Rresult.R.error_to_msg ~pp_error:Fmt.string (parse v) in
+    Arg.conv ~docv:"PATH" (parse, pp_pkgRef)
+  in
+  let doc = "Package identifier." in
+  Arg.(
+    value
+    & pos 0  (some pkgIdConv) None
+    & info [] ~doc
+  )
+
 let runAsyncToCmdlinerRet res =
   match Lwt_main.run res with
   | Ok v -> `Ok v
@@ -463,8 +512,7 @@ module SandboxInfo = struct
     in
     match task with
     | None -> errorf "package %s isn't built yet, run 'esy build'" pkgName
-    | Some None -> errorf "package %s isn't built yet, run 'esy build'" pkgName
-    | Some (Some task) ->
+    | Some task ->
       if%bind Plan.isBuilt ~cfg:copts.CommonOptions.cfg task
       then return (Plan.Task.installPath copts.CommonOptions.cfg task)
       else errorf "package %s isn't built yet, run 'esy build'" pkgName
@@ -602,35 +650,24 @@ let resolvedPathTerm =
   let print = Path.pp in
   Arg.conv ~docv:"PATH" (parse, print)
 
-let pkgIdTerm =
-  let open Cmdliner in
-  let pkgIdConv =
-    let parse v =
-      match EsyInstall.PackageId.parse v with
-      | Ok v -> Ok v
-      | Error err -> Error (`Msg err)
-    in
-    let print = EsyInstall.PackageId.pp in
-    Arg.conv ~docv:"PATH" (parse, print)
-  in
-  let doc = "Package identifier." in
-  Arg.(
-    value
-    & pos 0  (some pkgIdConv) None
-    & info [] ~doc
-  )
-
-let withTask info id f =
+let withTask info ref f =
   let open RunAsync.Syntax in
   let%bind plan = SandboxInfo.plan info in
-  match id with
-  | Some id ->
-    let name = PackageId.name id in
-    let version = PackageId.version id in
+  match ref with
+  | Some (PkgByName name as ref) ->
+    begin match Plan.findTaskByName plan name with
+    | Some task -> f task
+    | None -> errorf "no build found for package name %a" pp_pkgRef ref
+    end
+  | Some (PkgByNameVersion (name, version) as ref) ->
     begin match Plan.findTaskByNameVersion plan name version with
-    | Some Some task -> f task
-    | Some None
-    | None -> errorf "no build defined for %a" EsyInstall.PackageId.pp id
+    | Some task -> f task
+    | None -> errorf "no build found for %a" pp_pkgRef ref
+    end
+  | Some (PkgById id) ->
+    begin match Plan.findTaskById plan id with
+    | None -> errorf "no build found for %a" EsyInstall.PackageId.pp id
+    | Some task -> f task
     end
   | None -> f (Plan.rootTask plan)
 
@@ -716,7 +753,7 @@ let build ?(buildOnly=true) (copts : CommonOptions.t) cmd () =
       ~buildOnly
       plan
   | Some cmd ->
-    begin match%bind RunAsync.ofRun (Plan.findTaskById plan root) with
+    begin match Plan.findTaskById plan root with
     | None -> return ()
     | Some task ->
       let p =
@@ -953,7 +990,7 @@ let makeLsCommand ~computeTermNode ~includeTransitive (info: SandboxInfo.t) =
     else (
       let isRoot = Solution.isRoot pkg solution in
       seen := PackageId.Set.add id !seen;
-      match%bind RunAsync.ofRun (Plan.findTaskById plan id) with
+      match Plan.findTaskById plan id with
       | None -> return None
       | Some task ->
         let%bind children =
@@ -1303,10 +1340,7 @@ let exportDependencies (copts : CommonOptions.t) () =
   let%bind solution = SandboxInfo.solution info in
 
   let exportBuild (_, pkg) =
-    let task =
-      RunAsync.ofRun (Plan.findTaskById plan pkg.Solution.Package.id)
-    in
-    match%bind task with
+    match Plan.findTaskById plan pkg.Solution.Package.id with
     | None -> return ()
     | Some task ->
       let%lwt () = Logs_lwt.app (fun m -> m "Exporting %s@%a" pkg.name Version.pp pkg.version) in
@@ -1360,7 +1394,7 @@ let importDependencies (copts : CommonOptions.t) fromPath () =
   in
 
   let importBuild (_direct, pkg) =
-    match%bind RunAsync.ofRun (Plan.findTaskById plan pkg.Solution.Package.id) with
+    match Plan.findTaskById plan pkg.Solution.Package.id with
     | Some task ->
       if%bind Plan.isBuilt ~cfg:copts.cfg task
       then return ()
@@ -1574,7 +1608,7 @@ let makeCommands ~sandbox () =
       Term.(
         const buildPlan
         $ commonOpts
-        $ pkgIdTerm
+        $ pkgRefTerm
         $ Cli.setupLogTerm
       );
 
@@ -1584,7 +1618,7 @@ let makeCommands ~sandbox () =
       Term.(
         const buildShell
         $ commonOpts
-        $ pkgIdTerm
+        $ pkgRefTerm
         $ Cli.setupLogTerm
       );
 
@@ -1594,7 +1628,7 @@ let makeCommands ~sandbox () =
       Term.(
         const buildPackage
         $ commonOpts
-        $ pkgIdTerm
+        $ pkgRefTerm
         $ Cli.setupLogTerm
       );
 
@@ -1616,7 +1650,7 @@ let makeCommands ~sandbox () =
         const buildEnv
         $ commonOpts
         $ Arg.(value & flag & info ["json"]  ~doc:"Format output as JSON")
-        $ pkgIdTerm
+        $ pkgRefTerm
         $ Cli.setupLogTerm
       );
 
@@ -1628,7 +1662,7 @@ let makeCommands ~sandbox () =
         const commandEnv
         $ commonOpts
         $ Arg.(value & flag & info ["json"]  ~doc:"Format output as JSON")
-        $ pkgIdTerm
+        $ pkgRefTerm
         $ Cli.setupLogTerm
       );
 
@@ -1640,7 +1674,7 @@ let makeCommands ~sandbox () =
         const sandboxEnv
         $ commonOpts
         $ Arg.(value & flag & info ["json"]  ~doc:"Format output as JSON")
-        $ pkgIdTerm
+        $ pkgRefTerm
         $ Cli.setupLogTerm
       );
 

--- a/test-e2e/common/build-env.test.js
+++ b/test-e2e/common/build-env.test.js
@@ -90,4 +90,26 @@ describe('esy build-env', () => {
     expect(env.devDep__local).toBe(undefined);
     expect(env.devDep__global).toBe(undefined);
   });
+
+  it('allows to query build env for a dep (by name)', async () => {
+    const p = await createTestSandbox();
+    await p.fixture(...fixture.makeSimpleProject(p));
+
+    await p.esy('install');
+    await p.esy('build');
+
+    const env = JSON.parse((await p.esy('build-env --json dep')).stdout);
+    expect(env.cur__name).toBe('dep');
+  });
+
+  it('allows to query build env for a dep (by name, version)', async () => {
+    const p = await createTestSandbox();
+    await p.fixture(...fixture.makeSimpleProject(p));
+
+    await p.esy('install');
+    await p.esy('build');
+
+    const env = JSON.parse((await p.esy('build-env --json dep@1.0.0')).stdout);
+    expect(env.cur__name).toBe('dep');
+  });
 });

--- a/test-e2e/common/build-plan.test.js
+++ b/test-e2e/common/build-plan.test.js
@@ -1,0 +1,43 @@
+// @flow
+
+const path = require('path');
+const fs = require('fs-extra');
+
+const {createTestSandbox, promiseExec, skipSuiteOnWindows} = require('../test/helpers');
+const fixture = require('./fixture.js');
+
+describe('esy build-plan', () => {
+  it('shows build plan in JSON', async () => {
+    const p = await createTestSandbox();
+    await p.fixture(...fixture.makeSimpleProject(p));
+
+    await p.esy('install');
+    await p.esy('build');
+
+    const plan = JSON.parse((await p.esy('build-plan')).stdout);
+
+    expect(plan.name).toBe('simple-project');
+  });
+
+  it('shows build plan for a dep (by name)', async () => {
+    const p = await createTestSandbox();
+    await p.fixture(...fixture.makeSimpleProject(p));
+
+    await p.esy('install');
+    await p.esy('build');
+
+    const plan = JSON.parse((await p.esy('build-plan dep')).stdout);
+    expect(plan.name).toBe('dep');
+  });
+
+  it('shows build plan for a dep (by name)', async () => {
+    const p = await createTestSandbox();
+    await p.fixture(...fixture.makeSimpleProject(p));
+
+    await p.esy('install');
+    await p.esy('build');
+
+    const plan = JSON.parse((await p.esy('build-plan dep@1.0.0')).stdout);
+    expect(plan.name).toBe('dep');
+  });
+});


### PR DESCRIPTION
Now we require to pass `name@version` to commands which accept packages as arguments:

    % esy build-plan @opam/reason@3.3.7
    % esy build-shell @opam/reason@3.3.7
    % esy build-package @opam/reason@3.3.7

which is cumbersome.

This PR allows to refer to a package just by its name:

    % esy build-plan @opam/reason
    % esy build-shell @opam/reason
    % esy build-package @opam/reason

But still allow to pass version (and even digest for packages with those).