### PR TITLE
CI: fix paths for caching tarballs

### DIFF
--- a/.ci/build-nix.yml
+++ b/.ci/build-nix.yml
@@ -14,7 +14,7 @@ steps:
     displayName: 'Cache: Upload source tarballs'
     condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
     inputs:
-        pathToPublish: '$(ESY__CACHE_SOURCE_TARBALL_PATH)'
+        pathToPublish: '$(ESYCI__CACHE_INSTALL)'
         artifactName: 'cache-$(Agent.OS)-source-tarballs'
         parallel: true
         parallelCount: 8
@@ -26,7 +26,7 @@ steps:
     displayName: 'Cache: Upload install folder'
     condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
     inputs:
-        pathToPublish: '$(ESY__CACHE_INSTALL_PATH)'
+        pathToPublish: '$(ESYCI__CACHE_BUILD)'
         artifactName: 'cache-$(Agent.OS)-install'
         parallel: true
         parallelCount: 8

--- a/.ci/build-release.yml
+++ b/.ci/build-release.yml
@@ -16,8 +16,8 @@ jobs:
         vmImage: ubuntu-16.04
 
     variables:
-        ESY__CACHE_INSTALL_PATH: /home/vsts/.esy/3_____________________________________________________________________/i/
-        ESY__CACHE_SOURCE_TARBALL_PATH: /home/vsts/.esy/source-tarballs
+        ESYCI__CACHE_BUILD: /home/vsts/.esy/3_____________________________________________________________________/i/
+        ESYCI__CACHE_INSTALL: /home/vsts/.esy/source/i
 
     steps:
       - script: sudo apt-get update
@@ -38,8 +38,8 @@ jobs:
       demands: node.js
 
     variables:
-        ESY__CACHE_INSTALL_PATH: /Users/vsts/.esy/3____________________________________________________________________/i/
-        ESY__CACHE_SOURCE_TARBALL_PATH: /Users/vsts/.esy/source-tarballs
+        ESYCI__CACHE_BUILD: /Users/vsts/.esy/3____________________________________________________________________/i/
+        ESYCI__CACHE_INSTALL: /Users/vsts/.esy/source/i
 
     steps:
       - script: brew install gmp
@@ -60,8 +60,8 @@ jobs:
       demands: npm
 
     variables:
-        ESY__CACHE_INSTALL_PATH: C:\Users\VssAdministrator\.esy\3_\i
-        ESY__CACHE_SOURCE_TARBALL_PATH: C:\Users\VssAdministrator\.esy\source-tarballs
+        ESYCI__CACHE_BUILD: C:\Users\VssAdministrator\.esy\3_\i
+        ESYCI__CACHE_INSTALL: C:\Users\VssAdministrator\.esy\source\i
 
     steps:
       - template: build-windows.yml

--- a/.ci/build-windows.yml
+++ b/.ci/build-windows.yml
@@ -21,7 +21,7 @@ steps:
   - task: CopyFiles@2
     inputs:
         sourceFolder: '$(System.ArtifactsDirectory)\build-cache-windows-source-tarballs'
-        targetFolder: '$(ESY__CACHE_SOURCE_TARBALL_PATH)'
+        targetFolder: '$(ESYCI__CACHE_INSTALL)'
 
   - task: DownloadBuildArtifacts@0
     displayName: 'Cache: Restore install'
@@ -39,7 +39,7 @@ steps:
   - task: CopyFiles@2
     inputs:
         sourceFolder: '$(System.ArtifactsDirectory)\build-cache-windows-install'
-        targetFolder: '$(ESY__CACHE_INSTALL_PATH)'
+        targetFolder: '$(ESYCI__CACHE_BUILD)'
 
   - script: 'npm install -g esy@0.4.3'
     displayName: 'npm install -g esy@0.4.3'
@@ -54,7 +54,7 @@ steps:
     displayName: 'Cache: Upload source tarballs'
     condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
     inputs:
-        pathToPublish: '$(ESY__CACHE_SOURCE_TARBALL_PATH)'
+        pathToPublish: '$(ESYCI__CACHE_INSTALL)'
         artifactName: 'cache-$(Agent.OS)-source-tarballs'
         parallel: true
         parallelCount: 8
@@ -69,7 +69,7 @@ steps:
     displayName: 'Cache: Upload install folder'
     condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
     inputs:
-        pathToPublish: '$(ESY__CACHE_INSTALL_PATH)'
+        pathToPublish: '$(ESYCI__CACHE_BUILD)'
         artifactName: 'cache-$(Agent.OS)-install'
         parallel: true
         parallelCount: 8


### PR DESCRIPTION
Also use `ESYCI__*` prefix for CI related env vars.