### PR TITLE
Improvements to monorepo workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,16 +110,14 @@ refmt::
 # Test
 #
 
-JEST = $(BIN)/jest
-
 test-unit::
-	@esy b dune build @runtest
+	esy test:unit
 
 test-e2e::
-	@$(BIN)/jest test-e2e
+	esy test:e2e
 
 test-e2e-slow::
-	@node ./test-e2e-slow/run-slow-tests
+	esy test:e2e-slow
 
 test::
 	@echo "Running test suite: unit tests"

--- a/esy/BuildManifest.ml
+++ b/esy/BuildManifest.ml
@@ -365,7 +365,7 @@ let ofPath ?manifest (path : Path.t) =
 let ofInstallationLocation ~cfg (pkg : Solution.Package.t) (loc : Installation.location) =
   let open RunAsync.Syntax in
   match pkg.source with
-  | Solution.Package.Link { path; manifest; } ->
+  | Link { path; manifest; } ->
     let dist = Dist.LocalPath {path; manifest;} in
     let%bind res =
       DistResolver.resolve
@@ -412,7 +412,7 @@ let ofInstallationLocation ~cfg (pkg : Solution.Package.t) (loc : Installation.l
       return (Some manifest, res.DistResolver.paths)
     end
 
-  | Solution.Package.Install { source = _; opam = Some opam } ->
+  | Install { source = _; opam = Some opam } ->
     let name = Some (OpamResolution.name opam) in
     let version = Some (OpamResolution.version opam) in
     let%bind opamfile = OpamResolution.opam opam in
@@ -427,7 +427,7 @@ let ofInstallationLocation ~cfg (pkg : Solution.Package.t) (loc : Installation.l
     in
     return (Some manifest, Path.Set.empty)
 
-  | Solution.Package.Install { source = source, _; opam = None } ->
+  | Install { source = source, _; opam = None } ->
     let manifest = Dist.manifest source in
     let%bind manifest, paths = ofPath ?manifest loc in
     let%bind manifest =

--- a/esy/NpmRelease.ml
+++ b/esy/NpmRelease.ml
@@ -161,6 +161,7 @@ let make
     let%lwt () = Logs_lwt.app (fun m -> m "Building packages") in
     let%bind () =
       Plan.buildDependencies
+        ~buildLinked:true
         ~concurrency
         ~cfg
         plan

--- a/esy/Plan.ml
+++ b/esy/Plan.ml
@@ -345,7 +345,7 @@ let make'
 
     let dist, sourceType =
       match pkg.source with
-      | EsyInstall.Solution.Package.Install info ->
+      | Install info ->
         let hasTransientDeps =
           let f = function
             | _, Some {Task. sourceType = SourceType.Transient; _} -> true
@@ -360,7 +360,7 @@ let make'
           else SourceType.Immutable
         in
         Some dist, sourceType
-      | EsyInstall.Solution.Package.Link _ ->
+      | Link _ ->
         None, SourceType.Transient
     in
     let sourceType =

--- a/esy/Plan.ml
+++ b/esy/Plan.ml
@@ -9,7 +9,7 @@ module Version = EsyInstall.Version
 module Task = struct
   type t = {
     id : string;
-    pkgId : PackageId.t;
+    pkg : Package.t;
     name : string;
     version : Version.t;
     env : Scope.SandboxEnvironment.t;
@@ -72,7 +72,7 @@ module Task = struct
     let expr = Scope.SandboxValue.render cfg.Config.buildCfg expr in
     return expr
 
-  let pp fmt task = PackageId.pp fmt task.pkgId
+  let pp fmt task = PackageId.pp fmt task.pkg.id
 
 end
 
@@ -489,7 +489,7 @@ let make'
     let task = {
       Task.
       id;
-      pkgId;
+      pkg;
       name;
       version;
       buildCommands;
@@ -647,9 +647,9 @@ end
 let isBuilt ~cfg task = Fs.exists (Task.installPath cfg task)
 
 let buildTask ?quiet ?buildOnly ?logPath ~cfg task =
-  Logs_lwt.debug (fun m -> m "build %a" PackageId.pp task.Task.pkgId);%lwt
+  Logs_lwt.debug (fun m -> m "build %a" Task.pp task);%lwt
   let plan = Task.plan task in
-  let label = Fmt.strf "build %a" PackageId.pp task.Task.pkgId in
+  let label = Fmt.strf "build %a" Task.pp task in
   Perf.measureLwt ~label (fun () -> EsyBuildPackageApi.build ?quiet ?buildOnly ?logPath ~cfg plan)
 
 let build ~force ?quiet ?buildOnly ?logPath ~cfg plan id =
@@ -724,12 +724,12 @@ let buildDependencies' ?(concurrency=1) ~cfg plan id =
   let run ~quiet task () =
     let start = Unix.gettimeofday () in
     if not quiet
-    then Logs_lwt.app (fun m -> m "building %a" PackageId.pp task.Task.pkgId)
+    then Logs_lwt.app (fun m -> m "building %a" Task.pp task)
     else Lwt.return ();%lwt
     let logPath = Task.logPath cfg task in
     let%bind () = buildTask ~cfg ~logPath task in
     if not quiet
-    then Logs_lwt.app (fun m -> m "building %a: done" PackageId.pp task.Task.pkgId)
+    then Logs_lwt.app (fun m -> m "building %a: done" Task.pp task)
     else Lwt.return ();%lwt
     let stop = Unix.gettimeofday () in
     return (stop -. start)
@@ -744,7 +744,7 @@ let buildDependencies' ?(concurrency=1) ~cfg plan id =
       let%bind changesInSources, mtime = checkFreshModifyTime infoPath sourcePath in
       begin match isBuilt, Changes.(changesInDependencies + changesInSources) with
       | true, Changes.No ->
-        Logs_lwt.debug (fun m -> m "building %a: skipping" PackageId.pp task.Task.pkgId);%lwt
+        Logs_lwt.debug (fun m -> m "building %a: skipping" Task.pp task);%lwt
         return Changes.No
       | true, Changes.Yes
       | false, _ ->
@@ -759,7 +759,7 @@ let buildDependencies' ?(concurrency=1) ~cfg plan id =
     | SourceType.ImmutableWithTransientDependencies ->
       begin match isBuilt, changesInDependencies with
       | true, Changes.No ->
-        Logs_lwt.debug (fun m -> m "building %a: skipping" PackageId.pp task.Task.pkgId);%lwt
+        Logs_lwt.debug (fun m -> m "building %a: skipping" Task.pp task);%lwt
         return Changes.No
       | true, Changes.Yes
       | false, _ ->
@@ -833,7 +833,7 @@ let exposeUserEnv scope =
   |> Scope.exposeUserEnvWith Scope.SandboxEnvironment.Bindings.value "SHELL"
 
 let exposeDevDependenciesEnv plan task scope =
-  let pkg = Solution.getExn task.Task.pkgId plan.solution in
+  let pkg = Solution.getExn task.Task.pkg.id plan.solution in
   let f id scope =
     match PackageId.Map.find_opt id plan.tasks with
     | Some (Some task) -> Scope.add ~direct:true ~dep:task.Task.exportedScope scope

--- a/esy/Plan.mli
+++ b/esy/Plan.mli
@@ -1,7 +1,7 @@
 module Task : sig
   type t = {
     id : string;
-    pkgId : EsyInstall.PackageId.t;
+    pkg : EsyInstall.Solution.Package.t;
     name : string;
     version : EsyInstall.Version.t;
     env : Scope.SandboxEnvironment.t;

--- a/esy/Plan.mli
+++ b/esy/Plan.mli
@@ -81,6 +81,7 @@ val buildRoot :
 
 val buildDependencies :
   ?concurrency:int
+  -> buildLinked:bool
   -> cfg:Config.t
   -> t
   -> EsyInstall.PackageId.t

--- a/esy/Scope.ml
+++ b/esy/Scope.ml
@@ -223,12 +223,19 @@ end = struct
     in
 
     let p v = SandboxValue.show (SandboxPath.toValue v) in
+    let dev =
+      match scope.sourceType with
+      | Transient -> "true"
+      | Immutable
+      | ImmutableWithTransientDependencies -> "false"
+    in
 
     (* add builtins *)
     let env =
       [
         "cur__name", (name scope);
         "cur__version", (Version.showSimple (version scope));
+        "cur__dev", dev;
         "cur__root", (p (rootPath scope));
         "cur__original_root", (p (sourcePath scope));
         "cur__target_dir", (p (buildPath scope));

--- a/esy/bin/esyCommand.ml
+++ b/esy/bin/esyCommand.ml
@@ -711,7 +711,7 @@ let buildShell (copts : CommonOptions.t) packagePath () =
         ~cfg:copts.cfg
         ~concurrency:EsyRuntime.concurrency
         plan
-        task.Plan.Task.pkgId
+        task.Plan.Task.pkg.id
     in
     let p =
       Plan.shell
@@ -737,13 +737,13 @@ let buildPackage (copts : CommonOptions.t) packagePath () =
         ~cfg:copts.cfg
         ~concurrency:EsyRuntime.concurrency
         plan
-        task.Plan.Task.pkgId
+        task.Plan.Task.pkg.id
     in
     Plan.build
       ~cfg:copts.cfg
       ~force:true
       plan
-      task.Plan.Task.pkgId
+      task.Plan.Task.pkg.id
   in
   withTask info packagePath f
 
@@ -889,7 +889,7 @@ let makeExecCommand
         ~cfg:copts.cfg
         ~concurrency:EsyRuntime.concurrency
         plan
-        task.Plan.Task.pkgId
+        task.Plan.Task.pkg.id
     else return ()
   in
 
@@ -1167,7 +1167,7 @@ let lsModules copts only () =
         return []
     in
 
-    let isNotRoot = PackageId.compare task.pkgId root.id <> 0 in
+    let isNotRoot = PackageId.compare task.pkg.id root.id <> 0 in
     let constraintsSet = List.length only <> 0 in
     let noMatchedLibs = List.length (List.intersect only libs) = 0 in
 

--- a/esy/bin/esyCommand.ml
+++ b/esy/bin/esyCommand.ml
@@ -785,6 +785,18 @@ let build ?(buildOnly=true) (copts : CommonOptions.t) cmd () =
     end
   end
 
+let buildDependencies (copts : CommonOptions.t) () =
+  let open RunAsync.Syntax in
+  let%bind info = SandboxInfo.make copts in
+  let%bind plan = SandboxInfo.plan info in
+  let%bind solution = SandboxInfo.solution info in
+  let root = (Solution.root solution).id in
+  Plan.buildDependencies
+    ~cfg:copts.cfg
+    ~concurrency:EsyRuntime.concurrency
+    plan
+    root
+
 let makeEnvCommand ~computeEnv ~header copts asJson packagePath () =
   let open RunAsync.Syntax in
 
@@ -1615,6 +1627,15 @@ let makeCommands ~sandbox () =
 
     installCommand;
     buildCommand;
+
+    makeCommand
+      ~name:"build-dependencies"
+      ~doc:"Build dependencies"
+      Term.(
+        const buildDependencies
+        $ commonOpts
+        $ Cli.setupLogTerm
+      );
 
     makeCommand
       ~header:`No

--- a/esyi/Fetch.ml
+++ b/esyi/Fetch.ml
@@ -130,16 +130,16 @@ module PackagePaths = struct
     match sandbox.Sandbox.cfg.sourceArchivePath, pkg.Solution.Package.source with
     | None, _ ->
       None
-    | Some _, Solution.Package.Link _ ->
+    | Some _, Link _ ->
       (* has config, not caching b/c it's a link *)
       None
-    | Some sourceArchivePath, Solution.Package.Install _ ->
+    | Some sourceArchivePath, Install _ ->
       let id = key pkg in
       Some Path.(sourceArchivePath // v id |> addExt "tgz")
 
   let installPath sandbox pkg =
     match pkg.Solution.Package.source with
-    | Solution.Package.Link { path; manifest = _; } ->
+    | Link { path; manifest = _; } ->
       DistPath.toPath sandbox.Sandbox.spec.path path
     | Install _ ->
       Path.(sandbox.Sandbox.cfg.sourceInstallPath / key pkg)
@@ -233,7 +233,7 @@ end = struct
 
     RunAsync.contextf (
       match pkg.Solution.Package.source with
-      | Solution.Package.Link {path; _} ->
+      | Link {path; _} ->
         let path = DistPath.toPath sandbox.Sandbox.spec.path path in
         return (pkg, Linked path)
       | Install { source = main, mirrors; opam = _; } ->
@@ -371,7 +371,7 @@ end = struct
 
     let%bind filesOfOpam =
       match pkg.source with
-      | Solution.Package.Link _
+      | Link _
       | Install { opam = None; _ } -> return []
       | Install { opam = Some opam; _ } -> OpamResolution.files opam
     in

--- a/esyi/Package.ml
+++ b/esyi/Package.ml
@@ -728,10 +728,7 @@ module Dependencies = struct
 end
 
 type source =
-  | Link of {
-      path : DistPath.t;
-      manifest : ManifestSpec.t option;
-    }
+  | Link of Source.link
   | Install of {
       source : Dist.t * Dist.t list;
       opam : OpamResolution.t option;

--- a/esyi/Package.mli
+++ b/esyi/Package.mli
@@ -258,10 +258,7 @@ type t = {
 }
 
 and source =
-  | Link of {
-      path : DistPath.t;
-      manifest : ManifestSpec.t option;
-    }
+  | Link of Source.link
   | Install of {
       source : Dist.t * Dist.t list;
       opam : OpamResolution.t option;

--- a/esyi/Solution.ml
+++ b/esyi/Solution.ml
@@ -6,18 +6,11 @@ module Package = struct
     id : PackageId.t;
     name: string;
     version: Version.t;
-    source: source;
+    source: Package.source;
     overrides: Package.Overrides.t;
     dependencies : PackageId.Set.t;
     devDependencies : PackageId.Set.t;
   }
-
-  and source =
-    | Link of Source.link
-    | Install of {
-        source : Dist.t * Dist.t list;
-        opam : OpamResolution.t option;
-      }
 
   let compare a b =
     PackageId.compare a.id b.id

--- a/esyi/Solution.ml
+++ b/esyi/Solution.ml
@@ -13,10 +13,7 @@ module Package = struct
   }
 
   and source =
-    | Link of {
-        path : DistPath.t;
-        manifest : ManifestSpec.t option;
-      }
+    | Link of Source.link
     | Install of {
         source : Dist.t * Dist.t list;
         opam : OpamResolution.t option;

--- a/esyi/Solution.mli
+++ b/esyi/Solution.mli
@@ -11,18 +11,11 @@ module Package : sig
     id: PackageId.t;
     name: string;
     version: Version.t;
-    source: source;
+    source: Package.source;
     overrides: Package.Overrides.t;
     dependencies : PackageId.Set.t;
     devDependencies : PackageId.Set.t;
   }
-
-  and source =
-    | Link of Source.link
-    | Install of {
-        source : Dist.t * Dist.t list;
-        opam : OpamResolution.t option;
-      }
 
   include S.COMPARABLE with type t := t
   include S.PRINTABLE with type t := t

--- a/esyi/Solution.mli
+++ b/esyi/Solution.mli
@@ -18,10 +18,7 @@ module Package : sig
   }
 
   and source =
-    | Link of {
-        path : DistPath.t;
-        manifest : ManifestSpec.t option;
-      }
+    | Link of Source.link
     | Install of {
         source : Dist.t * Dist.t list;
         opam : OpamResolution.t option;

--- a/esyi/SolutionLock.ml
+++ b/esyi/SolutionLock.ml
@@ -1,8 +1,5 @@
 type source =
-  | Link of {
-      path : DistPath.t;
-      manifest : ManifestSpec.t option;
-    }
+  | Link of Source.link
   | Install of {
       source : Dist.t * Dist.t list;
       opam : OpamResolution.Lock.t option;

--- a/esyi/SolutionLock.ml
+++ b/esyi/SolutionLock.ml
@@ -74,7 +74,7 @@ let ofPackage sandbox (pkg : Solution.Package.t) =
   let open RunAsync.Syntax in
   let%bind source =
     match pkg.source with
-    | Solution.Package.Link { path; manifest } -> return (Link {path; manifest;})
+    | Link { path; manifest } -> return (Link {path; manifest;})
     | Install {source; opam = None;} -> return (Install {source; opam = None;})
     | Install {source; opam = Some opam;} ->
       let%bind opam = OpamResolution.toLock ~sandbox:sandbox.spec opam in
@@ -99,11 +99,11 @@ let toPackage sandbox (node : node) =
   let open RunAsync.Syntax in
   let%bind source =
     match node.source with
-    | Link { path; manifest } -> return (Solution.Package.Link {path;manifest;})
-    | Install {source; opam = None;} -> return (Solution.Package.Install {source; opam = None;})
+    | Link { path; manifest } -> return (Package.Link {path;manifest;})
+    | Install {source; opam = None;} -> return (Package.Install {source; opam = None;})
     | Install {source; opam = Some opam;} ->
       let%bind opam = OpamResolution.ofLock ~sandbox:sandbox.Sandbox.spec opam in
-      return (Solution.Package.Install {source; opam = Some opam;});
+      return (Package.Install {source; opam = Some opam;});
   in
   return {
     Solution.Package.

--- a/esyi/Solver.ml
+++ b/esyi/Solver.ml
@@ -298,18 +298,12 @@ let solutionPkgOfPkg
     PackageId.Set.diff devDependencies dependencies
   in
 
-  let source =
-    match pkg.source with
-    | Package.Link {path; manifest;} -> Solution.Package.Link {path;manifest;}
-    | Package.Install { source; opam } -> Solution.Package.Install {source;opam;}
-  in
-
   return {
     Solution.Package.
     id;
     name = pkg.name;
     version = pkg.version;
-    source;
+    source = pkg.source;
     overrides = pkg.overrides;
     dependencies;
     devDependencies;

--- a/esyi/Source.ml
+++ b/esyi/Source.ml
@@ -1,14 +1,14 @@
 open Sexplib0.Sexp_conv
 
+type link = {
+  path : DistPath.t;
+  manifest : ManifestSpec.t option;
+} [@@deriving ord, sexp_of, yojson]
+
 type t =
   | Dist of Dist.t
   | Link of link
   [@@deriving ord, sexp_of]
-
-and link = {
-  path : DistPath.t;
-  manifest : ManifestSpec.t option;
-}
 
 let manifest (src : t) =
   match src with

--- a/esyi/Source.mli
+++ b/esyi/Source.mli
@@ -1,11 +1,14 @@
-type t =
-  | Dist of Dist.t
-  | Link of link
-
-and link = {
+type link = {
   path : DistPath.t;
   manifest : ManifestSpec.t option;
 }
+
+val link_to_yojson : link Json.encoder
+val link_of_yojson : link Json.decoder
+
+type t =
+  | Dist of Dist.t
+  | Link of link
 
 include S.COMMON with type t := t
 

--- a/test-e2e/build-dependencies.test.js
+++ b/test-e2e/build-dependencies.test.js
@@ -1,0 +1,113 @@
+// @flow
+
+const path = require('path');
+const fs = require('fs-extra');
+const os = require('os');
+
+const helpers = require('./test/helpers');
+const {packageJson, dir, file, dummyExecutable, buildCommand} = helpers;
+
+helpers.skipSuiteOnWindows();
+
+describe(`'esy build-dependencies' command`, () => {
+  let prevEnv = {...process.env};
+
+  async function getCommandEnv(p) {
+    const proc = await p.esy('command-env --json');
+    const env = JSON.parse(proc.stdout);
+    return env;
+  }
+
+  function createPackage(p, {name, dependencies}: {name: string, dependencies?: Object}) {
+    return dir(
+      name,
+      packageJson({
+        name,
+        version: '1.0.0',
+        dependencies,
+        esy: {
+          install: [
+            'cp #{self.root / self.name}.js #{self.bin / self.name}.js',
+            buildCommand(p, '#{self.bin / self.name}.js'),
+          ],
+          buildEnv: {
+            [`${name}__buildvar`]: `${name}__buildvar__value`,
+          },
+          exportedEnv: {
+            [`${name}__local`]: {val: `${name}__local__value`},
+            [`${name}__global`]: {val: `${name}__global__value`, scope: 'global'},
+          },
+        },
+      }),
+
+      dummyExecutable(name),
+    );
+  }
+
+  async function createTestSandbox() {
+    const p = await helpers.createTestSandbox();
+    await p.fixture(
+      packageJson({
+        name: 'simple-project',
+        version: '1.0.0',
+        dependencies: {
+          dep: 'path:./dep',
+          linkedDep: '*',
+        },
+        devDependencies: {
+          devDep: 'path:./devDep',
+        },
+        resolutions: {
+          linkedDep: 'link:./linkedDep',
+        },
+      }),
+      createPackage(p, {name: 'dep'}),
+      createPackage(p, {name: 'linkedDep'}),
+      createPackage(p, {name: 'devDep'}),
+    );
+    return p;
+  }
+
+  it(`builds dependencies`, async () => {
+    const p = await createTestSandbox();
+    await p.esy('install');
+    await p.esy('build-dependencies');
+    const env = await getCommandEnv(p);
+    await expect(p.run('dep.cmd', env)).resolves.toEqual({
+      stdout: '__dep__' + os.EOL,
+      stderr: '',
+    });
+  });
+
+  it(`builds devDependencies`, async () => {
+    const p = await createTestSandbox();
+    await p.esy('install');
+    await p.esy('build-dependencies');
+    const env = await getCommandEnv(p);
+    await expect(p.run('devDep.cmd', env)).resolves.toEqual({
+      stdout: '__devDep__' + os.EOL,
+      stderr: '',
+    });
+  });
+
+  it(`doesn't build linked dependencies`, async () => {
+    const p = await createTestSandbox();
+    await p.esy('install');
+    await p.esy('build-dependencies');
+    const env = await getCommandEnv(p);
+    await expect(p.run('linkedDep.cmd', env)).rejects.toMatchObject({
+      code: 127,
+    });
+  });
+
+  it(`builds linked dependencies if --all passed`, async () => {
+    const p = await createTestSandbox();
+    await p.esy('install');
+    await p.esy('build-dependencies --all');
+    const env = await getCommandEnv(p);
+    await expect(p.run('linkedDep.cmd', env)).resolves.toEqual({
+      stdout: '__linkedDep__' + os.EOL,
+      stderr: '',
+    });
+  });
+});

--- a/test-e2e/common/anycmd.test.js
+++ b/test-e2e/common/anycmd.test.js
@@ -9,7 +9,7 @@ const fixture = require('./fixture.js');
 
 helpers.skipSuiteOnWindows();
 
-describe('Common - anycmd', () => {
+describe(`'esy CMD' invocation`, () => {
   let prevEnv = {...process.env};
 
   async function createTestSandbox() {
@@ -32,7 +32,7 @@ describe('Common - anycmd', () => {
     });
   });
 
-  it('Make sure we can pass environment from the outside dynamically', async () => {
+  it('inherits the outside environment', async () => {
     process.env.X = '1';
     const p = await createTestSandbox();
     await expect(p.esy('bash -c "echo $X"')).resolves.toEqual({
@@ -49,7 +49,7 @@ describe('Common - anycmd', () => {
     process.env = prevEnv;
   });
 
-  it('Make sure exit code is preserved', async () => {
+  it('preserves exit code of the command it runs', async () => {
     const p = await createTestSandbox();
     await expect(p.esy("bash -c 'exit 1'")).rejects.toEqual(
       expect.objectContaining({code: 1}),
@@ -59,7 +59,7 @@ describe('Common - anycmd', () => {
     );
   });
 
-  it('Make sure we can run commands out of subdirectories', async () => {
+  it(`can be invoked from project's subdirectories`, async () => {
     const p = await createTestSandbox();
     await fs.mkdir(path.join(p.projectPath, 'subdir'));
     await fs.writeFile(path.join(p.projectPath, 'subdir', 'X'), '');

--- a/test-e2e/common/anycmd.test.js
+++ b/test-e2e/common/anycmd.test.js
@@ -129,4 +129,34 @@ describe(`'esy CMD' invocation`, () => {
       expect.objectContaining({stdout: 'X\n'}),
     );
   });
+
+  it(`doesn't wait for linked packages to be built`, async () => {
+    const p = await helpers.createTestSandbox();
+    await p.fixture(
+      packageJson({
+        name: 'root',
+        version: '1.0.0',
+        dependencies: {
+          dep: 'path:./dep',
+        },
+        resolutions: {
+          dep: 'link:./dep',
+        },
+      }),
+      dir(
+        'dep',
+        packageJson({
+          name: 'dep',
+          version: '1.0.0',
+          esy: {
+            build: 'false',
+          },
+          dependencies: {},
+        }),
+      ),
+    );
+    await p.esy('install');
+    // just check that we don't faail on building 'dep'
+    await p.esy('true');
+  });
 });

--- a/test-e2e/common/anycmd.test.js
+++ b/test-e2e/common/anycmd.test.js
@@ -5,7 +5,6 @@ const fs = require('fs-extra');
 const os = require('os');
 
 const helpers = require('../test/helpers');
-const fixture = require('./fixture.js');
 const {packageJson, dir, file, dummyExecutable, buildCommand} = helpers;
 
 helpers.skipSuiteOnWindows();

--- a/test-e2e/common/build-anycmd.test.js
+++ b/test-e2e/common/build-anycmd.test.js
@@ -4,18 +4,18 @@ const os = require('os');
 const path = require('path');
 
 const helpers = require('../test/helpers');
-const fixture = require('./fixture.js');
 const {packageJson, dir, file, dummyExecutable, buildCommand} = helpers;
 
 helpers.skipSuiteOnWindows();
 
 describe(`'esy build CMD' invocation`, () => {
-  function createPackage(p, name) {
+  function createPackage(p, {name, dependencies}: {name: string, dependencies?: Object}) {
     return dir(
       name,
       packageJson({
         name,
         version: '1.0.0',
+        dependencies,
         esy: {
           install: [
             'cp #{self.root / self.name}.js #{self.bin / self.name}.js',
@@ -45,9 +45,10 @@ describe(`'esy build CMD' invocation`, () => {
           linkedDep: 'link:./linkedDep',
         },
       }),
-      createPackage(p, 'dep'),
-      createPackage(p, 'linkedDep'),
-      createPackage(p, 'devDep'),
+      createPackage(p, {name: 'dep', dependencies: {depOfDep: 'path:../depOfDep'}}),
+      createPackage(p, {name: 'depOfDep'}),
+      createPackage(p, {name: 'linkedDep'}),
+      createPackage(p, {name: 'devDep'}),
     );
     return p;
   }

--- a/test-e2e/common/build-anycmd.test.js
+++ b/test-e2e/common/build-anycmd.test.js
@@ -3,33 +3,112 @@
 const os = require('os');
 const path = require('path');
 
-const {createTestSandbox, skipSuiteOnWindows} = require('../test/helpers');
+const helpers = require('../test/helpers');
 const fixture = require('./fixture.js');
+const {packageJson, dir, file, dummyExecutable, buildCommand} = helpers;
 
-skipSuiteOnWindows();
+helpers.skipSuiteOnWindows();
 
-it('Common - build anycmd', async () => {
-  const p = await createTestSandbox();
-  await p.fixture(...fixture.makeSimpleProject(p));
+describe(`'esy build CMD' invocation`, () => {
+  function createPackage(p, name) {
+    return dir(
+      name,
+      packageJson({
+        name,
+        version: '1.0.0',
+        esy: {
+          install: [
+            'cp #{self.root / self.name}.js #{self.bin / self.name}.js',
+            buildCommand(p, '#{self.bin / self.name}.js'),
+          ],
+        },
+      }),
 
-  await p.esy('install');
-  await p.esy('build');
+      dummyExecutable(name),
+    );
+  }
 
-  await expect(p.esy('build dep.cmd')).resolves.toEqual({
-    stdout: '__dep__' + os.EOL,
-    stderr: '',
+  async function createTestSandbox() {
+    const p = await helpers.createTestSandbox();
+    await p.fixture(
+      packageJson({
+        name: 'simple-project',
+        version: '1.0.0',
+        dependencies: {
+          dep: 'path:./dep',
+          linkedDep: '*',
+        },
+        devDependencies: {
+          devDep: 'path:./devDep',
+        },
+        resolutions: {
+          linkedDep: 'link:./linkedDep',
+        },
+      }),
+      createPackage(p, 'dep'),
+      createPackage(p, 'linkedDep'),
+      createPackage(p, 'devDep'),
+    );
+    return p;
+  }
+
+  it(`invokes commands in build environment`, async () => {
+    const p = await createTestSandbox();
+    await p.esy('install');
+    await p.esy('build');
+
+    await expect(p.esy('build dep.cmd')).resolves.toEqual({
+      stdout: '__dep__' + os.EOL,
+      stderr: '',
+    });
   });
 
-  await expect(p.esy('b dep.cmd')).resolves.toEqual({
-    stdout: '__dep__' + os.EOL,
-    stderr: '',
+  it(`cannot invoke commands defined in devDependencies`, async () => {
+    const p = await createTestSandbox();
+    await p.esy('install');
+    await p.esy('build');
+
+    await expect(p.esy('build devDep.cmd')).rejects.toMatchObject({
+      code: 1,
+    });
   });
 
-  // make sure exit code is preserved
-  await expect(p.esy("b bash -c 'exit 1'")).rejects.toEqual(
-    expect.objectContaining({code: 1}),
-  );
-  await expect(p.esy("b bash -c 'exit 7'")).rejects.toEqual(
-    expect.objectContaining({code: 7}),
-  );
+  it(`builds dependencies before running a command`, async () => {
+    const p = await createTestSandbox();
+    await p.esy('install');
+
+    await p.esy('build dep.cmd');
+  });
+
+  it(`builds linked dependencies before running a command`, async () => {
+    const p = await createTestSandbox();
+    await p.esy('install');
+
+    await p.esy('build linkedDep.cmd');
+  });
+
+  it(`has 'esy b CMD' shortcut`, async () => {
+    const p = await createTestSandbox();
+    await p.esy('install');
+    await p.esy('build');
+
+    await expect(p.esy('b dep.cmd')).resolves.toEqual({
+      stdout: '__dep__' + os.EOL,
+      stderr: '',
+    });
+  });
+
+  it(`preserves exit code of the command it runs`, async () => {
+    const p = await createTestSandbox();
+    await p.esy('install');
+    await p.esy('build');
+
+    // make sure exit code is preserved
+    await expect(p.esy("b bash -c 'exit 1'")).rejects.toEqual(
+      expect.objectContaining({code: 1}),
+    );
+    await expect(p.esy("b bash -c 'exit 7'")).rejects.toEqual(
+      expect.objectContaining({code: 7}),
+    );
+  });
 });

--- a/test-e2e/common/x-anycmd.test.js
+++ b/test-e2e/common/x-anycmd.test.js
@@ -4,7 +4,6 @@ const path = require('path');
 const fs = require('fs-extra');
 
 const helpers = require('../test/helpers');
-const fixture = require('./fixture.js');
 const {packageJson, dir, file, dummyExecutable, buildCommand} = helpers;
 
 helpers.skipSuiteOnWindows();

--- a/test-e2e/common/x-anycmd.test.js
+++ b/test-e2e/common/x-anycmd.test.js
@@ -5,34 +5,146 @@ const fs = require('fs-extra');
 
 const helpers = require('../test/helpers');
 const fixture = require('./fixture.js');
+const {packageJson, dir, file, dummyExecutable, buildCommand} = helpers;
 
 helpers.skipSuiteOnWindows();
 
-describe('Common - x anycmd', () => {
+describe(`'esy x CMD' invocation`, () => {
   let prevEnv = {...process.env};
+
+  function createPackage(p, name) {
+    return dir(
+      name,
+      packageJson({
+        name,
+        version: '1.0.0',
+        esy: {
+          install: [
+            'cp #{self.root / self.name}.js #{self.bin / self.name}.js',
+            buildCommand(p, '#{self.bin / self.name}.js'),
+          ],
+        },
+      }),
+
+      dummyExecutable(name),
+    );
+  }
 
   async function createTestSandbox() {
     const p = await helpers.createTestSandbox();
-    await p.fixture(...fixture.makeSimpleProject(p));
-    await p.esy('install');
-    await p.esy('build');
+    await p.fixture(
+      packageJson({
+        name: 'root',
+        version: '1.0.0',
+        esy: {
+          install: [
+            'cp #{self.root / self.name}.js #{self.bin / self.name}.js',
+            buildCommand(p, '#{self.bin / self.name}.js'),
+          ],
+        },
+        dependencies: {
+          dep: 'path:./dep',
+          linkedDep: '*',
+        },
+        devDependencies: {
+          devDep: 'path:./devDep',
+        },
+        resolutions: {
+          linkedDep: 'link:./linkedDep',
+        },
+      }),
+      dummyExecutable('root'),
+      createPackage(p, 'dep'),
+      createPackage(p, 'linkedDep'),
+      createPackage(p, 'devDep'),
+    );
     return p;
   }
 
-  it('normal case works', async () => {
+  it('runs commands defined in root package', async () => {
     const p = await createTestSandbox();
+    await p.esy('install');
+    await p.esy('build');
+
+    await expect(p.esy('x root.cmd')).resolves.toEqual({
+      stdout: '__root__\n',
+      stderr: '',
+    });
+  });
+
+  it('runs commands defined in dependencies', async () => {
+    const p = await createTestSandbox();
+    await p.esy('install');
+    await p.esy('build');
+
     await expect(p.esy('x dep.cmd')).resolves.toEqual({
       stdout: '__dep__\n',
       stderr: '',
     });
+  });
+
+  it('runs commands defined in devDependencies', async () => {
+    const p = await createTestSandbox();
+    await p.esy('install');
+    await p.esy('build');
+
     await expect(p.esy('x devDep.cmd')).resolves.toEqual({
       stdout: '__devDep__\n',
       stderr: '',
     });
   });
 
-  it('Make sure we can pass environment from the outside dynamically', async () => {
+  it('runs commands defined in linked dependencies', async () => {
     const p = await createTestSandbox();
+    await p.esy('install');
+    await p.esy('build');
+
+    await expect(p.esy('x linkedDep.cmd')).resolves.toEqual({
+      stdout: '__linkedDep__\n',
+      stderr: '',
+    });
+  });
+
+  it('builds (and rebuilds) root before running a command', async () => {
+    const p = await createTestSandbox();
+    await p.esy('install');
+
+    await expect(p.esy('x root.cmd')).resolves.toMatchObject({
+      stdout: '__root__\n',
+    });
+
+    await fs.writeFile(
+      path.join(p.projectPath, 'root.js'),
+      'console.log("__CHANGED__");',
+    );
+
+    await expect(p.esy('x root.cmd')).resolves.toMatchObject({
+      stdout: '__CHANGED__\n',
+    });
+  });
+
+  it('builds (and rebuilds) linked packages before running a command', async () => {
+    const p = await createTestSandbox();
+    await p.esy('install');
+
+    await expect(p.esy('x linkedDep.cmd')).resolves.toMatchObject({
+      stdout: '__linkedDep__\n',
+    });
+
+    await fs.writeFile(
+      path.join(p.projectPath, 'linkedDep', 'linkedDep.js'),
+      'console.log("__CHANGED__");',
+    );
+
+    await expect(p.esy('x linkedDep.cmd')).resolves.toMatchObject({
+      stdout: '__CHANGED__\n',
+    });
+  });
+
+  it('inherits outside environment', async () => {
+    const p = await createTestSandbox();
+    await p.esy('install');
+    await p.esy('build');
 
     process.env.X = '1';
     await expect(p.esy('x bash -c "echo $X"')).resolves.toEqual({
@@ -49,8 +161,10 @@ describe('Common - x anycmd', () => {
     process.env = prevEnv;
   });
 
-  it('Make sure exit code is preserved', async () => {
+  it(`preserves exit code of the command it runs`, async () => {
     const p = await createTestSandbox();
+    await p.esy('install');
+    await p.esy('build');
 
     await expect(p.esy("x bash -c 'exit 1'")).rejects.toEqual(
       expect.objectContaining({code: 1}),
@@ -60,8 +174,10 @@ describe('Common - x anycmd', () => {
     );
   });
 
-  it('Make sure we can run commands out of subdirectories', async () => {
+  it(`can be invoked from project's subdirectories`, async () => {
     const p = await createTestSandbox();
+    await p.esy('install');
+    await p.esy('build');
 
     await fs.mkdir(path.join(p.projectPath, 'subdir'));
     await fs.writeFile(path.join(p.projectPath, 'subdir', 'X'), '');

--- a/test-e2e/test/helpers.js
+++ b/test-e2e/test/helpers.js
@@ -122,10 +122,13 @@ function getStorePathForPrefix(prefix) {
   }
 }
 
+const CREATED_SANDBOXES = [];
+
 async function createTestSandbox(...fixture: Fixture): Promise<TestSandbox> {
   // use /tmp on unix b/c sometimes it's too long to host the esy store
   const tmp = isWindows ? os.tmpdir() : '/tmp';
   const rootPath = await fs.realpath(await fs.mkdtemp(path.join(tmp, 'XXXX')));
+  CREATED_SANDBOXES.push(rootPath);
   const projectPath = path.join(rootPath, 'project');
   const binPath = path.join(rootPath, 'bin');
   const npmPrefixPath = path.join(rootPath, 'npm');
@@ -135,7 +138,7 @@ async function createTestSandbox(...fixture: Fixture): Promise<TestSandbox> {
   await fs.mkdir(projectPath);
   await fs.mkdir(npmPrefixPath);
   await fs.symlink(ESY, path.join(binPath, exe('esy')));
-  await fs.copyFile(process.execPath, path.join(binPath, exe('node')));
+  await fs.symlink(process.execPath, path.join(binPath, exe('node')));
 
   await FixtureUtils.initialize(projectPath, fixture);
   const npmRegistry = await NpmRegistryMock.initialize();
@@ -237,6 +240,14 @@ async function createTestSandbox(...fixture: Fixture): Promise<TestSandbox> {
       OpamRegistryMock.defineOpamPackageOfFixture(opamRegistry, spec, fixture),
   };
 }
+
+afterAll(function() {
+  if (process.env.TEST_ESY_DEBUG != undefined) {
+    for (const p of CREATED_SANDBOXES) {
+      fs.removeSync(p);
+    }
+  }
+});
 
 function skipSuiteOnWindows(blockingIssues?: string) {
   if (process.platform === 'win32') {

--- a/test-e2e/test/helpers.js
+++ b/test-e2e/test/helpers.js
@@ -44,7 +44,7 @@ export type TestSandbox = {
 
   fixture: (...fixture: Fixture) => Promise<void>,
 
-  run: (args: string) => Promise<{stderr: string, stdout: string}>,
+  run: (args: string, env?: Object) => Promise<{stderr: string, stdout: string}>,
 
   cd: (where: string) => void,
 
@@ -185,8 +185,11 @@ async function createTestSandbox(...fixture: Fixture): Promise<TestSandbox> {
     });
   }
 
-  function run(line: string) {
-    return promiseExec(line, {cwd});
+  function run(line: string, env) {
+    if (env == null) {
+      env = process.env;
+    }
+    return promiseExec(line, {cwd, env});
   }
 
   async function printEsy(cmd, options) {


### PR DESCRIPTION
- [x] Add `esy build-dependencies` command.
- [x] Skip building linked packages on `esy CMD` invocation.
- [ ] ~~Install linked packages' `devDependencies`.~~