### PR TITLE
Azure CI: Disable 'source-tarball' caching

### DIFF
--- a/.ci/build-nix.yml
+++ b/.ci/build-nix.yml
@@ -10,14 +10,14 @@ steps:
   - script: 'esy install'
     displayName: 'esy install'
 
-  - task: PublishBuildArtifacts@1
-    displayName: 'Cache: Upload source tarballs'
-    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
-    inputs:
-        pathToPublish: '$(ESYCI__CACHE_INSTALL)'
-        artifactName: 'cache-$(Agent.OS)-source-tarballs'
-        parallel: true
-        parallelCount: 8
+  # - task: PublishBuildArtifacts@1
+  #   displayName: 'Cache: Upload source tarballs'
+  #   condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+  #   inputs:
+  #       pathToPublish: '$(ESYCI__CACHE_INSTALL)'
+  #       artifactName: 'cache-$(Agent.OS)-source-tarballs'
+  #       parallel: true
+  #       parallelCount: 8
 
   - script: 'esy build'
     displayName: 'esy build'

--- a/.ci/build-windows.yml
+++ b/.ci/build-windows.yml
@@ -14,14 +14,14 @@ steps:
   - script: 'esy install'
     displayName: 'esy install'
 
-  - task: PublishBuildArtifacts@1
-    displayName: 'Cache: Upload source tarballs'
-    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
-    inputs:
-        pathToPublish: '$(ESYCI__CACHE_INSTALL)'
-        artifactName: 'cache-$(Agent.OS)-source-tarballs'
-        parallel: true
-        parallelCount: 8
+  # - task: PublishBuildArtifacts@1
+  #   displayName: 'Cache: Upload source tarballs'
+  #   condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+  #   inputs:
+  #       pathToPublish: '$(ESYCI__CACHE_INSTALL)'
+  #       artifactName: 'cache-$(Agent.OS)-source-tarballs'
+  #       parallel: true
+  #       parallelCount: 8
 
   - script: 'esy build'
     displayName: 'esy build'

--- a/.ci/restore-build-cache.yml
+++ b/.ci/restore-build-cache.yml
@@ -1,24 +1,24 @@
 steps:
-  - task: DownloadBuildArtifacts@0
-    displayName: 'Cache: Restore source-tarballs'
-    condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
-    inputs:
-        buildType: 'specific'
-        project: 'esy'
-        pipeline: 'build'
-        branchName: 'refs/heads/master'
-        buildVersionToDownload: 'latestFromBranch'
-        downloadType: 'single'
-        artifactName: 'cache-$(Agent.OS)-source-tarballs'
-        downloadPath: '$(System.ArtifactsDirectory)'
-    continueOnError: true
+  # - task: DownloadBuildArtifacts@0
+  #   displayName: 'Cache: Restore source-tarballs'
+  #   condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
+  #   inputs:
+  #       buildType: 'specific'
+  #       project: 'esy'
+  #       pipeline: 'build'
+  #       branchName: 'refs/heads/master'
+  #       buildVersionToDownload: 'latestFromBranch'
+  #       downloadType: 'single'
+  #       artifactName: 'cache-$(Agent.OS)-source-tarballs'
+  #       downloadPath: '$(System.ArtifactsDirectory)'
+  #   continueOnError: true
 
-  - task: CopyFiles@2
-    condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
-    continueOnError: true
-    inputs:
-        sourceFolder: '$(System.ArtifactsDirectory)\cache-$(Agent.OS)-source-tarballs'
-        targetFolder: '$(ESYCI__CACHE_INSTALL)'
+  # - task: CopyFiles@2
+  #   condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
+  #   continueOnError: true
+  #   inputs:
+  #       sourceFolder: '$(System.ArtifactsDirectory)\cache-$(Agent.OS)-source-tarballs'
+  #       targetFolder: '$(ESYCI__CACHE_INSTALL)'
 
   - task: DownloadBuildArtifacts@0
     condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))


### PR DESCRIPTION
The upload of the cached artifact for the tarballs folder is much more expensive than simply downloading the tarballs, so I'll disable this for the time being.