### PR TITLE
Azure CI: Only download build artifacts when not master

### DIFF
--- a/.ci/build-release.yml
+++ b/.ci/build-release.yml
@@ -64,6 +64,7 @@ jobs:
         ESYCI__CACHE_INSTALL: C:\Users\VssAdministrator\.esy\source\i
 
     steps:
+      # - template: restore-build-cache.yml
       - template: build-windows.yml
 
       - task: PublishBuildArtifacts@1

--- a/.ci/build-windows.yml
+++ b/.ci/build-windows.yml
@@ -15,12 +15,13 @@ steps:
         branchName: 'refs/heads/master'
         buildVersionToDownload: 'latestFromBranch'
         downloadType: 'single'
-        artifactName: 'build-cache-windows-source-tarballs'
+        artifactName: 'cache-$(Agent.OS)-source-tarballs'
         downloadPath: '$(System.ArtifactsDirectory)'
     continueOnError: true
 
   - task: CopyFiles@2
     condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
+    continueOnError: true
     inputs:
         sourceFolder: '$(System.ArtifactsDirectory)\build-cache-windows-source-tarballs'
         targetFolder: '$(ESYCI__CACHE_INSTALL)'
@@ -35,12 +36,13 @@ steps:
         buildVersionToDownload: 'latestFromBranch'
         branchName: 'refs/heads/master'
         downloadType: 'single'
-        artifactName: 'build-cache-windows-install'
+        artifactName: 'cache-$(Agent.OS)-install'
         downloadPath: '$(System.ArtifactsDirectory)'
     continueOnError: true
 
   - task: CopyFiles@2
     condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
+    continueOnError: true
     inputs:
         sourceFolder: '$(System.ArtifactsDirectory)\build-cache-windows-install'
         targetFolder: '$(ESYCI__CACHE_BUILD)'

--- a/.ci/build-windows.yml
+++ b/.ci/build-windows.yml
@@ -7,6 +7,7 @@ steps:
 
   - task: DownloadBuildArtifacts@0
     displayName: 'Cache: Restore source-tarballs'
+    condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
     inputs:
         buildType: 'specific'
         project: 'esy'
@@ -19,11 +20,13 @@ steps:
     continueOnError: true
 
   - task: CopyFiles@2
+    condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
     inputs:
         sourceFolder: '$(System.ArtifactsDirectory)\build-cache-windows-source-tarballs'
         targetFolder: '$(ESYCI__CACHE_INSTALL)'
 
   - task: DownloadBuildArtifacts@0
+    condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
     displayName: 'Cache: Restore install'
     inputs:
         buildType: 'specific'
@@ -37,6 +40,7 @@ steps:
     continueOnError: true
 
   - task: CopyFiles@2
+    condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
     inputs:
         sourceFolder: '$(System.ArtifactsDirectory)\build-cache-windows-install'
         targetFolder: '$(ESYCI__CACHE_BUILD)'

--- a/.ci/build-windows.yml
+++ b/.ci/build-windows.yml
@@ -23,7 +23,7 @@ steps:
     condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
     continueOnError: true
     inputs:
-        sourceFolder: '$(System.ArtifactsDirectory)\build-cache-windows-source-tarballs'
+        sourceFolder: '$(System.ArtifactsDirectory)\cache-$(Agent.OS)-source-tarballs'
         targetFolder: '$(ESYCI__CACHE_INSTALL)'
 
   - task: DownloadBuildArtifacts@0
@@ -44,7 +44,7 @@ steps:
     condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
     continueOnError: true
     inputs:
-        sourceFolder: '$(System.ArtifactsDirectory)\build-cache-windows-install'
+        sourceFolder: '$(System.ArtifactsDirectory)\cache-$(Agent.OS)-install'
         targetFolder: '$(ESYCI__CACHE_BUILD)'
 
   - script: 'npm install -g esy@0.4.3'

--- a/.ci/build-windows.yml
+++ b/.ci/build-windows.yml
@@ -5,48 +5,6 @@ steps:
     inputs:
       versionSpec: 8.x
 
