### PR TITLE
Correctly handle devDependencies when planning build

### DIFF
--- a/esy-lib/Run.ml
+++ b/esy-lib/Run.ml
@@ -110,4 +110,16 @@ module List = struct
     in
     fold (Ok init) xs
 
+  let waitAll xs =
+    let rec _waitAll xs = match xs with
+      | [] -> return ()
+      | x::xs ->
+        let f () = _waitAll xs in
+        bind ~f x
+    in
+    _waitAll xs
+
+  let mapAndWait ~f xs =
+    waitAll (List.map ~f xs)
+
 end

--- a/esy-lib/Run.mli
+++ b/esy-lib/Run.mli
@@ -85,5 +85,8 @@ end
 
 module List : sig
   val foldLeft : f:('a -> 'b -> 'a t) -> init:'a -> 'b list -> 'a t
+
+  val waitAll : unit t list -> unit t
+  val mapAndWait : f:('a -> unit t) -> 'a list -> unit t
 end
 


### PR DESCRIPTION
We were trying to plan devDependencies along with the root build and keep them away from scope by doing this check

    if PackageId.Set.mem id pkg.devDependencies
    then skip
    else ...

This is not so bad as `pkg.devDependencies` is a difference between `"devDependencies"` and `"dependencies"` in `package.json`. This is why it is so subtle - pakckages in `pkg.devDependencies` were not propagated to the root because of this.

So if you have a package which specify only `devDependencies.ocaml` then even if its other dependencies depend on `ocaml` it won't see `ocaml`:

    % esy b which ocamlc
    FAIL

Instead of this dumb check we now iterate over all devDependencies after we build plan for the root.