### PR TITLE
Azure CI - Windows: Get builds completely green

### DIFF
--- a/.ci/build-windows.yml
+++ b/.ci/build-windows.yml
@@ -58,9 +58,8 @@ steps:
     displayName: 'esy install'
     continueOnError: true
 
-  - script: 'esy install'
-    displayName: 'esy install'
-    continueOnError: true
+  - script: 'powershell ./.ci/esy-install-windows.ps1'
+    displayName: 'esy-install-windows.ps1'
 
   - task: PublishBuildArtifacts@1
     displayName: 'Cache: Upload source tarballs'

--- a/.ci/build-windows.yml
+++ b/.ci/build-windows.yml
@@ -50,14 +50,6 @@ steps:
   - script: 'cp scripts/build/patched-bash-exec.js C:\npm\prefix\node_modules\esy\node_modules\esy-bash\bash-exec.js'
     displayName: 'Workaround for issue fixed in bryphe/esy-bash#18'
 
-  - script: 'esy install'
-    displayName: 'esy install'
-    continueOnError: true
-
-  - script: 'esy install'
-    displayName: 'esy install'
-    continueOnError: true
-
   - script: 'powershell ./.ci/esy-install-windows.ps1'
     displayName: 'esy-install-windows.ps1'
 

--- a/.ci/esy-install-windows.ps1
+++ b/.ci/esy-install-windows.ps1
@@ -1,0 +1,11 @@
+# Ignore failures for the first two 'esy install' runs
+# This works around windows-specific issues with intermittency in failing esy install
+esy install
+esy install
+
+# For the last run, we'll check the exit code and fail if it failed
+esy install
+
+if ($LastExitCode -ne 0) {
+    exit $LastExitCode
+}


### PR DESCRIPTION
__Issue:__ The change in #663 is failing because the `DownloadPublishArtifact` task only gets the latest 'Succeeded' build - which doesn't include builds that 'Succeeded With Errors'.

__Fix:__ The esy-install retry logic keeps the build from being completely green, so we'll wrap that in a Powershell script.

This should unblock #663 