### PR TITLE
Windows - Bugfix: Cmdliner@1.0.3 fails to build in esy environment

### DIFF
--- a/esy/Scope.ml
+++ b/esy/Scope.ml
@@ -301,7 +301,10 @@ let make
     finalEnv = (
       let defaultPath =
           match platform with
-          | Windows -> "$PATH;/usr/local/bin;/usr/bin;/bin;/usr/sbin;/sbin"
+          | Windows -> 
+              let windir = Sys.getenv("WINDIR") ^ "/System32" in
+              let windir = Path.normalizePathSlashes windir in
+              "$PATH;/usr/local/bin;/usr/bin;/bin;/usr/sbin;/sbin;" ^ windir
           | _ -> "$PATH:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
       in
       SandboxEnvironment.[

--- a/test-e2e/build/no-deps.test.js
+++ b/test-e2e/build/no-deps.test.js
@@ -47,6 +47,7 @@ describe('Build simple executable with no deps', () => {
     test(
       'build-env',
       withProject(async function(p) {
+        let winsysDir = process.platform === "win32" ? [helpers.getWindowsSystemDirectory()] : [];
         const id = JSON.parse((await p.esy('build-plan')).stdout).id;
         const {stdout} = await p.esy('build-env --json');
         const env = JSON.parse(stdout);
@@ -66,7 +67,7 @@ describe('Build simple executable with no deps', () => {
           cur__etc: `${p.projectPath}/_esy/default/store/i/${id}/etc`,
           cur__doc: `${p.projectPath}/_esy/default/store/i/${id}/doc`,
           cur__bin: `${p.projectPath}/_esy/default/store/i/${id}/bin`,
-          PATH: [``, `/usr/local/bin`, `/usr/bin`, `/bin`, `/usr/sbin`, `/sbin`].join(
+          PATH: [``, `/usr/local/bin`, `/usr/bin`, `/bin`, `/usr/sbin`, `/sbin`, ...winsysDir].join(
             path.delimiter,
           ),
           OCAMLFIND_LDCONF: `ignore`,

--- a/test-e2e/build/with-dep.test.js
+++ b/test-e2e/build/with-dep.test.js
@@ -30,7 +30,10 @@ function makeFixture(p, buildDep) {
 
 describe('Build with dep', () => {
 
-  let winsysDir = process.platform === "win32" ? [path.join(process.env["windir"], "System32")] : [];
+  let winsysDir = 
+        process.platform === "win32" ?  
+        [path.join(process.env["windir"], "System32").split("\\").join("/")]
+        : [];
 
   async function checkDepIsInEnv(p) {
     {

--- a/test-e2e/build/with-dep.test.js
+++ b/test-e2e/build/with-dep.test.js
@@ -29,6 +29,9 @@ function makeFixture(p, buildDep) {
 }
 
 describe('Build with dep', () => {
+
+  let winsysDir = process.platform === "win32" ? [path.join(process.env["windir"], "System32")] : [];
+
   async function checkDepIsInEnv(p) {
     {
       const {stdout} = await p.esy('dep.cmd');
@@ -102,6 +105,7 @@ describe('Build with dep', () => {
             `/bin`,
             `/usr/sbin`,
             `/sbin`,
+            ...winsysDir,
           ].join(path.delimiter),
           OCAMLFIND_LDCONF: `ignore`,
           OCAMLFIND_DESTDIR: `${p.projectPath}/_esy/default/store/i/${id}/lib`,
@@ -132,7 +136,7 @@ describe('Build with dep', () => {
           cur__etc: `${p.esyStorePath}/s/${depId}/etc`,
           cur__doc: `${p.esyStorePath}/s/${depId}/doc`,
           cur__bin: `${p.esyStorePath}/s/${depId}/bin`,
-          PATH: [``, `/usr/local/bin`, `/usr/bin`, `/bin`, `/usr/sbin`, `/sbin`].join(
+          PATH: [``, `/usr/local/bin`, `/usr/bin`, `/bin`, `/usr/sbin`, `/sbin`, ...winsysDir].join(
             path.delimiter,
           ),
           OCAMLFIND_LDCONF: `ignore`,

--- a/test-e2e/build/with-dep.test.js
+++ b/test-e2e/build/with-dep.test.js
@@ -30,10 +30,7 @@ function makeFixture(p, buildDep) {
 
 describe('Build with dep', () => {
 
-  let winsysDir = 
-        process.platform === "win32" ?  
-        [path.join(process.env["windir"], "System32").split("\\").join("/")]
-        : [];
+  let winsysDir = process.platform === "win32" ? [helpers.getWindowsSystemDirectory()] : [];
 
   async function checkDepIsInEnv(p) {
     {

--- a/test-e2e/test/helpers.js
+++ b/test-e2e/test/helpers.js
@@ -21,7 +21,7 @@ const outdent = require('outdent');
 const isWindows = process.platform === 'win32';
 
 const getWindowsSystemDirectory = () => {
-    return path.join(process.env("windir"), "System32").split("\\").join("/");
+    return path.join(process.env["windir"], "System32").split("\\").join("/");
 };
 
 const ESY = isWindows

--- a/test-e2e/test/helpers.js
+++ b/test-e2e/test/helpers.js
@@ -20,6 +20,10 @@ const outdent = require('outdent');
 
 const isWindows = process.platform === 'win32';
 
+const getWindowsSystemDirectory = () => {
+    return path.join(process.env("windir"), "System32").split("\\").join("/");
+};
+
 const ESY = isWindows
   ? require.resolve('../../bin/esy.cmd')
   : require.resolve('../../bin/esy');
@@ -286,6 +290,7 @@ module.exports = {
   readFile: fs.readFile,
   execFile: exec.execFile,
   createTestSandbox,
+  getWindowsSystemDirectory,
   isWindows,
   dummyExecutable,
   buildCommand,


### PR DESCRIPTION
__Issue:__ `cmdliner@1.0.3` was recently released and fails to build in Windows esy environments.

The failure is: 
```
2018-11-27T18:50:16.2158348Z error: build failed with exit code: 1
2018-11-27T18:50:16.2158462Z   build log:
2018-11-27T18:50:16.2158532Z     # esy-build-package: building: @opam/cmdliner@opam:1.0.3
2018-11-27T18:50:16.2158582Z 
2018-11-27T18:50:16.2158692Z     # esy-build-package: pwd: C:\Users\VssAdministrator\.esy\3_\b\opam__s__cmdliner-opam__c__1.0.3-31a522df
2018-11-27T18:50:16.2158786Z 
2018-11-27T18:50:16.2158868Z     # esy-build-package: running: "make" "all" "PREFIX=C:/Users/VssAdministrator/.esy/3_/s/opam__s__cmdliner-opam__c__1.0.3-31a522df"
2018-11-27T18:50:16.2158985Z 
2018-11-27T18:50:16.2159040Z     ocaml build.ml cma
2018-11-27T18:50:16.2159103Z     No ocamldep found in PATH
2018-11-27T18:50:16.2159183Z 
2018-11-27T18:50:16.2159242Z     make: *** [Makefile:44: build-byte] Error 1
2018-11-27T18:50:16.2159376Z     error: command failed: "make" "all" "PREFIX=C:/Users/VssAdministrator/.esy/3_/s/opam__s__cmdliner-opam__c__1.0.3-31a522df" (exited with 2)
2018-11-27T18:50:16.2159432Z 
2018-11-27T18:50:16.2159493Z     esy-build-package: exiting with errors above...
2018-11-27T18:50:16.2159580Z 
2018-11-27T18:50:16.2159632Z     
2018-11-27T18:50:16.2159694Z   building @opam/cmdliner@opam:1.0.3@76a49c3c
```

__Defect:__ The `cmdliner` uses the following logic to determine where the `ocamldep` command is:
```
let find_cmd cmds =
  let test, null = match Sys.win32 with
  | true -> "where", " NUL"
  | false -> "type", "/dev/null"
  in
  let cmd c = Sys.command (strf "%s %s 1>%s 2>%s" test c null null) = 0 in
  try Some (List.find cmd cmds) with Not_found -> None
```

If it's win32 (which it will be on Windows), it tries to use `where`. `where` is a utility bundled with Windows, usually in C:\Windows\System32. However, we don't include this system directory in our build environment.

__Fix:__ Include the system directory in the build environment.

__Workaround:__ For now, you can work around this by adding the following resolution in your `package.json`:
```
   "resolutions": {
      "@opam/cmdliner": "1.0.2"
   } 
```