### PR TITLE
Remove $PATH duplication in command-env/sandbox-env

### DIFF
--- a/esy/Plan.ml
+++ b/esy/Plan.ml
@@ -830,8 +830,6 @@ let buildDependencies ?concurrency ~cfg plan id =
 
 let exposeUserEnv scope =
   scope
-  |> Scope.exposeUserEnvWith Scope.SandboxEnvironment.Bindings.suffixValue "PATH"
-  |> Scope.exposeUserEnvWith Scope.SandboxEnvironment.Bindings.suffixValue "MAN_PATH"
   |> Scope.exposeUserEnvWith Scope.SandboxEnvironment.Bindings.value "SHELL"
 
 let exposeDevDependenciesEnv plan task scope =


### PR DESCRIPTION
We were adding `$PATH` and `$MAN_PATH` there but it isn't really neccessary as original bindings for those variables are "open" (contain references to the previously defined values).