### PR TITLE
Generate batch files for non-js npm bins

### DIFF
--- a/test-e2e/install/link.test.js
+++ b/test-e2e/install/link.test.js
@@ -88,10 +88,11 @@ describe(`installing linked packages`, () => {
       },
     });
 
-    const binPath = path.join(p.projectPath, '_esy', 'default', 'bin', 'dep');
-    expect(await helpers.exists(binPath)).toBeTruthy();
-    const binContents = await helpers.readFile(binPath);
-    expect(binContents.toString()).toEqual('something');
+    if (helpers.isWindows) {
+      await expect(p.esy('where dep')).resolves.not.toThrow();
+    } else {
+      await expect(p.esy('which dep')).resolves.not.toThrow();
+    }
   });
 
   test('it should install local packages of dependencies (path: -> path:)', async () => {


### PR DESCRIPTION
Previously we used symlinks but now we generate batch files instead. Of course that would only work in case the dest has `.cmd` or `.exe` extension.