### PR TITLE
Run slowtests on Windows outside of esy env

### DIFF
--- a/.ci/build-windows.yml
+++ b/.ci/build-windows.yml
@@ -41,7 +41,7 @@ steps:
   - script: 'esy test:e2e'
     displayName: 'esy test:e2e'
 
-  - script: 'esy test:e2e-slow'
+  - script: 'node -r ./_esy/default/pnp.js ./test-e2e-slow/run-slow-tests.js'
     displayName: 'esy test:e2e-slow'
     continueOnError: true
 


### PR DESCRIPTION
This should fix failures due to hitting env limit.