### PR TITLE
Print nice error in case of circular build error

### DIFF
--- a/esy-lib/Graph.ml
+++ b/esy-lib/Graph.ml
@@ -113,7 +113,8 @@ module Make (Node : GRAPH_NODE) : GRAPH
       enqueue true (traverse node);
       process (Node.Id.Set.empty, [])
     in
-    dependencies
+
+    List.rev dependencies
 
   let find f graph =
     let f id =

--- a/test-e2e/esy-build/circular-deps-error.test.js
+++ b/test-e2e/esy-build/circular-deps-error.test.js
@@ -1,0 +1,65 @@
+// @flow
+
+const path = require('path');
+const outdent = require('outdent');
+const helpers = require('../test/helpers');
+
+function makeFixture(p) {
+  return [
+    helpers.packageJson({
+      name: 'hasCircularDeps',
+      version: '1.0.0',
+      esy: {
+        build: 'true',
+      },
+      dependencies: {
+        dep: 'path:./dep',
+      },
+    }),
+    helpers.dir(
+      'dep',
+      helpers.packageJson({
+        name: 'dep',
+        version: '1.0.0',
+        esy: {
+          build: 'true',
+        },
+        dependencies: {
+          depOfDep: 'path:../depOfDep',
+        },
+      }),
+    ),
+    helpers.dir(
+      'depOfDep',
+      helpers.packageJson({
+        name: 'depOfDep',
+        version: '1.0.0',
+        esy: {
+          build: 'true',
+        },
+        dependencies: {
+          dep: 'path:../dep',
+        },
+      }),
+    ),
+  ];
+}
+
+describe(`'esy build' command: circular dependency error`, () => {
+  test('it prints a nice error message', async () => {
+    const p = await helpers.createTestSandbox();
+    await p.fixture(...makeFixture(p));
+    await p.esy('install');
+    expect(p.esy('build')).rejects.toMatchObject({
+      stderr: outdent`
+        info esy build ${helpers.esyVersion}
+        error: found circular dependency on: dep@path:dep
+          processing depOfDep@path:depOfDep
+          processing dep@path:dep
+          processing hasCircularDeps@link:./package.json
+        esy: exiting due to errors above
+
+      `,
+    });
+  });
+});

--- a/test-e2e/esy-x-CMD.test.js
+++ b/test-e2e/esy-x-CMD.test.js
@@ -128,6 +128,9 @@ describe(`'esy x CMD' invocation`, () => {
       stdout: '__root__' + os.EOL,
     });
 
+    // wait, on macOS sometimes it doesn't pick up changes
+    await new Promise(resolve => setTimeout(resolve, 1000));
+
     await fs.writeFile(
       path.join(p.projectPath, 'root.js'),
       'console.log("__CHANGED__");',
@@ -145,6 +148,9 @@ describe(`'esy x CMD' invocation`, () => {
     await expect(p.esy('x linkedDep.cmd')).resolves.toMatchObject({
       stdout: '__linkedDep__' + os.EOL,
     });
+
+    // wait, on macOS sometimes it doesn't pick up changes
+    await new Promise(resolve => setTimeout(resolve, 1000));
 
     await fs.writeFile(
       path.join(p.projectPath, 'linkedDep', 'linkedDep.js'),

--- a/test-e2e/test/helpers.js
+++ b/test-e2e/test/helpers.js
@@ -17,11 +17,15 @@ const PackageGraph = require('./PackageGraph.js');
 const NpmRegistryMock = require('./NpmRegistryMock.js');
 const OpamRegistryMock = require('./OpamRegistryMock.js');
 const outdent = require('outdent');
+const pkgJson = require('../../package.json');
 
 const isWindows = process.platform === 'win32';
 
 const getWindowsSystemDirectory = () => {
-    return path.join(process.env["windir"], "System32").split("\\").join("/");
+  return path
+    .join(process.env['windir'], 'System32')
+    .split('\\')
+    .join('/');
 };
 
 const ESY = isWindows
@@ -309,4 +313,5 @@ module.exports = {
   dummyExecutable,
   buildCommand,
   buildCommandInOpam,
+  esyVersion: pkgJson.version,
 };


### PR DESCRIPTION
Previously we failed with an stack overflow, now we print a nice error message telling how the circular dependency appeared.

This commit also fixes Graph.allDependenciesBFS to return in BFS order, previously it was only visiting in BFS (argh!).

I've also added a test to ensure we don't regress.