-  - task: DownloadBuildArtifacts@0
-    displayName: 'Cache: Restore source-tarballs'
-    condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
-    inputs:
-        buildType: 'specific'
-        project: 'esy'
-        pipeline: 'build'
-        branchName: 'refs/heads/master'
-        buildVersionToDownload: 'latestFromBranch'
-        downloadType: 'single'
-        artifactName: 'cache-$(Agent.OS)-source-tarballs'
-        downloadPath: '$(System.ArtifactsDirectory)'
-    continueOnError: true
-
-  - task: CopyFiles@2
-    condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
-    continueOnError: true
-    inputs:
-        sourceFolder: '$(System.ArtifactsDirectory)\cache-$(Agent.OS)-source-tarballs'
-        targetFolder: '$(ESYCI__CACHE_INSTALL)'
-
-  - task: DownloadBuildArtifacts@0
-    condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
-    displayName: 'Cache: Restore install'
-    inputs:
-        buildType: 'specific'
-        project: 'esy'
-        pipeline: 'build'
-        buildVersionToDownload: 'latestFromBranch'
-        branchName: 'refs/heads/master'
-        downloadType: 'single'
-        artifactName: 'cache-$(Agent.OS)-install'
-        downloadPath: '$(System.ArtifactsDirectory)'
-    continueOnError: true
-
-  - task: CopyFiles@2
-    condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
-    continueOnError: true
-    inputs:
-        sourceFolder: '$(System.ArtifactsDirectory)\cache-$(Agent.OS)-install'
-        targetFolder: '$(ESYCI__CACHE_BUILD)'
-
   - script: 'npm install -g esy@0.4.3'
     displayName: 'npm install -g esy@0.4.3'
 

--- a/.ci/restore-build-cache.yml
+++ b/.ci/restore-build-cache.yml
@@ -1,0 +1,43 @@
+steps:
+  - task: DownloadBuildArtifacts@0
+    displayName: 'Cache: Restore source-tarballs'
+    condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
+    inputs:
+        buildType: 'specific'
+        project: 'esy'
+        pipeline: 'build'
+        branchName: 'refs/heads/master'
+        buildVersionToDownload: 'latestFromBranch'
+        downloadType: 'single'
+        artifactName: 'cache-$(Agent.OS)-source-tarballs'
+        downloadPath: '$(System.ArtifactsDirectory)'
+    continueOnError: true
+
+  - task: CopyFiles@2
+    condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
+    continueOnError: true
+    inputs:
+        sourceFolder: '$(System.ArtifactsDirectory)\cache-$(Agent.OS)-source-tarballs'
+        targetFolder: '$(ESYCI__CACHE_INSTALL)'
+
+  - task: DownloadBuildArtifacts@0
+    condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
+    displayName: 'Cache: Restore install'
+    inputs:
+        buildType: 'specific'
+        project: 'esy'
+        pipeline: 'build'
+        buildVersionToDownload: 'latestFromBranch'
+        branchName: 'refs/heads/master'
+        downloadType: 'single'
+        artifactName: 'cache-$(Agent.OS)-install'
+        downloadPath: '$(System.ArtifactsDirectory)'
+    continueOnError: true
+
+  - task: CopyFiles@2
+    condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
+    continueOnError: true
+    inputs:
+        sourceFolder: '$(System.ArtifactsDirectory)\cache-$(Agent.OS)-install'
+        targetFolder: '$(ESYCI__CACHE_BUILD)'
+


### PR DESCRIPTION
__Issue:__ Our cache packages keep growing, because when we build, we download the latest cache, install/build, and upload the complete cache. 

__Defect:__ The problem is that, as new versions of packages come up, we bring those into the cache and don't delete the old oens.

__Fix:__ On `master` - don't restore the cache. This means that `master` builds won't benefit from caching, but those can be a bit slower (we're optimizing for PR validation speed with the cache). It also gets us out of our 'chicken-and-egg' problem, where we can't download the cache until the cache is populated.