### PR TITLE
esy-build.test: add build env snapshots

### DIFF
--- a/test-e2e/esy-build/__snapshots__/no-deps.test.js.snap
+++ b/test-e2e/esy-build/__snapshots__/no-deps.test.js.snap
@@ -1,0 +1,73 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`'esy build': simple executable with no deps out of source build macos: build-env --json snapshot 1`] = `
+"{
+  \\"cur__version\\": \\"1.0.0\\",
+  \\"cur__toplevel\\":
+    \\"%projectPath%/_esy/default/store/i/no_deps-2b5db858/toplevel\\",
+  \\"cur__target_dir\\":
+    \\"%projectPath%/_esy/default/store/b/no_deps-2b5db858\\",
+  \\"cur__stublibs\\":
+    \\"%projectPath%/_esy/default/store/i/no_deps-2b5db858/stublibs\\",
+  \\"cur__share\\":
+    \\"%projectPath%/_esy/default/store/i/no_deps-2b5db858/share\\",
+  \\"cur__sbin\\":
+    \\"%projectPath%/_esy/default/store/i/no_deps-2b5db858/sbin\\",
+  \\"cur__root\\": \\"%projectPath%\\",
+  \\"cur__original_root\\": \\"%projectPath%\\",
+  \\"cur__name\\": \\"no-deps\\",
+  \\"cur__man\\":
+    \\"%projectPath%/_esy/default/store/i/no_deps-2b5db858/man\\",
+  \\"cur__lib\\":
+    \\"%projectPath%/_esy/default/store/i/no_deps-2b5db858/lib\\",
+  \\"cur__install\\":
+    \\"%projectPath%/_esy/default/store/i/no_deps-2b5db858\\",
+  \\"cur__etc\\":
+    \\"%projectPath%/_esy/default/store/i/no_deps-2b5db858/etc\\",
+  \\"cur__doc\\":
+    \\"%projectPath%/_esy/default/store/i/no_deps-2b5db858/doc\\",
+  \\"cur__dev\\": \\"true\\",
+  \\"cur__bin\\":
+    \\"%projectPath%/_esy/default/store/i/no_deps-2b5db858/bin\\",
+  \\"SHELL\\": \\"env -i /bin/bash --norc --noprofile\\",
+  \\"PATH\\": \\":/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\",
+  \\"OCAMLFIND_LDCONF\\": \\"ignore\\",
+  \\"OCAMLFIND_DESTDIR\\":
+    \\"%projectPath%/_esy/default/store/i/no_deps-2b5db858/lib\\",
+  \\"DUNE_BUILD_DIR\\":
+    \\"%projectPath%/_esy/default/store/b/no_deps-2b5db858\\"
+}"
+`;
+
+exports[`'esy build': simple executable with no deps out of source build macos: build-env snapshot 1`] = `
+"# Build environment for no-deps@link:./package.json
+
+#
+# no-deps@1.0.0
+#
+export OCAMLFIND_LDCONF=\\"ignore\\"
+export OCAMLFIND_DESTDIR=\\"%projectPath%/_esy/default/store/i/no_deps-2b5db858/lib\\"
+export cur__etc=\\"%projectPath%/_esy/default/store/i/no_deps-2b5db858/etc\\"
+export cur__share=\\"%projectPath%/_esy/default/store/i/no_deps-2b5db858/share\\"
+export cur__toplevel=\\"%projectPath%/_esy/default/store/i/no_deps-2b5db858/toplevel\\"
+export cur__stublibs=\\"%projectPath%/_esy/default/store/i/no_deps-2b5db858/stublibs\\"
+export cur__doc=\\"%projectPath%/_esy/default/store/i/no_deps-2b5db858/doc\\"
+export cur__man=\\"%projectPath%/_esy/default/store/i/no_deps-2b5db858/man\\"
+export cur__lib=\\"%projectPath%/_esy/default/store/i/no_deps-2b5db858/lib\\"
+export cur__sbin=\\"%projectPath%/_esy/default/store/i/no_deps-2b5db858/sbin\\"
+export cur__bin=\\"%projectPath%/_esy/default/store/i/no_deps-2b5db858/bin\\"
+export cur__install=\\"%projectPath%/_esy/default/store/i/no_deps-2b5db858\\"
+export cur__target_dir=\\"%projectPath%/_esy/default/store/b/no_deps-2b5db858\\"
+export cur__original_root=\\"%projectPath%\\"
+export cur__root=\\"%projectPath%\\"
+export cur__dev=\\"true\\"
+export cur__version=\\"1.0.0\\"
+export cur__name=\\"no-deps\\"
+export DUNE_BUILD_DIR=\\"%projectPath%/_esy/default/store/b/no_deps-2b5db858\\"
+
+#
+# Built-in
+#
+export SHELL=\\"env -i /bin/bash --norc --noprofile\\"
+export PATH=\\"$PATH:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\""
+`;

--- a/test-e2e/esy-build/__snapshots__/no-deps.test.js.snap
+++ b/test-e2e/esy-build/__snapshots__/no-deps.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`'esy build': simple executable with no deps out of source build macos: build-env snapshot 1`] = `
+exports[`'esy build': simple executable with no deps out of source build macos || linux: build-env snapshot 1`] = `
 "# Build environment for no-deps@link:./package.json
 
 #

--- a/test-e2e/esy-build/__snapshots__/no-deps.test.js.snap
+++ b/test-e2e/esy-build/__snapshots__/no-deps.test.js.snap
@@ -1,44 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`'esy build': simple executable with no deps out of source build macos: build-env --json snapshot 1`] = `
-"{
-  \\"cur__version\\": \\"1.0.0\\",
-  \\"cur__toplevel\\":
-    \\"%projectPath%/_esy/default/store/i/no_deps-2b5db858/toplevel\\",
-  \\"cur__target_dir\\":
-    \\"%projectPath%/_esy/default/store/b/no_deps-2b5db858\\",
-  \\"cur__stublibs\\":
-    \\"%projectPath%/_esy/default/store/i/no_deps-2b5db858/stublibs\\",
-  \\"cur__share\\":
-    \\"%projectPath%/_esy/default/store/i/no_deps-2b5db858/share\\",
-  \\"cur__sbin\\":
-    \\"%projectPath%/_esy/default/store/i/no_deps-2b5db858/sbin\\",
-  \\"cur__root\\": \\"%projectPath%\\",
-  \\"cur__original_root\\": \\"%projectPath%\\",
-  \\"cur__name\\": \\"no-deps\\",
-  \\"cur__man\\":
-    \\"%projectPath%/_esy/default/store/i/no_deps-2b5db858/man\\",
-  \\"cur__lib\\":
-    \\"%projectPath%/_esy/default/store/i/no_deps-2b5db858/lib\\",
-  \\"cur__install\\":
-    \\"%projectPath%/_esy/default/store/i/no_deps-2b5db858\\",
-  \\"cur__etc\\":
-    \\"%projectPath%/_esy/default/store/i/no_deps-2b5db858/etc\\",
-  \\"cur__doc\\":
-    \\"%projectPath%/_esy/default/store/i/no_deps-2b5db858/doc\\",
-  \\"cur__dev\\": \\"true\\",
-  \\"cur__bin\\":
-    \\"%projectPath%/_esy/default/store/i/no_deps-2b5db858/bin\\",
-  \\"SHELL\\": \\"env -i /bin/bash --norc --noprofile\\",
-  \\"PATH\\": \\":/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\",
-  \\"OCAMLFIND_LDCONF\\": \\"ignore\\",
-  \\"OCAMLFIND_DESTDIR\\":
-    \\"%projectPath%/_esy/default/store/i/no_deps-2b5db858/lib\\",
-  \\"DUNE_BUILD_DIR\\":
-    \\"%projectPath%/_esy/default/store/b/no_deps-2b5db858\\"
-}"
-`;
-
 exports[`'esy build': simple executable with no deps out of source build macos: build-env snapshot 1`] = `
 "# Build environment for no-deps@link:./package.json
 
@@ -46,24 +7,24 @@ exports[`'esy build': simple executable with no deps out of source build macos: 
 # no-deps@1.0.0
 #
 export OCAMLFIND_LDCONF=\\"ignore\\"
-export OCAMLFIND_DESTDIR=\\"%projectPath%/_esy/default/store/i/no_deps-2b5db858/lib\\"
-export cur__etc=\\"%projectPath%/_esy/default/store/i/no_deps-2b5db858/etc\\"
-export cur__share=\\"%projectPath%/_esy/default/store/i/no_deps-2b5db858/share\\"
-export cur__toplevel=\\"%projectPath%/_esy/default/store/i/no_deps-2b5db858/toplevel\\"
-export cur__stublibs=\\"%projectPath%/_esy/default/store/i/no_deps-2b5db858/stublibs\\"
-export cur__doc=\\"%projectPath%/_esy/default/store/i/no_deps-2b5db858/doc\\"
-export cur__man=\\"%projectPath%/_esy/default/store/i/no_deps-2b5db858/man\\"
-export cur__lib=\\"%projectPath%/_esy/default/store/i/no_deps-2b5db858/lib\\"
-export cur__sbin=\\"%projectPath%/_esy/default/store/i/no_deps-2b5db858/sbin\\"
-export cur__bin=\\"%projectPath%/_esy/default/store/i/no_deps-2b5db858/bin\\"
-export cur__install=\\"%projectPath%/_esy/default/store/i/no_deps-2b5db858\\"
-export cur__target_dir=\\"%projectPath%/_esy/default/store/b/no_deps-2b5db858\\"
+export OCAMLFIND_DESTDIR=\\"%projectPath%/_esy/default/store/i/%id%/lib\\"
+export cur__etc=\\"%projectPath%/_esy/default/store/i/%id%/etc\\"
+export cur__share=\\"%projectPath%/_esy/default/store/i/%id%/share\\"
+export cur__toplevel=\\"%projectPath%/_esy/default/store/i/%id%/toplevel\\"
+export cur__stublibs=\\"%projectPath%/_esy/default/store/i/%id%/stublibs\\"
+export cur__doc=\\"%projectPath%/_esy/default/store/i/%id%/doc\\"
+export cur__man=\\"%projectPath%/_esy/default/store/i/%id%/man\\"
+export cur__lib=\\"%projectPath%/_esy/default/store/i/%id%/lib\\"
+export cur__sbin=\\"%projectPath%/_esy/default/store/i/%id%/sbin\\"
+export cur__bin=\\"%projectPath%/_esy/default/store/i/%id%/bin\\"
+export cur__install=\\"%projectPath%/_esy/default/store/i/%id%\\"
+export cur__target_dir=\\"%projectPath%/_esy/default/store/b/%id%\\"
 export cur__original_root=\\"%projectPath%\\"
 export cur__root=\\"%projectPath%\\"
 export cur__dev=\\"true\\"
 export cur__version=\\"1.0.0\\"
 export cur__name=\\"no-deps\\"
-export DUNE_BUILD_DIR=\\"%projectPath%/_esy/default/store/b/no_deps-2b5db858\\"
+export DUNE_BUILD_DIR=\\"%projectPath%/_esy/default/store/b/%id%\\"
 
 #
 # Built-in

--- a/test-e2e/esy-build/__snapshots__/optDependencies.test.js.snap
+++ b/test-e2e/esy-build/__snapshots__/optDependencies.test.js.snap
@@ -6,18 +6,18 @@ exports[`Build with optDependencies builds w/ opt dependency installed snapshot 
 #
 # optDep@1.0.0
 #
-export CAML_LD_LIBRARY_PATH=\\"%esyStorePath%/i/optdep-f9d4268f/stublibs:%esyStorePath%/i/optdep-f9d4268f/lib/stublibs:$CAML_LD_LIBRARY_PATH\\"
-export OCAMLPATH=\\"%esyStorePath%/i/optdep-f9d4268f/lib:$OCAMLPATH\\"
-export MAN_PATH=\\"%esyStorePath%/i/optdep-f9d4268f/man:$MAN_PATH\\"
-export PATH=\\"%esyStorePath%/i/optdep-f9d4268f/bin:$PATH\\"
+export CAML_LD_LIBRARY_PATH=\\"%esyStorePath%/i/%optdepid%/stublibs:%esyStorePath%/i/%optdepid%/lib/stublibs:$CAML_LD_LIBRARY_PATH\\"
+export OCAMLPATH=\\"%esyStorePath%/i/%optdepid%/lib:$OCAMLPATH\\"
+export MAN_PATH=\\"%esyStorePath%/i/%optdepid%/man:$MAN_PATH\\"
+export PATH=\\"%esyStorePath%/i/%optdepid%/bin:$PATH\\"
 
 #
 # dep@1.0.0
 #
-export CAML_LD_LIBRARY_PATH=\\"%esyStorePath%/i/dep-09cf1d25/stublibs:%esyStorePath%/i/dep-09cf1d25/lib/stublibs:$CAML_LD_LIBRARY_PATH\\"
-export OCAMLPATH=\\"%esyStorePath%/i/dep-09cf1d25/lib:$OCAMLPATH\\"
-export MAN_PATH=\\"%esyStorePath%/i/dep-09cf1d25/man:$MAN_PATH\\"
-export PATH=\\"%esyStorePath%/i/dep-09cf1d25/bin:$PATH\\"
+export CAML_LD_LIBRARY_PATH=\\"%esyStorePath%/i/%depid%/stublibs:%esyStorePath%/i/%depid%/lib/stublibs:$CAML_LD_LIBRARY_PATH\\"
+export OCAMLPATH=\\"%esyStorePath%/i/%depid%/lib:$OCAMLPATH\\"
+export MAN_PATH=\\"%esyStorePath%/i/%depid%/man:$MAN_PATH\\"
+export PATH=\\"%esyStorePath%/i/%depid%/bin:$PATH\\"
 
 #
 # root@1.0.0
@@ -55,10 +55,10 @@ exports[`Build with optDependencies builds w/ opt dependency installed snapshot 
 #
 # optDep@1.0.0
 #
-export CAML_LD_LIBRARY_PATH=\\"%esyStorePath%/i/optdep-f9d4268f/stublibs:%esyStorePath%/i/optdep-f9d4268f/lib/stublibs:$CAML_LD_LIBRARY_PATH\\"
-export OCAMLPATH=\\"%esyStorePath%/i/optdep-f9d4268f/lib:$OCAMLPATH\\"
-export MAN_PATH=\\"%esyStorePath%/i/optdep-f9d4268f/man:$MAN_PATH\\"
-export PATH=\\"%esyStorePath%/i/optdep-f9d4268f/bin:$PATH\\"
+export CAML_LD_LIBRARY_PATH=\\"%esyStorePath%/i/%optdepid%/stublibs:%esyStorePath%/i/%optdepid%/lib/stublibs:$CAML_LD_LIBRARY_PATH\\"
+export OCAMLPATH=\\"%esyStorePath%/i/%optdepid%/lib:$OCAMLPATH\\"
+export MAN_PATH=\\"%esyStorePath%/i/%optdepid%/man:$MAN_PATH\\"
+export PATH=\\"%esyStorePath%/i/%optdepid%/bin:$PATH\\"
 
 #
 # dep@1.0.0
@@ -96,10 +96,10 @@ exports[`Build with optDependencies builds w/o opt dependency installed snapshot
 #
 # dep@1.0.0
 #
-export CAML_LD_LIBRARY_PATH=\\"%esyStorePath%/i/dep-53a9a3ba/stublibs:%esyStorePath%/i/dep-53a9a3ba/lib/stublibs:$CAML_LD_LIBRARY_PATH\\"
-export OCAMLPATH=\\"%esyStorePath%/i/dep-53a9a3ba/lib:$OCAMLPATH\\"
-export MAN_PATH=\\"%esyStorePath%/i/dep-53a9a3ba/man:$MAN_PATH\\"
-export PATH=\\"%esyStorePath%/i/dep-53a9a3ba/bin:$PATH\\"
+export CAML_LD_LIBRARY_PATH=\\"%esyStorePath%/i/%depid%/stublibs:%esyStorePath%/i/%depid%/lib/stublibs:$CAML_LD_LIBRARY_PATH\\"
+export OCAMLPATH=\\"%esyStorePath%/i/%depid%/lib:$OCAMLPATH\\"
+export MAN_PATH=\\"%esyStorePath%/i/%depid%/man:$MAN_PATH\\"
+export PATH=\\"%esyStorePath%/i/%depid%/bin:$PATH\\"
 
 #
 # root@1.0.0

--- a/test-e2e/esy-build/__snapshots__/optDependencies.test.js.snap
+++ b/test-e2e/esy-build/__snapshots__/optDependencies.test.js.snap
@@ -1,0 +1,165 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Build with optDependencies builds w/ opt dependency installed 1`] = `
+"# Build environment for root@link:./package.json
+
+#
+# optDep@1.0.0
+#
+export CAML_LD_LIBRARY_PATH=\\"%esyPrefixPath%/3_________________________________________________________/i/optdep-f9d4268f/stublibs:%esyPrefixPath%/3_________________________________________________________/i/optdep-f9d4268f/lib/stublibs:$CAML_LD_LIBRARY_PATH\\"
+export OCAMLPATH=\\"%esyPrefixPath%/3_________________________________________________________/i/optdep-f9d4268f/lib:$OCAMLPATH\\"
+export MAN_PATH=\\"%esyPrefixPath%/3_________________________________________________________/i/optdep-f9d4268f/man:$MAN_PATH\\"
+export PATH=\\"%esyPrefixPath%/3_________________________________________________________/i/optdep-f9d4268f/bin:$PATH\\"
+
+#
+# dep@1.0.0
+#
+export CAML_LD_LIBRARY_PATH=\\"%esyPrefixPath%/3_________________________________________________________/i/dep-09cf1d25/stublibs:%esyPrefixPath%/3_________________________________________________________/i/dep-09cf1d25/lib/stublibs:$CAML_LD_LIBRARY_PATH\\"
+export OCAMLPATH=\\"%esyPrefixPath%/3_________________________________________________________/i/dep-09cf1d25/lib:$OCAMLPATH\\"
+export MAN_PATH=\\"%esyPrefixPath%/3_________________________________________________________/i/dep-09cf1d25/man:$MAN_PATH\\"
+export PATH=\\"%esyPrefixPath%/3_________________________________________________________/i/dep-09cf1d25/bin:$PATH\\"
+
+#
+# root@1.0.0
+#
+export OCAMLFIND_LDCONF=\\"ignore\\"
+export OCAMLFIND_DESTDIR=\\"%projectPath%/_esy/default/store/i/root-fcc61fbb/lib\\"
+export cur__etc=\\"%projectPath%/_esy/default/store/i/root-fcc61fbb/etc\\"
+export cur__share=\\"%projectPath%/_esy/default/store/i/root-fcc61fbb/share\\"
+export cur__toplevel=\\"%projectPath%/_esy/default/store/i/root-fcc61fbb/toplevel\\"
+export cur__stublibs=\\"%projectPath%/_esy/default/store/i/root-fcc61fbb/stublibs\\"
+export cur__doc=\\"%projectPath%/_esy/default/store/i/root-fcc61fbb/doc\\"
+export cur__man=\\"%projectPath%/_esy/default/store/i/root-fcc61fbb/man\\"
+export cur__lib=\\"%projectPath%/_esy/default/store/i/root-fcc61fbb/lib\\"
+export cur__sbin=\\"%projectPath%/_esy/default/store/i/root-fcc61fbb/sbin\\"
+export cur__bin=\\"%projectPath%/_esy/default/store/i/root-fcc61fbb/bin\\"
+export cur__install=\\"%projectPath%/_esy/default/store/i/root-fcc61fbb\\"
+export cur__target_dir=\\"%projectPath%/_esy/default/store/b/root-fcc61fbb\\"
+export cur__original_root=\\"%projectPath%\\"
+export cur__root=\\"%projectPath%\\"
+export cur__dev=\\"true\\"
+export cur__version=\\"1.0.0\\"
+export cur__name=\\"root\\"
+export DUNE_BUILD_DIR=\\"%projectPath%/_esy/default/store/b/root-fcc61fbb\\"
+
+#
+# Built-in
+#
+export SHELL=\\"env -i /bin/bash --norc --noprofile\\"
+export PATH=\\"$PATH:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\""
+`;
+
+exports[`Build with optDependencies builds w/ opt dependency installed 2`] = `
+"# Build environment for dep@path:dep
+
+#
+# optDep@1.0.0
+#
+export CAML_LD_LIBRARY_PATH=\\"%esyPrefixPath%/3_________________________________________________________/i/optdep-f9d4268f/stublibs:%esyPrefixPath%/3_________________________________________________________/i/optdep-f9d4268f/lib/stublibs:$CAML_LD_LIBRARY_PATH\\"
+export OCAMLPATH=\\"%esyPrefixPath%/3_________________________________________________________/i/optdep-f9d4268f/lib:$OCAMLPATH\\"
+export MAN_PATH=\\"%esyPrefixPath%/3_________________________________________________________/i/optdep-f9d4268f/man:$MAN_PATH\\"
+export PATH=\\"%esyPrefixPath%/3_________________________________________________________/i/optdep-f9d4268f/bin:$PATH\\"
+
+#
+# dep@1.0.0
+#
+export OCAMLFIND_LDCONF=\\"ignore\\"
+export OCAMLFIND_DESTDIR=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-09cf1d25/lib\\"
+export cur__etc=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-09cf1d25/etc\\"
+export cur__share=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-09cf1d25/share\\"
+export cur__toplevel=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-09cf1d25/toplevel\\"
+export cur__stublibs=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-09cf1d25/stublibs\\"
+export cur__doc=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-09cf1d25/doc\\"
+export cur__man=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-09cf1d25/man\\"
+export cur__lib=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-09cf1d25/lib\\"
+export cur__sbin=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-09cf1d25/sbin\\"
+export cur__bin=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-09cf1d25/bin\\"
+export cur__install=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-09cf1d25\\"
+export cur__target_dir=\\"%esyPrefixPath%/3_________________________________________________________/b/dep-09cf1d25\\"
+export cur__original_root=\\"%esyPrefixPath%/esyi/source/i/dep--67b360d9a56facfd6fc9b90817f589ec\\"
+export cur__root=\\"%esyPrefixPath%/esyi/source/i/dep--67b360d9a56facfd6fc9b90817f589ec\\"
+export cur__dev=\\"false\\"
+export cur__version=\\"1.0.0\\"
+export cur__name=\\"dep\\"
+export DUNE_BUILD_DIR=\\"%esyPrefixPath%/3_________________________________________________________/b/dep-09cf1d25\\"
+
+#
+# Built-in
+#
+export SHELL=\\"env -i /bin/bash --norc --noprofile\\"
+export PATH=\\"$PATH:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\""
+`;
+
+exports[`Build with optDependencies builds w/o opt dependency installed 1`] = `
+"# Build environment for root@link:./package.json
+
+#
+# dep@1.0.0
+#
+export CAML_LD_LIBRARY_PATH=\\"%esyPrefixPath%/3_________________________________________________________/i/dep-53a9a3ba/stublibs:%esyPrefixPath%/3_________________________________________________________/i/dep-53a9a3ba/lib/stublibs:$CAML_LD_LIBRARY_PATH\\"
+export OCAMLPATH=\\"%esyPrefixPath%/3_________________________________________________________/i/dep-53a9a3ba/lib:$OCAMLPATH\\"
+export MAN_PATH=\\"%esyPrefixPath%/3_________________________________________________________/i/dep-53a9a3ba/man:$MAN_PATH\\"
+export PATH=\\"%esyPrefixPath%/3_________________________________________________________/i/dep-53a9a3ba/bin:$PATH\\"
+
+#
+# root@1.0.0
+#
+export OCAMLFIND_LDCONF=\\"ignore\\"
+export OCAMLFIND_DESTDIR=\\"%projectPath%/_esy/default/store/i/root-80f266a4/lib\\"
+export cur__etc=\\"%projectPath%/_esy/default/store/i/root-80f266a4/etc\\"
+export cur__share=\\"%projectPath%/_esy/default/store/i/root-80f266a4/share\\"
+export cur__toplevel=\\"%projectPath%/_esy/default/store/i/root-80f266a4/toplevel\\"
+export cur__stublibs=\\"%projectPath%/_esy/default/store/i/root-80f266a4/stublibs\\"
+export cur__doc=\\"%projectPath%/_esy/default/store/i/root-80f266a4/doc\\"
+export cur__man=\\"%projectPath%/_esy/default/store/i/root-80f266a4/man\\"
+export cur__lib=\\"%projectPath%/_esy/default/store/i/root-80f266a4/lib\\"
+export cur__sbin=\\"%projectPath%/_esy/default/store/i/root-80f266a4/sbin\\"
+export cur__bin=\\"%projectPath%/_esy/default/store/i/root-80f266a4/bin\\"
+export cur__install=\\"%projectPath%/_esy/default/store/i/root-80f266a4\\"
+export cur__target_dir=\\"%projectPath%/_esy/default/store/b/root-80f266a4\\"
+export cur__original_root=\\"%projectPath%\\"
+export cur__root=\\"%projectPath%\\"
+export cur__dev=\\"true\\"
+export cur__version=\\"1.0.0\\"
+export cur__name=\\"root\\"
+export DUNE_BUILD_DIR=\\"%projectPath%/_esy/default/store/b/root-80f266a4\\"
+
+#
+# Built-in
+#
+export SHELL=\\"env -i /bin/bash --norc --noprofile\\"
+export PATH=\\"$PATH:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\""
+`;
+
+exports[`Build with optDependencies builds w/o opt dependency installed 2`] = `
+"# Build environment for dep@path:dep
+
+#
+# dep@1.0.0
+#
+export OCAMLFIND_LDCONF=\\"ignore\\"
+export OCAMLFIND_DESTDIR=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-53a9a3ba/lib\\"
+export cur__etc=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-53a9a3ba/etc\\"
+export cur__share=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-53a9a3ba/share\\"
+export cur__toplevel=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-53a9a3ba/toplevel\\"
+export cur__stublibs=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-53a9a3ba/stublibs\\"
+export cur__doc=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-53a9a3ba/doc\\"
+export cur__man=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-53a9a3ba/man\\"
+export cur__lib=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-53a9a3ba/lib\\"
+export cur__sbin=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-53a9a3ba/sbin\\"
+export cur__bin=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-53a9a3ba/bin\\"
+export cur__install=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-53a9a3ba\\"
+export cur__target_dir=\\"%esyPrefixPath%/3_________________________________________________________/b/dep-53a9a3ba\\"
+export cur__original_root=\\"%esyPrefixPath%/esyi/source/i/dep--67b360d9a56facfd6fc9b90817f589ec\\"
+export cur__root=\\"%esyPrefixPath%/esyi/source/i/dep--67b360d9a56facfd6fc9b90817f589ec\\"
+export cur__dev=\\"false\\"
+export cur__version=\\"1.0.0\\"
+export cur__name=\\"dep\\"
+export DUNE_BUILD_DIR=\\"%esyPrefixPath%/3_________________________________________________________/b/dep-53a9a3ba\\"
+
+#
+# Built-in
+#
+export SHELL=\\"env -i /bin/bash --norc --noprofile\\"
+export PATH=\\"$PATH:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\""
+`;

--- a/test-e2e/esy-build/__snapshots__/optDependencies.test.js.snap
+++ b/test-e2e/esy-build/__snapshots__/optDependencies.test.js.snap
@@ -6,41 +6,41 @@ exports[`Build with optDependencies builds w/ opt dependency installed snapshot 
 #
 # optDep@1.0.0
 #
-export CAML_LD_LIBRARY_PATH=\\"%esyPrefixPath%/3_________________________________________________________/i/optdep-f9d4268f/stublibs:%esyPrefixPath%/3_________________________________________________________/i/optdep-f9d4268f/lib/stublibs:$CAML_LD_LIBRARY_PATH\\"
-export OCAMLPATH=\\"%esyPrefixPath%/3_________________________________________________________/i/optdep-f9d4268f/lib:$OCAMLPATH\\"
-export MAN_PATH=\\"%esyPrefixPath%/3_________________________________________________________/i/optdep-f9d4268f/man:$MAN_PATH\\"
-export PATH=\\"%esyPrefixPath%/3_________________________________________________________/i/optdep-f9d4268f/bin:$PATH\\"
+export CAML_LD_LIBRARY_PATH=\\"%esyStorePath%/i/optdep-f9d4268f/stublibs:%esyStorePath%/i/optdep-f9d4268f/lib/stublibs:$CAML_LD_LIBRARY_PATH\\"
+export OCAMLPATH=\\"%esyStorePath%/i/optdep-f9d4268f/lib:$OCAMLPATH\\"
+export MAN_PATH=\\"%esyStorePath%/i/optdep-f9d4268f/man:$MAN_PATH\\"
+export PATH=\\"%esyStorePath%/i/optdep-f9d4268f/bin:$PATH\\"
 
 #
 # dep@1.0.0
 #
-export CAML_LD_LIBRARY_PATH=\\"%esyPrefixPath%/3_________________________________________________________/i/dep-09cf1d25/stublibs:%esyPrefixPath%/3_________________________________________________________/i/dep-09cf1d25/lib/stublibs:$CAML_LD_LIBRARY_PATH\\"
-export OCAMLPATH=\\"%esyPrefixPath%/3_________________________________________________________/i/dep-09cf1d25/lib:$OCAMLPATH\\"
-export MAN_PATH=\\"%esyPrefixPath%/3_________________________________________________________/i/dep-09cf1d25/man:$MAN_PATH\\"
-export PATH=\\"%esyPrefixPath%/3_________________________________________________________/i/dep-09cf1d25/bin:$PATH\\"
+export CAML_LD_LIBRARY_PATH=\\"%esyStorePath%/i/dep-09cf1d25/stublibs:%esyStorePath%/i/dep-09cf1d25/lib/stublibs:$CAML_LD_LIBRARY_PATH\\"
+export OCAMLPATH=\\"%esyStorePath%/i/dep-09cf1d25/lib:$OCAMLPATH\\"
+export MAN_PATH=\\"%esyStorePath%/i/dep-09cf1d25/man:$MAN_PATH\\"
+export PATH=\\"%esyStorePath%/i/dep-09cf1d25/bin:$PATH\\"
 
 #
 # root@1.0.0
 #
 export OCAMLFIND_LDCONF=\\"ignore\\"
-export OCAMLFIND_DESTDIR=\\"%projectPath%/_esy/default/store/i/root-fcc61fbb/lib\\"
-export cur__etc=\\"%projectPath%/_esy/default/store/i/root-fcc61fbb/etc\\"
-export cur__share=\\"%projectPath%/_esy/default/store/i/root-fcc61fbb/share\\"
-export cur__toplevel=\\"%projectPath%/_esy/default/store/i/root-fcc61fbb/toplevel\\"
-export cur__stublibs=\\"%projectPath%/_esy/default/store/i/root-fcc61fbb/stublibs\\"
-export cur__doc=\\"%projectPath%/_esy/default/store/i/root-fcc61fbb/doc\\"
-export cur__man=\\"%projectPath%/_esy/default/store/i/root-fcc61fbb/man\\"
-export cur__lib=\\"%projectPath%/_esy/default/store/i/root-fcc61fbb/lib\\"
-export cur__sbin=\\"%projectPath%/_esy/default/store/i/root-fcc61fbb/sbin\\"
-export cur__bin=\\"%projectPath%/_esy/default/store/i/root-fcc61fbb/bin\\"
-export cur__install=\\"%projectPath%/_esy/default/store/i/root-fcc61fbb\\"
-export cur__target_dir=\\"%projectPath%/_esy/default/store/b/root-fcc61fbb\\"
+export OCAMLFIND_DESTDIR=\\"%projectPath%/_esy/default/store/i/%id%/lib\\"
+export cur__etc=\\"%projectPath%/_esy/default/store/i/%id%/etc\\"
+export cur__share=\\"%projectPath%/_esy/default/store/i/%id%/share\\"
+export cur__toplevel=\\"%projectPath%/_esy/default/store/i/%id%/toplevel\\"
+export cur__stublibs=\\"%projectPath%/_esy/default/store/i/%id%/stublibs\\"
+export cur__doc=\\"%projectPath%/_esy/default/store/i/%id%/doc\\"
+export cur__man=\\"%projectPath%/_esy/default/store/i/%id%/man\\"
+export cur__lib=\\"%projectPath%/_esy/default/store/i/%id%/lib\\"
+export cur__sbin=\\"%projectPath%/_esy/default/store/i/%id%/sbin\\"
+export cur__bin=\\"%projectPath%/_esy/default/store/i/%id%/bin\\"
+export cur__install=\\"%projectPath%/_esy/default/store/i/%id%\\"
+export cur__target_dir=\\"%projectPath%/_esy/default/store/b/%id%\\"
 export cur__original_root=\\"%projectPath%\\"
 export cur__root=\\"%projectPath%\\"
 export cur__dev=\\"true\\"
 export cur__version=\\"1.0.0\\"
 export cur__name=\\"root\\"
-export DUNE_BUILD_DIR=\\"%projectPath%/_esy/default/store/b/root-fcc61fbb\\"
+export DUNE_BUILD_DIR=\\"%projectPath%/_esy/default/store/b/%id%\\"
 
 #
 # Built-in
@@ -55,33 +55,33 @@ exports[`Build with optDependencies builds w/ opt dependency installed snapshot 
 #
 # optDep@1.0.0
 #
-export CAML_LD_LIBRARY_PATH=\\"%esyPrefixPath%/3_________________________________________________________/i/optdep-f9d4268f/stublibs:%esyPrefixPath%/3_________________________________________________________/i/optdep-f9d4268f/lib/stublibs:$CAML_LD_LIBRARY_PATH\\"
-export OCAMLPATH=\\"%esyPrefixPath%/3_________________________________________________________/i/optdep-f9d4268f/lib:$OCAMLPATH\\"
-export MAN_PATH=\\"%esyPrefixPath%/3_________________________________________________________/i/optdep-f9d4268f/man:$MAN_PATH\\"
-export PATH=\\"%esyPrefixPath%/3_________________________________________________________/i/optdep-f9d4268f/bin:$PATH\\"
+export CAML_LD_LIBRARY_PATH=\\"%esyStorePath%/i/optdep-f9d4268f/stublibs:%esyStorePath%/i/optdep-f9d4268f/lib/stublibs:$CAML_LD_LIBRARY_PATH\\"
+export OCAMLPATH=\\"%esyStorePath%/i/optdep-f9d4268f/lib:$OCAMLPATH\\"
+export MAN_PATH=\\"%esyStorePath%/i/optdep-f9d4268f/man:$MAN_PATH\\"
+export PATH=\\"%esyStorePath%/i/optdep-f9d4268f/bin:$PATH\\"
 
 #
 # dep@1.0.0
 #
 export OCAMLFIND_LDCONF=\\"ignore\\"
-export OCAMLFIND_DESTDIR=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-09cf1d25/lib\\"
-export cur__etc=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-09cf1d25/etc\\"
-export cur__share=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-09cf1d25/share\\"
-export cur__toplevel=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-09cf1d25/toplevel\\"
-export cur__stublibs=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-09cf1d25/stublibs\\"
-export cur__doc=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-09cf1d25/doc\\"
-export cur__man=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-09cf1d25/man\\"
-export cur__lib=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-09cf1d25/lib\\"
-export cur__sbin=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-09cf1d25/sbin\\"
-export cur__bin=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-09cf1d25/bin\\"
-export cur__install=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-09cf1d25\\"
-export cur__target_dir=\\"%esyPrefixPath%/3_________________________________________________________/b/dep-09cf1d25\\"
+export OCAMLFIND_DESTDIR=\\"%esyStorePath%/s/%id%/lib\\"
+export cur__etc=\\"%esyStorePath%/s/%id%/etc\\"
+export cur__share=\\"%esyStorePath%/s/%id%/share\\"
+export cur__toplevel=\\"%esyStorePath%/s/%id%/toplevel\\"
+export cur__stublibs=\\"%esyStorePath%/s/%id%/stublibs\\"
+export cur__doc=\\"%esyStorePath%/s/%id%/doc\\"
+export cur__man=\\"%esyStorePath%/s/%id%/man\\"
+export cur__lib=\\"%esyStorePath%/s/%id%/lib\\"
+export cur__sbin=\\"%esyStorePath%/s/%id%/sbin\\"
+export cur__bin=\\"%esyStorePath%/s/%id%/bin\\"
+export cur__install=\\"%esyStorePath%/s/%id%\\"
+export cur__target_dir=\\"%esyStorePath%/b/%id%\\"
 export cur__original_root=\\"%esyPrefixPath%/esyi/source/i/dep--67b360d9a56facfd6fc9b90817f589ec\\"
 export cur__root=\\"%esyPrefixPath%/esyi/source/i/dep--67b360d9a56facfd6fc9b90817f589ec\\"
 export cur__dev=\\"false\\"
 export cur__version=\\"1.0.0\\"
 export cur__name=\\"dep\\"
-export DUNE_BUILD_DIR=\\"%esyPrefixPath%/3_________________________________________________________/b/dep-09cf1d25\\"
+export DUNE_BUILD_DIR=\\"%esyStorePath%/b/%id%\\"
 
 #
 # Built-in
@@ -96,33 +96,33 @@ exports[`Build with optDependencies builds w/o opt dependency installed snapshot
 #
 # dep@1.0.0
 #
-export CAML_LD_LIBRARY_PATH=\\"%esyPrefixPath%/3_________________________________________________________/i/dep-53a9a3ba/stublibs:%esyPrefixPath%/3_________________________________________________________/i/dep-53a9a3ba/lib/stublibs:$CAML_LD_LIBRARY_PATH\\"
-export OCAMLPATH=\\"%esyPrefixPath%/3_________________________________________________________/i/dep-53a9a3ba/lib:$OCAMLPATH\\"
-export MAN_PATH=\\"%esyPrefixPath%/3_________________________________________________________/i/dep-53a9a3ba/man:$MAN_PATH\\"
-export PATH=\\"%esyPrefixPath%/3_________________________________________________________/i/dep-53a9a3ba/bin:$PATH\\"
+export CAML_LD_LIBRARY_PATH=\\"%esyStorePath%/i/dep-53a9a3ba/stublibs:%esyStorePath%/i/dep-53a9a3ba/lib/stublibs:$CAML_LD_LIBRARY_PATH\\"
+export OCAMLPATH=\\"%esyStorePath%/i/dep-53a9a3ba/lib:$OCAMLPATH\\"
+export MAN_PATH=\\"%esyStorePath%/i/dep-53a9a3ba/man:$MAN_PATH\\"
+export PATH=\\"%esyStorePath%/i/dep-53a9a3ba/bin:$PATH\\"
 
 #
 # root@1.0.0
 #
 export OCAMLFIND_LDCONF=\\"ignore\\"
-export OCAMLFIND_DESTDIR=\\"%projectPath%/_esy/default/store/i/root-80f266a4/lib\\"
-export cur__etc=\\"%projectPath%/_esy/default/store/i/root-80f266a4/etc\\"
-export cur__share=\\"%projectPath%/_esy/default/store/i/root-80f266a4/share\\"
-export cur__toplevel=\\"%projectPath%/_esy/default/store/i/root-80f266a4/toplevel\\"
-export cur__stublibs=\\"%projectPath%/_esy/default/store/i/root-80f266a4/stublibs\\"
-export cur__doc=\\"%projectPath%/_esy/default/store/i/root-80f266a4/doc\\"
-export cur__man=\\"%projectPath%/_esy/default/store/i/root-80f266a4/man\\"
-export cur__lib=\\"%projectPath%/_esy/default/store/i/root-80f266a4/lib\\"
-export cur__sbin=\\"%projectPath%/_esy/default/store/i/root-80f266a4/sbin\\"
-export cur__bin=\\"%projectPath%/_esy/default/store/i/root-80f266a4/bin\\"
-export cur__install=\\"%projectPath%/_esy/default/store/i/root-80f266a4\\"
-export cur__target_dir=\\"%projectPath%/_esy/default/store/b/root-80f266a4\\"
+export OCAMLFIND_DESTDIR=\\"%projectPath%/_esy/default/store/i/%id%/lib\\"
+export cur__etc=\\"%projectPath%/_esy/default/store/i/%id%/etc\\"
+export cur__share=\\"%projectPath%/_esy/default/store/i/%id%/share\\"
+export cur__toplevel=\\"%projectPath%/_esy/default/store/i/%id%/toplevel\\"
+export cur__stublibs=\\"%projectPath%/_esy/default/store/i/%id%/stublibs\\"
+export cur__doc=\\"%projectPath%/_esy/default/store/i/%id%/doc\\"
+export cur__man=\\"%projectPath%/_esy/default/store/i/%id%/man\\"
+export cur__lib=\\"%projectPath%/_esy/default/store/i/%id%/lib\\"
+export cur__sbin=\\"%projectPath%/_esy/default/store/i/%id%/sbin\\"
+export cur__bin=\\"%projectPath%/_esy/default/store/i/%id%/bin\\"
+export cur__install=\\"%projectPath%/_esy/default/store/i/%id%\\"
+export cur__target_dir=\\"%projectPath%/_esy/default/store/b/%id%\\"
 export cur__original_root=\\"%projectPath%\\"
 export cur__root=\\"%projectPath%\\"
 export cur__dev=\\"true\\"
 export cur__version=\\"1.0.0\\"
 export cur__name=\\"root\\"
-export DUNE_BUILD_DIR=\\"%projectPath%/_esy/default/store/b/root-80f266a4\\"
+export DUNE_BUILD_DIR=\\"%projectPath%/_esy/default/store/b/%id%\\"
 
 #
 # Built-in
@@ -138,24 +138,24 @@ exports[`Build with optDependencies builds w/o opt dependency installed snapshot
 # dep@1.0.0
 #
 export OCAMLFIND_LDCONF=\\"ignore\\"
-export OCAMLFIND_DESTDIR=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-53a9a3ba/lib\\"
-export cur__etc=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-53a9a3ba/etc\\"
-export cur__share=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-53a9a3ba/share\\"
-export cur__toplevel=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-53a9a3ba/toplevel\\"
-export cur__stublibs=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-53a9a3ba/stublibs\\"
-export cur__doc=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-53a9a3ba/doc\\"
-export cur__man=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-53a9a3ba/man\\"
-export cur__lib=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-53a9a3ba/lib\\"
-export cur__sbin=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-53a9a3ba/sbin\\"
-export cur__bin=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-53a9a3ba/bin\\"
-export cur__install=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-53a9a3ba\\"
-export cur__target_dir=\\"%esyPrefixPath%/3_________________________________________________________/b/dep-53a9a3ba\\"
+export OCAMLFIND_DESTDIR=\\"%esyStorePath%/s/%id%/lib\\"
+export cur__etc=\\"%esyStorePath%/s/%id%/etc\\"
+export cur__share=\\"%esyStorePath%/s/%id%/share\\"
+export cur__toplevel=\\"%esyStorePath%/s/%id%/toplevel\\"
+export cur__stublibs=\\"%esyStorePath%/s/%id%/stublibs\\"
+export cur__doc=\\"%esyStorePath%/s/%id%/doc\\"
+export cur__man=\\"%esyStorePath%/s/%id%/man\\"
+export cur__lib=\\"%esyStorePath%/s/%id%/lib\\"
+export cur__sbin=\\"%esyStorePath%/s/%id%/sbin\\"
+export cur__bin=\\"%esyStorePath%/s/%id%/bin\\"
+export cur__install=\\"%esyStorePath%/s/%id%\\"
+export cur__target_dir=\\"%esyStorePath%/b/%id%\\"
 export cur__original_root=\\"%esyPrefixPath%/esyi/source/i/dep--67b360d9a56facfd6fc9b90817f589ec\\"
 export cur__root=\\"%esyPrefixPath%/esyi/source/i/dep--67b360d9a56facfd6fc9b90817f589ec\\"
 export cur__dev=\\"false\\"
 export cur__version=\\"1.0.0\\"
 export cur__name=\\"dep\\"
-export DUNE_BUILD_DIR=\\"%esyPrefixPath%/3_________________________________________________________/b/dep-53a9a3ba\\"
+export DUNE_BUILD_DIR=\\"%esyStorePath%/b/%id%\\"
 
 #
 # Built-in

--- a/test-e2e/esy-build/__snapshots__/optDependencies.test.js.snap
+++ b/test-e2e/esy-build/__snapshots__/optDependencies.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Build with optDependencies builds w/ opt dependency installed 1`] = `
+exports[`Build with optDependencies builds w/ opt dependency installed snapshot build-env 1`] = `
 "# Build environment for root@link:./package.json
 
 #
@@ -49,7 +49,7 @@ export SHELL=\\"env -i /bin/bash --norc --noprofile\\"
 export PATH=\\"$PATH:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\""
 `;
 
-exports[`Build with optDependencies builds w/ opt dependency installed 2`] = `
+exports[`Build with optDependencies builds w/ opt dependency installed snapshot build-env 2`] = `
 "# Build environment for dep@path:dep
 
 #
@@ -90,7 +90,7 @@ export SHELL=\\"env -i /bin/bash --norc --noprofile\\"
 export PATH=\\"$PATH:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\""
 `;
 
-exports[`Build with optDependencies builds w/o opt dependency installed 1`] = `
+exports[`Build with optDependencies builds w/o opt dependency installed snapshot build-env 1`] = `
 "# Build environment for root@link:./package.json
 
 #
@@ -131,7 +131,7 @@ export SHELL=\\"env -i /bin/bash --norc --noprofile\\"
 export PATH=\\"$PATH:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\""
 `;
 
-exports[`Build with optDependencies builds w/o opt dependency installed 2`] = `
+exports[`Build with optDependencies builds w/o opt dependency installed snapshot build-env 2`] = `
 "# Build environment for dep@path:dep
 
 #

--- a/test-e2e/esy-build/__snapshots__/with-dep.test.js.snap
+++ b/test-e2e/esy-build/__snapshots__/with-dep.test.js.snap
@@ -39,10 +39,10 @@ exports[`Build with dep out of source build macos || linux: build-env snapshot 1
 #
 # dep@1.0.0
 #
-export CAML_LD_LIBRARY_PATH=\\"%esyStorePath%/i/dep-cb7685c8/stublibs:%esyStorePath%/i/dep-cb7685c8/lib/stublibs:$CAML_LD_LIBRARY_PATH\\"
-export OCAMLPATH=\\"%esyStorePath%/i/dep-cb7685c8/lib:$OCAMLPATH\\"
-export MAN_PATH=\\"%esyStorePath%/i/dep-cb7685c8/man:$MAN_PATH\\"
-export PATH=\\"%esyStorePath%/i/dep-cb7685c8/bin:$PATH\\"
+export CAML_LD_LIBRARY_PATH=\\"%esyStorePath%/i/%depid%/stublibs:%esyStorePath%/i/%depid%/lib/stublibs:$CAML_LD_LIBRARY_PATH\\"
+export OCAMLPATH=\\"%esyStorePath%/i/%depid%/lib:$OCAMLPATH\\"
+export MAN_PATH=\\"%esyStorePath%/i/%depid%/man:$MAN_PATH\\"
+export PATH=\\"%esyStorePath%/i/%depid%/bin:$PATH\\"
 
 #
 # withDep@1.0.0

--- a/test-e2e/esy-build/__snapshots__/with-dep.test.js.snap
+++ b/test-e2e/esy-build/__snapshots__/with-dep.test.js.snap
@@ -1,0 +1,162 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Build with dep out of source build macos: build-env --json dep snapshot 1`] = `
+"{
+  \\"cur__version\\": \\"1.0.0\\",
+  \\"cur__toplevel\\":
+    \\"%esyPrefixPath%/3_________________________________________________________/s/dep-cb7685c8/toplevel\\",
+  \\"cur__target_dir\\":
+    \\"%esyPrefixPath%/3_________________________________________________________/b/dep-cb7685c8\\",
+  \\"cur__stublibs\\":
+    \\"%esyPrefixPath%/3_________________________________________________________/s/dep-cb7685c8/stublibs\\",
+  \\"cur__share\\":
+    \\"%esyPrefixPath%/3_________________________________________________________/s/dep-cb7685c8/share\\",
+  \\"cur__sbin\\":
+    \\"%esyPrefixPath%/3_________________________________________________________/s/dep-cb7685c8/sbin\\",
+  \\"cur__root\\":
+    \\"%esyPrefixPath%/esyi/source/i/dep--67b360d9a56facfd6fc9b90817f589ec\\",
+  \\"cur__original_root\\":
+    \\"%esyPrefixPath%/esyi/source/i/dep--67b360d9a56facfd6fc9b90817f589ec\\",
+  \\"cur__name\\": \\"dep\\",
+  \\"cur__man\\":
+    \\"%esyPrefixPath%/3_________________________________________________________/s/dep-cb7685c8/man\\",
+  \\"cur__lib\\":
+    \\"%esyPrefixPath%/3_________________________________________________________/s/dep-cb7685c8/lib\\",
+  \\"cur__install\\":
+    \\"%esyPrefixPath%/3_________________________________________________________/s/dep-cb7685c8\\",
+  \\"cur__etc\\":
+    \\"%esyPrefixPath%/3_________________________________________________________/s/dep-cb7685c8/etc\\",
+  \\"cur__doc\\":
+    \\"%esyPrefixPath%/3_________________________________________________________/s/dep-cb7685c8/doc\\",
+  \\"cur__dev\\": \\"false\\",
+  \\"cur__bin\\":
+    \\"%esyPrefixPath%/3_________________________________________________________/s/dep-cb7685c8/bin\\",
+  \\"SHELL\\": \\"env -i /bin/bash --norc --noprofile\\",
+  \\"PATH\\": \\":/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\",
+  \\"OCAMLFIND_LDCONF\\": \\"ignore\\",
+  \\"OCAMLFIND_DESTDIR\\":
+    \\"%esyPrefixPath%/3_________________________________________________________/s/dep-cb7685c8/lib\\",
+  \\"DUNE_BUILD_DIR\\":
+    \\"%esyPrefixPath%/3_________________________________________________________/b/dep-cb7685c8\\"
+}"
+`;
+
+exports[`Build with dep out of source build macos: build-env --json snapshot 1`] = `
+"{
+  \\"cur__version\\": \\"1.0.0\\",
+  \\"cur__toplevel\\":
+    \\"%projectPath%/_esy/default/store/i/withdep-102cf969/toplevel\\",
+  \\"cur__target_dir\\":
+    \\"%projectPath%/_esy/default/store/b/withdep-102cf969\\",
+  \\"cur__stublibs\\":
+    \\"%projectPath%/_esy/default/store/i/withdep-102cf969/stublibs\\",
+  \\"cur__share\\":
+    \\"%projectPath%/_esy/default/store/i/withdep-102cf969/share\\",
+  \\"cur__sbin\\":
+    \\"%projectPath%/_esy/default/store/i/withdep-102cf969/sbin\\",
+  \\"cur__root\\": \\"%projectPath%\\",
+  \\"cur__original_root\\": \\"%projectPath%\\",
+  \\"cur__name\\": \\"withDep\\",
+  \\"cur__man\\":
+    \\"%projectPath%/_esy/default/store/i/withdep-102cf969/man\\",
+  \\"cur__lib\\":
+    \\"%projectPath%/_esy/default/store/i/withdep-102cf969/lib\\",
+  \\"cur__install\\":
+    \\"%projectPath%/_esy/default/store/i/withdep-102cf969\\",
+  \\"cur__etc\\":
+    \\"%projectPath%/_esy/default/store/i/withdep-102cf969/etc\\",
+  \\"cur__doc\\":
+    \\"%projectPath%/_esy/default/store/i/withdep-102cf969/doc\\",
+  \\"cur__dev\\": \\"true\\",
+  \\"cur__bin\\":
+    \\"%projectPath%/_esy/default/store/i/withdep-102cf969/bin\\",
+  \\"SHELL\\": \\"env -i /bin/bash --norc --noprofile\\",
+  \\"PATH\\":
+    \\"%esyPrefixPath%/3_________________________________________________________/i/dep-cb7685c8/bin::/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\",
+  \\"OCAMLPATH\\":
+    \\"%esyPrefixPath%/3_________________________________________________________/i/dep-cb7685c8/lib:\\",
+  \\"OCAMLFIND_LDCONF\\": \\"ignore\\",
+  \\"OCAMLFIND_DESTDIR\\":
+    \\"%projectPath%/_esy/default/store/i/withdep-102cf969/lib\\",
+  \\"MAN_PATH\\":
+    \\"%esyPrefixPath%/3_________________________________________________________/i/dep-cb7685c8/man:\\",
+  \\"DUNE_BUILD_DIR\\":
+    \\"%projectPath%/_esy/default/store/b/withdep-102cf969\\",
+  \\"CAML_LD_LIBRARY_PATH\\":
+    \\"%esyPrefixPath%/3_________________________________________________________/i/dep-cb7685c8/stublibs:%esyPrefixPath%/3_________________________________________________________/i/dep-cb7685c8/lib/stublibs:\\"
+}"
+`;
+
+exports[`Build with dep out of source build macos: build-env dep snapshot 1`] = `
+"# Build environment for dep@path:dep
+
+#
+# dep@1.0.0
+#
+export OCAMLFIND_LDCONF=\\"ignore\\"
+export OCAMLFIND_DESTDIR=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-cb7685c8/lib\\"
+export cur__etc=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-cb7685c8/etc\\"
+export cur__share=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-cb7685c8/share\\"
+export cur__toplevel=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-cb7685c8/toplevel\\"
+export cur__stublibs=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-cb7685c8/stublibs\\"
+export cur__doc=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-cb7685c8/doc\\"
+export cur__man=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-cb7685c8/man\\"
+export cur__lib=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-cb7685c8/lib\\"
+export cur__sbin=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-cb7685c8/sbin\\"
+export cur__bin=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-cb7685c8/bin\\"
+export cur__install=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-cb7685c8\\"
+export cur__target_dir=\\"%esyPrefixPath%/3_________________________________________________________/b/dep-cb7685c8\\"
+export cur__original_root=\\"%esyPrefixPath%/esyi/source/i/dep--67b360d9a56facfd6fc9b90817f589ec\\"
+export cur__root=\\"%esyPrefixPath%/esyi/source/i/dep--67b360d9a56facfd6fc9b90817f589ec\\"
+export cur__dev=\\"false\\"
+export cur__version=\\"1.0.0\\"
+export cur__name=\\"dep\\"
+export DUNE_BUILD_DIR=\\"%esyPrefixPath%/3_________________________________________________________/b/dep-cb7685c8\\"
+
+#
+# Built-in
+#
+export SHELL=\\"env -i /bin/bash --norc --noprofile\\"
+export PATH=\\"$PATH:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\""
+`;
+
+exports[`Build with dep out of source build macos: build-env snapshot 1`] = `
+"# Build environment for withDep@link:./package.json
+
+#
+# dep@1.0.0
+#
+export CAML_LD_LIBRARY_PATH=\\"%esyPrefixPath%/3_________________________________________________________/i/dep-cb7685c8/stublibs:%esyPrefixPath%/3_________________________________________________________/i/dep-cb7685c8/lib/stublibs:$CAML_LD_LIBRARY_PATH\\"
+export OCAMLPATH=\\"%esyPrefixPath%/3_________________________________________________________/i/dep-cb7685c8/lib:$OCAMLPATH\\"
+export MAN_PATH=\\"%esyPrefixPath%/3_________________________________________________________/i/dep-cb7685c8/man:$MAN_PATH\\"
+export PATH=\\"%esyPrefixPath%/3_________________________________________________________/i/dep-cb7685c8/bin:$PATH\\"
+
+#
+# withDep@1.0.0
+#
+export OCAMLFIND_LDCONF=\\"ignore\\"
+export OCAMLFIND_DESTDIR=\\"%projectPath%/_esy/default/store/i/withdep-102cf969/lib\\"
+export cur__etc=\\"%projectPath%/_esy/default/store/i/withdep-102cf969/etc\\"
+export cur__share=\\"%projectPath%/_esy/default/store/i/withdep-102cf969/share\\"
+export cur__toplevel=\\"%projectPath%/_esy/default/store/i/withdep-102cf969/toplevel\\"
+export cur__stublibs=\\"%projectPath%/_esy/default/store/i/withdep-102cf969/stublibs\\"
+export cur__doc=\\"%projectPath%/_esy/default/store/i/withdep-102cf969/doc\\"
+export cur__man=\\"%projectPath%/_esy/default/store/i/withdep-102cf969/man\\"
+export cur__lib=\\"%projectPath%/_esy/default/store/i/withdep-102cf969/lib\\"
+export cur__sbin=\\"%projectPath%/_esy/default/store/i/withdep-102cf969/sbin\\"
+export cur__bin=\\"%projectPath%/_esy/default/store/i/withdep-102cf969/bin\\"
+export cur__install=\\"%projectPath%/_esy/default/store/i/withdep-102cf969\\"
+export cur__target_dir=\\"%projectPath%/_esy/default/store/b/withdep-102cf969\\"
+export cur__original_root=\\"%projectPath%\\"
+export cur__root=\\"%projectPath%\\"
+export cur__dev=\\"true\\"
+export cur__version=\\"1.0.0\\"
+export cur__name=\\"withDep\\"
+export DUNE_BUILD_DIR=\\"%projectPath%/_esy/default/store/b/withdep-102cf969\\"
+
+#
+# Built-in
+#
+export SHELL=\\"env -i /bin/bash --norc --noprofile\\"
+export PATH=\\"$PATH:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\""
+`;

--- a/test-e2e/esy-build/__snapshots__/with-dep.test.js.snap
+++ b/test-e2e/esy-build/__snapshots__/with-dep.test.js.snap
@@ -1,92 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Build with dep out of source build macos: build-env --json dep snapshot 1`] = `
-"{
-  \\"cur__version\\": \\"1.0.0\\",
-  \\"cur__toplevel\\":
-    \\"%esyPrefixPath%/3_________________________________________________________/s/dep-cb7685c8/toplevel\\",
-  \\"cur__target_dir\\":
-    \\"%esyPrefixPath%/3_________________________________________________________/b/dep-cb7685c8\\",
-  \\"cur__stublibs\\":
-    \\"%esyPrefixPath%/3_________________________________________________________/s/dep-cb7685c8/stublibs\\",
-  \\"cur__share\\":
-    \\"%esyPrefixPath%/3_________________________________________________________/s/dep-cb7685c8/share\\",
-  \\"cur__sbin\\":
-    \\"%esyPrefixPath%/3_________________________________________________________/s/dep-cb7685c8/sbin\\",
-  \\"cur__root\\":
-    \\"%esyPrefixPath%/esyi/source/i/dep--67b360d9a56facfd6fc9b90817f589ec\\",
-  \\"cur__original_root\\":
-    \\"%esyPrefixPath%/esyi/source/i/dep--67b360d9a56facfd6fc9b90817f589ec\\",
-  \\"cur__name\\": \\"dep\\",
-  \\"cur__man\\":
-    \\"%esyPrefixPath%/3_________________________________________________________/s/dep-cb7685c8/man\\",
-  \\"cur__lib\\":
-    \\"%esyPrefixPath%/3_________________________________________________________/s/dep-cb7685c8/lib\\",
-  \\"cur__install\\":
-    \\"%esyPrefixPath%/3_________________________________________________________/s/dep-cb7685c8\\",
-  \\"cur__etc\\":
-    \\"%esyPrefixPath%/3_________________________________________________________/s/dep-cb7685c8/etc\\",
-  \\"cur__doc\\":
-    \\"%esyPrefixPath%/3_________________________________________________________/s/dep-cb7685c8/doc\\",
-  \\"cur__dev\\": \\"false\\",
-  \\"cur__bin\\":
-    \\"%esyPrefixPath%/3_________________________________________________________/s/dep-cb7685c8/bin\\",
-  \\"SHELL\\": \\"env -i /bin/bash --norc --noprofile\\",
-  \\"PATH\\": \\":/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\",
-  \\"OCAMLFIND_LDCONF\\": \\"ignore\\",
-  \\"OCAMLFIND_DESTDIR\\":
-    \\"%esyPrefixPath%/3_________________________________________________________/s/dep-cb7685c8/lib\\",
-  \\"DUNE_BUILD_DIR\\":
-    \\"%esyPrefixPath%/3_________________________________________________________/b/dep-cb7685c8\\"
-}"
-`;
-
-exports[`Build with dep out of source build macos: build-env --json snapshot 1`] = `
-"{
-  \\"cur__version\\": \\"1.0.0\\",
-  \\"cur__toplevel\\":
-    \\"%projectPath%/_esy/default/store/i/withdep-102cf969/toplevel\\",
-  \\"cur__target_dir\\":
-    \\"%projectPath%/_esy/default/store/b/withdep-102cf969\\",
-  \\"cur__stublibs\\":
-    \\"%projectPath%/_esy/default/store/i/withdep-102cf969/stublibs\\",
-  \\"cur__share\\":
-    \\"%projectPath%/_esy/default/store/i/withdep-102cf969/share\\",
-  \\"cur__sbin\\":
-    \\"%projectPath%/_esy/default/store/i/withdep-102cf969/sbin\\",
-  \\"cur__root\\": \\"%projectPath%\\",
-  \\"cur__original_root\\": \\"%projectPath%\\",
-  \\"cur__name\\": \\"withDep\\",
-  \\"cur__man\\":
-    \\"%projectPath%/_esy/default/store/i/withdep-102cf969/man\\",
-  \\"cur__lib\\":
-    \\"%projectPath%/_esy/default/store/i/withdep-102cf969/lib\\",
-  \\"cur__install\\":
-    \\"%projectPath%/_esy/default/store/i/withdep-102cf969\\",
-  \\"cur__etc\\":
-    \\"%projectPath%/_esy/default/store/i/withdep-102cf969/etc\\",
-  \\"cur__doc\\":
-    \\"%projectPath%/_esy/default/store/i/withdep-102cf969/doc\\",
-  \\"cur__dev\\": \\"true\\",
-  \\"cur__bin\\":
-    \\"%projectPath%/_esy/default/store/i/withdep-102cf969/bin\\",
-  \\"SHELL\\": \\"env -i /bin/bash --norc --noprofile\\",
-  \\"PATH\\":
-    \\"%esyPrefixPath%/3_________________________________________________________/i/dep-cb7685c8/bin::/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\",
-  \\"OCAMLPATH\\":
-    \\"%esyPrefixPath%/3_________________________________________________________/i/dep-cb7685c8/lib:\\",
-  \\"OCAMLFIND_LDCONF\\": \\"ignore\\",
-  \\"OCAMLFIND_DESTDIR\\":
-    \\"%projectPath%/_esy/default/store/i/withdep-102cf969/lib\\",
-  \\"MAN_PATH\\":
-    \\"%esyPrefixPath%/3_________________________________________________________/i/dep-cb7685c8/man:\\",
-  \\"DUNE_BUILD_DIR\\":
-    \\"%projectPath%/_esy/default/store/b/withdep-102cf969\\",
-  \\"CAML_LD_LIBRARY_PATH\\":
-    \\"%esyPrefixPath%/3_________________________________________________________/i/dep-cb7685c8/stublibs:%esyPrefixPath%/3_________________________________________________________/i/dep-cb7685c8/lib/stublibs:\\"
-}"
-`;
-
 exports[`Build with dep out of source build macos: build-env dep snapshot 1`] = `
 "# Build environment for dep@path:dep
 
@@ -94,24 +7,24 @@ exports[`Build with dep out of source build macos: build-env dep snapshot 1`] = 
 # dep@1.0.0
 #
 export OCAMLFIND_LDCONF=\\"ignore\\"
-export OCAMLFIND_DESTDIR=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-cb7685c8/lib\\"
-export cur__etc=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-cb7685c8/etc\\"
-export cur__share=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-cb7685c8/share\\"
-export cur__toplevel=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-cb7685c8/toplevel\\"
-export cur__stublibs=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-cb7685c8/stublibs\\"
-export cur__doc=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-cb7685c8/doc\\"
-export cur__man=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-cb7685c8/man\\"
-export cur__lib=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-cb7685c8/lib\\"
-export cur__sbin=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-cb7685c8/sbin\\"
-export cur__bin=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-cb7685c8/bin\\"
-export cur__install=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-cb7685c8\\"
-export cur__target_dir=\\"%esyPrefixPath%/3_________________________________________________________/b/dep-cb7685c8\\"
+export OCAMLFIND_DESTDIR=\\"%esyStorePath%/s/%id%/lib\\"
+export cur__etc=\\"%esyStorePath%/s/%id%/etc\\"
+export cur__share=\\"%esyStorePath%/s/%id%/share\\"
+export cur__toplevel=\\"%esyStorePath%/s/%id%/toplevel\\"
+export cur__stublibs=\\"%esyStorePath%/s/%id%/stublibs\\"
+export cur__doc=\\"%esyStorePath%/s/%id%/doc\\"
+export cur__man=\\"%esyStorePath%/s/%id%/man\\"
+export cur__lib=\\"%esyStorePath%/s/%id%/lib\\"
+export cur__sbin=\\"%esyStorePath%/s/%id%/sbin\\"
+export cur__bin=\\"%esyStorePath%/s/%id%/bin\\"
+export cur__install=\\"%esyStorePath%/s/%id%\\"
+export cur__target_dir=\\"%esyStorePath%/b/%id%\\"
 export cur__original_root=\\"%esyPrefixPath%/esyi/source/i/dep--67b360d9a56facfd6fc9b90817f589ec\\"
 export cur__root=\\"%esyPrefixPath%/esyi/source/i/dep--67b360d9a56facfd6fc9b90817f589ec\\"
 export cur__dev=\\"false\\"
 export cur__version=\\"1.0.0\\"
 export cur__name=\\"dep\\"
-export DUNE_BUILD_DIR=\\"%esyPrefixPath%/3_________________________________________________________/b/dep-cb7685c8\\"
+export DUNE_BUILD_DIR=\\"%esyStorePath%/b/%id%\\"
 
 #
 # Built-in
@@ -126,33 +39,33 @@ exports[`Build with dep out of source build macos: build-env snapshot 1`] = `
 #
 # dep@1.0.0
 #
-export CAML_LD_LIBRARY_PATH=\\"%esyPrefixPath%/3_________________________________________________________/i/dep-cb7685c8/stublibs:%esyPrefixPath%/3_________________________________________________________/i/dep-cb7685c8/lib/stublibs:$CAML_LD_LIBRARY_PATH\\"
-export OCAMLPATH=\\"%esyPrefixPath%/3_________________________________________________________/i/dep-cb7685c8/lib:$OCAMLPATH\\"
-export MAN_PATH=\\"%esyPrefixPath%/3_________________________________________________________/i/dep-cb7685c8/man:$MAN_PATH\\"
-export PATH=\\"%esyPrefixPath%/3_________________________________________________________/i/dep-cb7685c8/bin:$PATH\\"
+export CAML_LD_LIBRARY_PATH=\\"%esyStorePath%/i/dep-cb7685c8/stublibs:%esyStorePath%/i/dep-cb7685c8/lib/stublibs:$CAML_LD_LIBRARY_PATH\\"
+export OCAMLPATH=\\"%esyStorePath%/i/dep-cb7685c8/lib:$OCAMLPATH\\"
+export MAN_PATH=\\"%esyStorePath%/i/dep-cb7685c8/man:$MAN_PATH\\"
+export PATH=\\"%esyStorePath%/i/dep-cb7685c8/bin:$PATH\\"
 
 #
 # withDep@1.0.0
 #
 export OCAMLFIND_LDCONF=\\"ignore\\"
-export OCAMLFIND_DESTDIR=\\"%projectPath%/_esy/default/store/i/withdep-102cf969/lib\\"
-export cur__etc=\\"%projectPath%/_esy/default/store/i/withdep-102cf969/etc\\"
-export cur__share=\\"%projectPath%/_esy/default/store/i/withdep-102cf969/share\\"
-export cur__toplevel=\\"%projectPath%/_esy/default/store/i/withdep-102cf969/toplevel\\"
-export cur__stublibs=\\"%projectPath%/_esy/default/store/i/withdep-102cf969/stublibs\\"
-export cur__doc=\\"%projectPath%/_esy/default/store/i/withdep-102cf969/doc\\"
-export cur__man=\\"%projectPath%/_esy/default/store/i/withdep-102cf969/man\\"
-export cur__lib=\\"%projectPath%/_esy/default/store/i/withdep-102cf969/lib\\"
-export cur__sbin=\\"%projectPath%/_esy/default/store/i/withdep-102cf969/sbin\\"
-export cur__bin=\\"%projectPath%/_esy/default/store/i/withdep-102cf969/bin\\"
-export cur__install=\\"%projectPath%/_esy/default/store/i/withdep-102cf969\\"
-export cur__target_dir=\\"%projectPath%/_esy/default/store/b/withdep-102cf969\\"
+export OCAMLFIND_DESTDIR=\\"%projectPath%/_esy/default/store/i/%id%/lib\\"
+export cur__etc=\\"%projectPath%/_esy/default/store/i/%id%/etc\\"
+export cur__share=\\"%projectPath%/_esy/default/store/i/%id%/share\\"
+export cur__toplevel=\\"%projectPath%/_esy/default/store/i/%id%/toplevel\\"
+export cur__stublibs=\\"%projectPath%/_esy/default/store/i/%id%/stublibs\\"
+export cur__doc=\\"%projectPath%/_esy/default/store/i/%id%/doc\\"
+export cur__man=\\"%projectPath%/_esy/default/store/i/%id%/man\\"
+export cur__lib=\\"%projectPath%/_esy/default/store/i/%id%/lib\\"
+export cur__sbin=\\"%projectPath%/_esy/default/store/i/%id%/sbin\\"
+export cur__bin=\\"%projectPath%/_esy/default/store/i/%id%/bin\\"
+export cur__install=\\"%projectPath%/_esy/default/store/i/%id%\\"
+export cur__target_dir=\\"%projectPath%/_esy/default/store/b/%id%\\"
 export cur__original_root=\\"%projectPath%\\"
 export cur__root=\\"%projectPath%\\"
 export cur__dev=\\"true\\"
 export cur__version=\\"1.0.0\\"
 export cur__name=\\"withDep\\"
-export DUNE_BUILD_DIR=\\"%projectPath%/_esy/default/store/b/withdep-102cf969\\"
+export DUNE_BUILD_DIR=\\"%projectPath%/_esy/default/store/b/%id%\\"
 
 #
 # Built-in

--- a/test-e2e/esy-build/__snapshots__/with-dep.test.js.snap
+++ b/test-e2e/esy-build/__snapshots__/with-dep.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Build with dep out of source build macos: build-env dep snapshot 1`] = `
+exports[`Build with dep out of source build macos || linux: build-env dep snapshot 1`] = `
 "# Build environment for dep@path:dep
 
 #
@@ -33,7 +33,7 @@ export SHELL=\\"env -i /bin/bash --norc --noprofile\\"
 export PATH=\\"$PATH:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\""
 `;
 
-exports[`Build with dep out of source build macos: build-env snapshot 1`] = `
+exports[`Build with dep out of source build macos || linux: build-env snapshot 1`] = `
 "# Build environment for withDep@link:./package.json
 
 #

--- a/test-e2e/esy-build/__snapshots__/with-dev-dep.test.js.snap
+++ b/test-e2e/esy-build/__snapshots__/with-dev-dep.test.js.snap
@@ -1,0 +1,230 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`devDep workflow macos: build-env --json dep snapshot 1`] = `
+"{
+  \\"cur__version\\": \\"1.0.0\\",
+  \\"cur__toplevel\\":
+    \\"%esyPrefixPath%/3_________________________________________________________/s/dep-e7448809/toplevel\\",
+  \\"cur__target_dir\\":
+    \\"%esyPrefixPath%/3_________________________________________________________/b/dep-e7448809\\",
+  \\"cur__stublibs\\":
+    \\"%esyPrefixPath%/3_________________________________________________________/s/dep-e7448809/stublibs\\",
+  \\"cur__share\\":
+    \\"%esyPrefixPath%/3_________________________________________________________/s/dep-e7448809/share\\",
+  \\"cur__sbin\\":
+    \\"%esyPrefixPath%/3_________________________________________________________/s/dep-e7448809/sbin\\",
+  \\"cur__root\\":
+    \\"%esyPrefixPath%/3_________________________________________________________/b/dep-e7448809\\",
+  \\"cur__original_root\\":
+    \\"%esyPrefixPath%/esyi/source/i/dep--67b360d9a56facfd6fc9b90817f589ec\\",
+  \\"cur__name\\": \\"dep\\",
+  \\"cur__man\\":
+    \\"%esyPrefixPath%/3_________________________________________________________/s/dep-e7448809/man\\",
+  \\"cur__lib\\":
+    \\"%esyPrefixPath%/3_________________________________________________________/s/dep-e7448809/lib\\",
+  \\"cur__install\\":
+    \\"%esyPrefixPath%/3_________________________________________________________/s/dep-e7448809\\",
+  \\"cur__etc\\":
+    \\"%esyPrefixPath%/3_________________________________________________________/s/dep-e7448809/etc\\",
+  \\"cur__doc\\":
+    \\"%esyPrefixPath%/3_________________________________________________________/s/dep-e7448809/doc\\",
+  \\"cur__dev\\": \\"false\\",
+  \\"cur__bin\\":
+    \\"%esyPrefixPath%/3_________________________________________________________/s/dep-e7448809/bin\\",
+  \\"SHELL\\": \\"env -i /bin/bash --norc --noprofile\\",
+  \\"PATH\\": \\":/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\",
+  \\"OCAMLFIND_LDCONF\\": \\"ignore\\",
+  \\"OCAMLFIND_DESTDIR\\":
+    \\"%esyPrefixPath%/3_________________________________________________________/s/dep-e7448809/lib\\"
+}"
+`;
+
+exports[`devDep workflow macos: build-env --json devDep snapshot 1`] = `
+"{
+  \\"cur__version\\": \\"1.0.0\\",
+  \\"cur__toplevel\\":
+    \\"%esyPrefixPath%/3_________________________________________________________/s/devdep-a0236b3a/toplevel\\",
+  \\"cur__target_dir\\":
+    \\"%esyPrefixPath%/3_________________________________________________________/b/devdep-a0236b3a\\",
+  \\"cur__stublibs\\":
+    \\"%esyPrefixPath%/3_________________________________________________________/s/devdep-a0236b3a/stublibs\\",
+  \\"cur__share\\":
+    \\"%esyPrefixPath%/3_________________________________________________________/s/devdep-a0236b3a/share\\",
+  \\"cur__sbin\\":
+    \\"%esyPrefixPath%/3_________________________________________________________/s/devdep-a0236b3a/sbin\\",
+  \\"cur__root\\":
+    \\"%esyPrefixPath%/3_________________________________________________________/b/devdep-a0236b3a\\",
+  \\"cur__original_root\\":
+    \\"%esyPrefixPath%/esyi/source/i/devdep--6e88dff5673a130a450ce61f64675503\\",
+  \\"cur__name\\": \\"devDep\\",
+  \\"cur__man\\":
+    \\"%esyPrefixPath%/3_________________________________________________________/s/devdep-a0236b3a/man\\",
+  \\"cur__lib\\":
+    \\"%esyPrefixPath%/3_________________________________________________________/s/devdep-a0236b3a/lib\\",
+  \\"cur__install\\":
+    \\"%esyPrefixPath%/3_________________________________________________________/s/devdep-a0236b3a\\",
+  \\"cur__etc\\":
+    \\"%esyPrefixPath%/3_________________________________________________________/s/devdep-a0236b3a/etc\\",
+  \\"cur__doc\\":
+    \\"%esyPrefixPath%/3_________________________________________________________/s/devdep-a0236b3a/doc\\",
+  \\"cur__dev\\": \\"false\\",
+  \\"cur__bin\\":
+    \\"%esyPrefixPath%/3_________________________________________________________/s/devdep-a0236b3a/bin\\",
+  \\"SHELL\\": \\"env -i /bin/bash --norc --noprofile\\",
+  \\"PATH\\": \\":/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\",
+  \\"OCAMLFIND_LDCONF\\": \\"ignore\\",
+  \\"OCAMLFIND_DESTDIR\\":
+    \\"%esyPrefixPath%/3_________________________________________________________/s/devdep-a0236b3a/lib\\"
+}"
+`;
+
+exports[`devDep workflow macos: build-env --json snapshot 1`] = `
+"{
+  \\"cur__version\\": \\"1.0.0\\",
+  \\"cur__toplevel\\":
+    \\"%projectPath%/_esy/default/store/i/withdevdep-f5ff937d/toplevel\\",
+  \\"cur__target_dir\\":
+    \\"%projectPath%/_esy/default/store/b/withdevdep-f5ff937d\\",
+  \\"cur__stublibs\\":
+    \\"%projectPath%/_esy/default/store/i/withdevdep-f5ff937d/stublibs\\",
+  \\"cur__share\\":
+    \\"%projectPath%/_esy/default/store/i/withdevdep-f5ff937d/share\\",
+  \\"cur__sbin\\":
+    \\"%projectPath%/_esy/default/store/i/withdevdep-f5ff937d/sbin\\",
+  \\"cur__root\\": \\"%projectPath%\\",
+  \\"cur__original_root\\": \\"%projectPath%\\",
+  \\"cur__name\\": \\"withDevDep\\",
+  \\"cur__man\\":
+    \\"%projectPath%/_esy/default/store/i/withdevdep-f5ff937d/man\\",
+  \\"cur__lib\\":
+    \\"%projectPath%/_esy/default/store/i/withdevdep-f5ff937d/lib\\",
+  \\"cur__install\\":
+    \\"%projectPath%/_esy/default/store/i/withdevdep-f5ff937d\\",
+  \\"cur__etc\\":
+    \\"%projectPath%/_esy/default/store/i/withdevdep-f5ff937d/etc\\",
+  \\"cur__doc\\":
+    \\"%projectPath%/_esy/default/store/i/withdevdep-f5ff937d/doc\\",
+  \\"cur__dev\\": \\"true\\",
+  \\"cur__bin\\":
+    \\"%projectPath%/_esy/default/store/i/withdevdep-f5ff937d/bin\\",
+  \\"SHELL\\": \\"env -i /bin/bash --norc --noprofile\\",
+  \\"PATH\\":
+    \\"%esyPrefixPath%/3_________________________________________________________/i/dep-e7448809/bin::/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\",
+  \\"OCAMLPATH\\":
+    \\"%esyPrefixPath%/3_________________________________________________________/i/dep-e7448809/lib:\\",
+  \\"OCAMLFIND_LDCONF\\": \\"ignore\\",
+  \\"OCAMLFIND_DESTDIR\\":
+    \\"%projectPath%/_esy/default/store/i/withdevdep-f5ff937d/lib\\",
+  \\"MAN_PATH\\":
+    \\"%esyPrefixPath%/3_________________________________________________________/i/dep-e7448809/man:\\",
+  \\"DUNE_BUILD_DIR\\":
+    \\"%projectPath%/_esy/default/store/b/withdevdep-f5ff937d\\",
+  \\"CAML_LD_LIBRARY_PATH\\":
+    \\"%esyPrefixPath%/3_________________________________________________________/i/dep-e7448809/stublibs:%esyPrefixPath%/3_________________________________________________________/i/dep-e7448809/lib/stublibs:\\"
+}"
+`;
+
+exports[`devDep workflow macos: build-env dep snapshot 1`] = `
+"# Build environment for dep@path:dep
+
+#
+# dep@1.0.0
+#
+export OCAMLFIND_LDCONF=\\"ignore\\"
+export OCAMLFIND_DESTDIR=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-e7448809/lib\\"
+export cur__etc=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-e7448809/etc\\"
+export cur__share=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-e7448809/share\\"
+export cur__toplevel=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-e7448809/toplevel\\"
+export cur__stublibs=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-e7448809/stublibs\\"
+export cur__doc=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-e7448809/doc\\"
+export cur__man=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-e7448809/man\\"
+export cur__lib=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-e7448809/lib\\"
+export cur__sbin=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-e7448809/sbin\\"
+export cur__bin=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-e7448809/bin\\"
+export cur__install=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-e7448809\\"
+export cur__target_dir=\\"%esyPrefixPath%/3_________________________________________________________/b/dep-e7448809\\"
+export cur__original_root=\\"%esyPrefixPath%/esyi/source/i/dep--67b360d9a56facfd6fc9b90817f589ec\\"
+export cur__root=\\"%esyPrefixPath%/3_________________________________________________________/b/dep-e7448809\\"
+export cur__dev=\\"false\\"
+export cur__version=\\"1.0.0\\"
+export cur__name=\\"dep\\"
+
+#
+# Built-in
+#
+export SHELL=\\"env -i /bin/bash --norc --noprofile\\"
+export PATH=\\"$PATH:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\""
+`;
+
+exports[`devDep workflow macos: build-env devDep snapshot 1`] = `
+"# Build environment for devDep@path:devDep
+
+#
+# devDep@1.0.0
+#
+export OCAMLFIND_LDCONF=\\"ignore\\"
+export OCAMLFIND_DESTDIR=\\"%esyPrefixPath%/3_________________________________________________________/s/devdep-a0236b3a/lib\\"
+export cur__etc=\\"%esyPrefixPath%/3_________________________________________________________/s/devdep-a0236b3a/etc\\"
+export cur__share=\\"%esyPrefixPath%/3_________________________________________________________/s/devdep-a0236b3a/share\\"
+export cur__toplevel=\\"%esyPrefixPath%/3_________________________________________________________/s/devdep-a0236b3a/toplevel\\"
+export cur__stublibs=\\"%esyPrefixPath%/3_________________________________________________________/s/devdep-a0236b3a/stublibs\\"
+export cur__doc=\\"%esyPrefixPath%/3_________________________________________________________/s/devdep-a0236b3a/doc\\"
+export cur__man=\\"%esyPrefixPath%/3_________________________________________________________/s/devdep-a0236b3a/man\\"
+export cur__lib=\\"%esyPrefixPath%/3_________________________________________________________/s/devdep-a0236b3a/lib\\"
+export cur__sbin=\\"%esyPrefixPath%/3_________________________________________________________/s/devdep-a0236b3a/sbin\\"
+export cur__bin=\\"%esyPrefixPath%/3_________________________________________________________/s/devdep-a0236b3a/bin\\"
+export cur__install=\\"%esyPrefixPath%/3_________________________________________________________/s/devdep-a0236b3a\\"
+export cur__target_dir=\\"%esyPrefixPath%/3_________________________________________________________/b/devdep-a0236b3a\\"
+export cur__original_root=\\"%esyPrefixPath%/esyi/source/i/devdep--6e88dff5673a130a450ce61f64675503\\"
+export cur__root=\\"%esyPrefixPath%/3_________________________________________________________/b/devdep-a0236b3a\\"
+export cur__dev=\\"false\\"
+export cur__version=\\"1.0.0\\"
+export cur__name=\\"devDep\\"
+
+#
+# Built-in
+#
+export SHELL=\\"env -i /bin/bash --norc --noprofile\\"
+export PATH=\\"$PATH:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\""
+`;
+
+exports[`devDep workflow macos: build-env snapshot 1`] = `
+"# Build environment for withDevDep@link:./package.json
+
+#
+# dep@1.0.0
+#
+export CAML_LD_LIBRARY_PATH=\\"%esyPrefixPath%/3_________________________________________________________/i/dep-e7448809/stublibs:%esyPrefixPath%/3_________________________________________________________/i/dep-e7448809/lib/stublibs:$CAML_LD_LIBRARY_PATH\\"
+export OCAMLPATH=\\"%esyPrefixPath%/3_________________________________________________________/i/dep-e7448809/lib:$OCAMLPATH\\"
+export MAN_PATH=\\"%esyPrefixPath%/3_________________________________________________________/i/dep-e7448809/man:$MAN_PATH\\"
+export PATH=\\"%esyPrefixPath%/3_________________________________________________________/i/dep-e7448809/bin:$PATH\\"
+
+#
+# withDevDep@1.0.0
+#
+export OCAMLFIND_LDCONF=\\"ignore\\"
+export OCAMLFIND_DESTDIR=\\"%projectPath%/_esy/default/store/i/withdevdep-f5ff937d/lib\\"
+export cur__etc=\\"%projectPath%/_esy/default/store/i/withdevdep-f5ff937d/etc\\"
+export cur__share=\\"%projectPath%/_esy/default/store/i/withdevdep-f5ff937d/share\\"
+export cur__toplevel=\\"%projectPath%/_esy/default/store/i/withdevdep-f5ff937d/toplevel\\"
+export cur__stublibs=\\"%projectPath%/_esy/default/store/i/withdevdep-f5ff937d/stublibs\\"
+export cur__doc=\\"%projectPath%/_esy/default/store/i/withdevdep-f5ff937d/doc\\"
+export cur__man=\\"%projectPath%/_esy/default/store/i/withdevdep-f5ff937d/man\\"
+export cur__lib=\\"%projectPath%/_esy/default/store/i/withdevdep-f5ff937d/lib\\"
+export cur__sbin=\\"%projectPath%/_esy/default/store/i/withdevdep-f5ff937d/sbin\\"
+export cur__bin=\\"%projectPath%/_esy/default/store/i/withdevdep-f5ff937d/bin\\"
+export cur__install=\\"%projectPath%/_esy/default/store/i/withdevdep-f5ff937d\\"
+export cur__target_dir=\\"%projectPath%/_esy/default/store/b/withdevdep-f5ff937d\\"
+export cur__original_root=\\"%projectPath%\\"
+export cur__root=\\"%projectPath%\\"
+export cur__dev=\\"true\\"
+export cur__version=\\"1.0.0\\"
+export cur__name=\\"withDevDep\\"
+export DUNE_BUILD_DIR=\\"%projectPath%/_esy/default/store/b/withdevdep-f5ff937d\\"
+
+#
+# Built-in
+#
+export SHELL=\\"env -i /bin/bash --norc --noprofile\\"
+export PATH=\\"$PATH:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\""
+`;

--- a/test-e2e/esy-build/__snapshots__/with-dev-dep.test.js.snap
+++ b/test-e2e/esy-build/__snapshots__/with-dev-dep.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`devDep workflow macos: build-env dep snapshot 1`] = `
+exports[`devDep workflow macos || linux: build-env dep snapshot 1`] = `
 "# Build environment for dep@path:dep
 
 #
@@ -32,7 +32,7 @@ export SHELL=\\"env -i /bin/bash --norc --noprofile\\"
 export PATH=\\"$PATH:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\""
 `;
 
-exports[`devDep workflow macos: build-env devDep snapshot 1`] = `
+exports[`devDep workflow macos || linux: build-env devDep snapshot 1`] = `
 "# Build environment for devDep@path:devDep
 
 #
@@ -64,7 +64,7 @@ export SHELL=\\"env -i /bin/bash --norc --noprofile\\"
 export PATH=\\"$PATH:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\""
 `;
 
-exports[`devDep workflow macos: build-env snapshot 1`] = `
+exports[`devDep workflow macos || linux: build-env snapshot 1`] = `
 "# Build environment for withDevDep@link:./package.json
 
 #

--- a/test-e2e/esy-build/__snapshots__/with-dev-dep.test.js.snap
+++ b/test-e2e/esy-build/__snapshots__/with-dev-dep.test.js.snap
@@ -1,129 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`devDep workflow macos: build-env --json dep snapshot 1`] = `
-"{
-  \\"cur__version\\": \\"1.0.0\\",
-  \\"cur__toplevel\\":
-    \\"%esyPrefixPath%/3_________________________________________________________/s/dep-e7448809/toplevel\\",
-  \\"cur__target_dir\\":
-    \\"%esyPrefixPath%/3_________________________________________________________/b/dep-e7448809\\",
-  \\"cur__stublibs\\":
-    \\"%esyPrefixPath%/3_________________________________________________________/s/dep-e7448809/stublibs\\",
-  \\"cur__share\\":
-    \\"%esyPrefixPath%/3_________________________________________________________/s/dep-e7448809/share\\",
-  \\"cur__sbin\\":
-    \\"%esyPrefixPath%/3_________________________________________________________/s/dep-e7448809/sbin\\",
-  \\"cur__root\\":
-    \\"%esyPrefixPath%/3_________________________________________________________/b/dep-e7448809\\",
-  \\"cur__original_root\\":
-    \\"%esyPrefixPath%/esyi/source/i/dep--67b360d9a56facfd6fc9b90817f589ec\\",
-  \\"cur__name\\": \\"dep\\",
-  \\"cur__man\\":
-    \\"%esyPrefixPath%/3_________________________________________________________/s/dep-e7448809/man\\",
-  \\"cur__lib\\":
-    \\"%esyPrefixPath%/3_________________________________________________________/s/dep-e7448809/lib\\",
-  \\"cur__install\\":
-    \\"%esyPrefixPath%/3_________________________________________________________/s/dep-e7448809\\",
-  \\"cur__etc\\":
-    \\"%esyPrefixPath%/3_________________________________________________________/s/dep-e7448809/etc\\",
-  \\"cur__doc\\":
-    \\"%esyPrefixPath%/3_________________________________________________________/s/dep-e7448809/doc\\",
-  \\"cur__dev\\": \\"false\\",
-  \\"cur__bin\\":
-    \\"%esyPrefixPath%/3_________________________________________________________/s/dep-e7448809/bin\\",
-  \\"SHELL\\": \\"env -i /bin/bash --norc --noprofile\\",
-  \\"PATH\\": \\":/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\",
-  \\"OCAMLFIND_LDCONF\\": \\"ignore\\",
-  \\"OCAMLFIND_DESTDIR\\":
-    \\"%esyPrefixPath%/3_________________________________________________________/s/dep-e7448809/lib\\"
-}"
-`;
-
-exports[`devDep workflow macos: build-env --json devDep snapshot 1`] = `
-"{
-  \\"cur__version\\": \\"1.0.0\\",
-  \\"cur__toplevel\\":
-    \\"%esyPrefixPath%/3_________________________________________________________/s/devdep-a0236b3a/toplevel\\",
-  \\"cur__target_dir\\":
-    \\"%esyPrefixPath%/3_________________________________________________________/b/devdep-a0236b3a\\",
-  \\"cur__stublibs\\":
-    \\"%esyPrefixPath%/3_________________________________________________________/s/devdep-a0236b3a/stublibs\\",
-  \\"cur__share\\":
-    \\"%esyPrefixPath%/3_________________________________________________________/s/devdep-a0236b3a/share\\",
-  \\"cur__sbin\\":
-    \\"%esyPrefixPath%/3_________________________________________________________/s/devdep-a0236b3a/sbin\\",
-  \\"cur__root\\":
-    \\"%esyPrefixPath%/3_________________________________________________________/b/devdep-a0236b3a\\",
-  \\"cur__original_root\\":
-    \\"%esyPrefixPath%/esyi/source/i/devdep--6e88dff5673a130a450ce61f64675503\\",
-  \\"cur__name\\": \\"devDep\\",
-  \\"cur__man\\":
-    \\"%esyPrefixPath%/3_________________________________________________________/s/devdep-a0236b3a/man\\",
-  \\"cur__lib\\":
-    \\"%esyPrefixPath%/3_________________________________________________________/s/devdep-a0236b3a/lib\\",
-  \\"cur__install\\":
-    \\"%esyPrefixPath%/3_________________________________________________________/s/devdep-a0236b3a\\",
-  \\"cur__etc\\":
-    \\"%esyPrefixPath%/3_________________________________________________________/s/devdep-a0236b3a/etc\\",
-  \\"cur__doc\\":
-    \\"%esyPrefixPath%/3_________________________________________________________/s/devdep-a0236b3a/doc\\",
-  \\"cur__dev\\": \\"false\\",
-  \\"cur__bin\\":
-    \\"%esyPrefixPath%/3_________________________________________________________/s/devdep-a0236b3a/bin\\",
-  \\"SHELL\\": \\"env -i /bin/bash --norc --noprofile\\",
-  \\"PATH\\": \\":/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\",
-  \\"OCAMLFIND_LDCONF\\": \\"ignore\\",
-  \\"OCAMLFIND_DESTDIR\\":
-    \\"%esyPrefixPath%/3_________________________________________________________/s/devdep-a0236b3a/lib\\"
-}"
-`;
-
-exports[`devDep workflow macos: build-env --json snapshot 1`] = `
-"{
-  \\"cur__version\\": \\"1.0.0\\",
-  \\"cur__toplevel\\":
-    \\"%projectPath%/_esy/default/store/i/withdevdep-f5ff937d/toplevel\\",
-  \\"cur__target_dir\\":
-    \\"%projectPath%/_esy/default/store/b/withdevdep-f5ff937d\\",
-  \\"cur__stublibs\\":
-    \\"%projectPath%/_esy/default/store/i/withdevdep-f5ff937d/stublibs\\",
-  \\"cur__share\\":
-    \\"%projectPath%/_esy/default/store/i/withdevdep-f5ff937d/share\\",
-  \\"cur__sbin\\":
-    \\"%projectPath%/_esy/default/store/i/withdevdep-f5ff937d/sbin\\",
-  \\"cur__root\\": \\"%projectPath%\\",
-  \\"cur__original_root\\": \\"%projectPath%\\",
-  \\"cur__name\\": \\"withDevDep\\",
-  \\"cur__man\\":
-    \\"%projectPath%/_esy/default/store/i/withdevdep-f5ff937d/man\\",
-  \\"cur__lib\\":
-    \\"%projectPath%/_esy/default/store/i/withdevdep-f5ff937d/lib\\",
-  \\"cur__install\\":
-    \\"%projectPath%/_esy/default/store/i/withdevdep-f5ff937d\\",
-  \\"cur__etc\\":
-    \\"%projectPath%/_esy/default/store/i/withdevdep-f5ff937d/etc\\",
-  \\"cur__doc\\":
-    \\"%projectPath%/_esy/default/store/i/withdevdep-f5ff937d/doc\\",
-  \\"cur__dev\\": \\"true\\",
-  \\"cur__bin\\":
-    \\"%projectPath%/_esy/default/store/i/withdevdep-f5ff937d/bin\\",
-  \\"SHELL\\": \\"env -i /bin/bash --norc --noprofile\\",
-  \\"PATH\\":
-    \\"%esyPrefixPath%/3_________________________________________________________/i/dep-e7448809/bin::/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\",
-  \\"OCAMLPATH\\":
-    \\"%esyPrefixPath%/3_________________________________________________________/i/dep-e7448809/lib:\\",
-  \\"OCAMLFIND_LDCONF\\": \\"ignore\\",
-  \\"OCAMLFIND_DESTDIR\\":
-    \\"%projectPath%/_esy/default/store/i/withdevdep-f5ff937d/lib\\",
-  \\"MAN_PATH\\":
-    \\"%esyPrefixPath%/3_________________________________________________________/i/dep-e7448809/man:\\",
-  \\"DUNE_BUILD_DIR\\":
-    \\"%projectPath%/_esy/default/store/b/withdevdep-f5ff937d\\",
-  \\"CAML_LD_LIBRARY_PATH\\":
-    \\"%esyPrefixPath%/3_________________________________________________________/i/dep-e7448809/stublibs:%esyPrefixPath%/3_________________________________________________________/i/dep-e7448809/lib/stublibs:\\"
-}"
-`;
-
 exports[`devDep workflow macos: build-env dep snapshot 1`] = `
 "# Build environment for dep@path:dep
 
@@ -131,20 +7,20 @@ exports[`devDep workflow macos: build-env dep snapshot 1`] = `
 # dep@1.0.0
 #
 export OCAMLFIND_LDCONF=\\"ignore\\"
-export OCAMLFIND_DESTDIR=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-e7448809/lib\\"
-export cur__etc=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-e7448809/etc\\"
-export cur__share=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-e7448809/share\\"
-export cur__toplevel=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-e7448809/toplevel\\"
-export cur__stublibs=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-e7448809/stublibs\\"
-export cur__doc=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-e7448809/doc\\"
-export cur__man=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-e7448809/man\\"
-export cur__lib=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-e7448809/lib\\"
-export cur__sbin=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-e7448809/sbin\\"
-export cur__bin=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-e7448809/bin\\"
-export cur__install=\\"%esyPrefixPath%/3_________________________________________________________/s/dep-e7448809\\"
-export cur__target_dir=\\"%esyPrefixPath%/3_________________________________________________________/b/dep-e7448809\\"
+export OCAMLFIND_DESTDIR=\\"%esyStorePath%/s/%id%/lib\\"
+export cur__etc=\\"%esyStorePath%/s/%id%/etc\\"
+export cur__share=\\"%esyStorePath%/s/%id%/share\\"
+export cur__toplevel=\\"%esyStorePath%/s/%id%/toplevel\\"
+export cur__stublibs=\\"%esyStorePath%/s/%id%/stublibs\\"
+export cur__doc=\\"%esyStorePath%/s/%id%/doc\\"
+export cur__man=\\"%esyStorePath%/s/%id%/man\\"
+export cur__lib=\\"%esyStorePath%/s/%id%/lib\\"
+export cur__sbin=\\"%esyStorePath%/s/%id%/sbin\\"
+export cur__bin=\\"%esyStorePath%/s/%id%/bin\\"
+export cur__install=\\"%esyStorePath%/s/%id%\\"
+export cur__target_dir=\\"%esyStorePath%/b/%id%\\"
 export cur__original_root=\\"%esyPrefixPath%/esyi/source/i/dep--67b360d9a56facfd6fc9b90817f589ec\\"
-export cur__root=\\"%esyPrefixPath%/3_________________________________________________________/b/dep-e7448809\\"
+export cur__root=\\"%esyStorePath%/b/%id%\\"
 export cur__dev=\\"false\\"
 export cur__version=\\"1.0.0\\"
 export cur__name=\\"dep\\"
@@ -163,20 +39,20 @@ exports[`devDep workflow macos: build-env devDep snapshot 1`] = `
 # devDep@1.0.0
 #
 export OCAMLFIND_LDCONF=\\"ignore\\"
-export OCAMLFIND_DESTDIR=\\"%esyPrefixPath%/3_________________________________________________________/s/devdep-a0236b3a/lib\\"
-export cur__etc=\\"%esyPrefixPath%/3_________________________________________________________/s/devdep-a0236b3a/etc\\"
-export cur__share=\\"%esyPrefixPath%/3_________________________________________________________/s/devdep-a0236b3a/share\\"
-export cur__toplevel=\\"%esyPrefixPath%/3_________________________________________________________/s/devdep-a0236b3a/toplevel\\"
-export cur__stublibs=\\"%esyPrefixPath%/3_________________________________________________________/s/devdep-a0236b3a/stublibs\\"
-export cur__doc=\\"%esyPrefixPath%/3_________________________________________________________/s/devdep-a0236b3a/doc\\"
-export cur__man=\\"%esyPrefixPath%/3_________________________________________________________/s/devdep-a0236b3a/man\\"
-export cur__lib=\\"%esyPrefixPath%/3_________________________________________________________/s/devdep-a0236b3a/lib\\"
-export cur__sbin=\\"%esyPrefixPath%/3_________________________________________________________/s/devdep-a0236b3a/sbin\\"
-export cur__bin=\\"%esyPrefixPath%/3_________________________________________________________/s/devdep-a0236b3a/bin\\"
-export cur__install=\\"%esyPrefixPath%/3_________________________________________________________/s/devdep-a0236b3a\\"
-export cur__target_dir=\\"%esyPrefixPath%/3_________________________________________________________/b/devdep-a0236b3a\\"
+export OCAMLFIND_DESTDIR=\\"%esyStorePath%/s/%id%/lib\\"
+export cur__etc=\\"%esyStorePath%/s/%id%/etc\\"
+export cur__share=\\"%esyStorePath%/s/%id%/share\\"
+export cur__toplevel=\\"%esyStorePath%/s/%id%/toplevel\\"
+export cur__stublibs=\\"%esyStorePath%/s/%id%/stublibs\\"
+export cur__doc=\\"%esyStorePath%/s/%id%/doc\\"
+export cur__man=\\"%esyStorePath%/s/%id%/man\\"
+export cur__lib=\\"%esyStorePath%/s/%id%/lib\\"
+export cur__sbin=\\"%esyStorePath%/s/%id%/sbin\\"
+export cur__bin=\\"%esyStorePath%/s/%id%/bin\\"
+export cur__install=\\"%esyStorePath%/s/%id%\\"
+export cur__target_dir=\\"%esyStorePath%/b/%id%\\"
 export cur__original_root=\\"%esyPrefixPath%/esyi/source/i/devdep--6e88dff5673a130a450ce61f64675503\\"
-export cur__root=\\"%esyPrefixPath%/3_________________________________________________________/b/devdep-a0236b3a\\"
+export cur__root=\\"%esyStorePath%/b/%id%\\"
 export cur__dev=\\"false\\"
 export cur__version=\\"1.0.0\\"
 export cur__name=\\"devDep\\"
@@ -194,33 +70,33 @@ exports[`devDep workflow macos: build-env snapshot 1`] = `
 #
 # dep@1.0.0
 #
-export CAML_LD_LIBRARY_PATH=\\"%esyPrefixPath%/3_________________________________________________________/i/dep-e7448809/stublibs:%esyPrefixPath%/3_________________________________________________________/i/dep-e7448809/lib/stublibs:$CAML_LD_LIBRARY_PATH\\"
-export OCAMLPATH=\\"%esyPrefixPath%/3_________________________________________________________/i/dep-e7448809/lib:$OCAMLPATH\\"
-export MAN_PATH=\\"%esyPrefixPath%/3_________________________________________________________/i/dep-e7448809/man:$MAN_PATH\\"
-export PATH=\\"%esyPrefixPath%/3_________________________________________________________/i/dep-e7448809/bin:$PATH\\"
+export CAML_LD_LIBRARY_PATH=\\"%esyStorePath%/i/dep-e7448809/stublibs:%esyStorePath%/i/dep-e7448809/lib/stublibs:$CAML_LD_LIBRARY_PATH\\"
+export OCAMLPATH=\\"%esyStorePath%/i/dep-e7448809/lib:$OCAMLPATH\\"
+export MAN_PATH=\\"%esyStorePath%/i/dep-e7448809/man:$MAN_PATH\\"
+export PATH=\\"%esyStorePath%/i/dep-e7448809/bin:$PATH\\"
 
 #
 # withDevDep@1.0.0
 #
 export OCAMLFIND_LDCONF=\\"ignore\\"
-export OCAMLFIND_DESTDIR=\\"%projectPath%/_esy/default/store/i/withdevdep-f5ff937d/lib\\"
-export cur__etc=\\"%projectPath%/_esy/default/store/i/withdevdep-f5ff937d/etc\\"
-export cur__share=\\"%projectPath%/_esy/default/store/i/withdevdep-f5ff937d/share\\"
-export cur__toplevel=\\"%projectPath%/_esy/default/store/i/withdevdep-f5ff937d/toplevel\\"
-export cur__stublibs=\\"%projectPath%/_esy/default/store/i/withdevdep-f5ff937d/stublibs\\"
-export cur__doc=\\"%projectPath%/_esy/default/store/i/withdevdep-f5ff937d/doc\\"
-export cur__man=\\"%projectPath%/_esy/default/store/i/withdevdep-f5ff937d/man\\"
-export cur__lib=\\"%projectPath%/_esy/default/store/i/withdevdep-f5ff937d/lib\\"
-export cur__sbin=\\"%projectPath%/_esy/default/store/i/withdevdep-f5ff937d/sbin\\"
-export cur__bin=\\"%projectPath%/_esy/default/store/i/withdevdep-f5ff937d/bin\\"
-export cur__install=\\"%projectPath%/_esy/default/store/i/withdevdep-f5ff937d\\"
-export cur__target_dir=\\"%projectPath%/_esy/default/store/b/withdevdep-f5ff937d\\"
+export OCAMLFIND_DESTDIR=\\"%projectPath%/_esy/default/store/i/%id%/lib\\"
+export cur__etc=\\"%projectPath%/_esy/default/store/i/%id%/etc\\"
+export cur__share=\\"%projectPath%/_esy/default/store/i/%id%/share\\"
+export cur__toplevel=\\"%projectPath%/_esy/default/store/i/%id%/toplevel\\"
+export cur__stublibs=\\"%projectPath%/_esy/default/store/i/%id%/stublibs\\"
+export cur__doc=\\"%projectPath%/_esy/default/store/i/%id%/doc\\"
+export cur__man=\\"%projectPath%/_esy/default/store/i/%id%/man\\"
+export cur__lib=\\"%projectPath%/_esy/default/store/i/%id%/lib\\"
+export cur__sbin=\\"%projectPath%/_esy/default/store/i/%id%/sbin\\"
+export cur__bin=\\"%projectPath%/_esy/default/store/i/%id%/bin\\"
+export cur__install=\\"%projectPath%/_esy/default/store/i/%id%\\"
+export cur__target_dir=\\"%projectPath%/_esy/default/store/b/%id%\\"
 export cur__original_root=\\"%projectPath%\\"
 export cur__root=\\"%projectPath%\\"
 export cur__dev=\\"true\\"
 export cur__version=\\"1.0.0\\"
 export cur__name=\\"withDevDep\\"
-export DUNE_BUILD_DIR=\\"%projectPath%/_esy/default/store/b/withdevdep-f5ff937d\\"
+export DUNE_BUILD_DIR=\\"%projectPath%/_esy/default/store/b/%id%\\"
 
 #
 # Built-in

--- a/test-e2e/esy-build/__snapshots__/with-dev-dep.test.js.snap
+++ b/test-e2e/esy-build/__snapshots__/with-dev-dep.test.js.snap
@@ -70,10 +70,10 @@ exports[`devDep workflow macos || linux: build-env snapshot 1`] = `
 #
 # dep@1.0.0
 #
-export CAML_LD_LIBRARY_PATH=\\"%esyStorePath%/i/dep-e7448809/stublibs:%esyStorePath%/i/dep-e7448809/lib/stublibs:$CAML_LD_LIBRARY_PATH\\"
-export OCAMLPATH=\\"%esyStorePath%/i/dep-e7448809/lib:$OCAMLPATH\\"
-export MAN_PATH=\\"%esyStorePath%/i/dep-e7448809/man:$MAN_PATH\\"
-export PATH=\\"%esyStorePath%/i/dep-e7448809/bin:$PATH\\"
+export CAML_LD_LIBRARY_PATH=\\"%esyStorePath%/i/%depid%/stublibs:%esyStorePath%/i/%depid%/lib/stublibs:$CAML_LD_LIBRARY_PATH\\"
+export OCAMLPATH=\\"%esyStorePath%/i/%depid%/lib:$OCAMLPATH\\"
+export MAN_PATH=\\"%esyStorePath%/i/%depid%/man:$MAN_PATH\\"
+export PATH=\\"%esyStorePath%/i/%depid%/bin:$PATH\\"
 
 #
 # withDevDep@1.0.0

--- a/test-e2e/esy-build/__snapshots__/with-linked-dep.test.js.snap
+++ b/test-e2e/esy-build/__snapshots__/with-linked-dep.test.js.snap
@@ -1,30 +1,30 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Build with a linked dep out of source build macos: build-env dep snapshot 1`] = `
+exports[`Build with a linked dep out of source build macos || linux: build-env dep snapshot 1`] = `
 "# Build environment for dep@link:dep
 
 #
 # dep@1.0.0
 #
 export OCAMLFIND_LDCONF=\\"ignore\\"
-export OCAMLFIND_DESTDIR=\\"%projectPath%/_esy/default/store/i/dep-342de796/lib\\"
-export cur__etc=\\"%projectPath%/_esy/default/store/i/dep-342de796/etc\\"
-export cur__share=\\"%projectPath%/_esy/default/store/i/dep-342de796/share\\"
-export cur__toplevel=\\"%projectPath%/_esy/default/store/i/dep-342de796/toplevel\\"
-export cur__stublibs=\\"%projectPath%/_esy/default/store/i/dep-342de796/stublibs\\"
-export cur__doc=\\"%projectPath%/_esy/default/store/i/dep-342de796/doc\\"
-export cur__man=\\"%projectPath%/_esy/default/store/i/dep-342de796/man\\"
-export cur__lib=\\"%projectPath%/_esy/default/store/i/dep-342de796/lib\\"
-export cur__sbin=\\"%projectPath%/_esy/default/store/i/dep-342de796/sbin\\"
-export cur__bin=\\"%projectPath%/_esy/default/store/i/dep-342de796/bin\\"
-export cur__install=\\"%projectPath%/_esy/default/store/i/dep-342de796\\"
-export cur__target_dir=\\"%projectPath%/_esy/default/store/b/dep-342de796\\"
+export OCAMLFIND_DESTDIR=\\"%projectPath%/_esy/default/store/i/%id%/lib\\"
+export cur__etc=\\"%projectPath%/_esy/default/store/i/%id%/etc\\"
+export cur__share=\\"%projectPath%/_esy/default/store/i/%id%/share\\"
+export cur__toplevel=\\"%projectPath%/_esy/default/store/i/%id%/toplevel\\"
+export cur__stublibs=\\"%projectPath%/_esy/default/store/i/%id%/stublibs\\"
+export cur__doc=\\"%projectPath%/_esy/default/store/i/%id%/doc\\"
+export cur__man=\\"%projectPath%/_esy/default/store/i/%id%/man\\"
+export cur__lib=\\"%projectPath%/_esy/default/store/i/%id%/lib\\"
+export cur__sbin=\\"%projectPath%/_esy/default/store/i/%id%/sbin\\"
+export cur__bin=\\"%projectPath%/_esy/default/store/i/%id%/bin\\"
+export cur__install=\\"%projectPath%/_esy/default/store/i/%id%\\"
+export cur__target_dir=\\"%projectPath%/_esy/default/store/b/%id%\\"
 export cur__original_root=\\"%projectPath%/dep\\"
 export cur__root=\\"%projectPath%/dep\\"
 export cur__dev=\\"true\\"
 export cur__version=\\"1.0.0\\"
 export cur__name=\\"dep\\"
-export DUNE_BUILD_DIR=\\"%projectPath%/_esy/default/store/b/dep-342de796\\"
+export DUNE_BUILD_DIR=\\"%projectPath%/_esy/default/store/b/%id%\\"
 
 #
 # Built-in
@@ -33,7 +33,7 @@ export SHELL=\\"env -i /bin/bash --norc --noprofile\\"
 export PATH=\\"$PATH:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\""
 `;
 
-exports[`Build with a linked dep out of source build macos: build-env snapshot 1`] = `
+exports[`Build with a linked dep out of source build macos || linux: build-env snapshot 1`] = `
 "# Build environment for with-linked-dep-_build@link:./package.json
 
 #
@@ -48,24 +48,24 @@ export PATH=\\"%projectPath%/_esy/default/store/i/dep-342de796/bin:$PATH\\"
 # with-linked-dep-_build@1.0.0
 #
 export OCAMLFIND_LDCONF=\\"ignore\\"
-export OCAMLFIND_DESTDIR=\\"%projectPath%/_esy/default/store/i/with_linked_dep___build-825869e7/lib\\"
-export cur__etc=\\"%projectPath%/_esy/default/store/i/with_linked_dep___build-825869e7/etc\\"
-export cur__share=\\"%projectPath%/_esy/default/store/i/with_linked_dep___build-825869e7/share\\"
-export cur__toplevel=\\"%projectPath%/_esy/default/store/i/with_linked_dep___build-825869e7/toplevel\\"
-export cur__stublibs=\\"%projectPath%/_esy/default/store/i/with_linked_dep___build-825869e7/stublibs\\"
-export cur__doc=\\"%projectPath%/_esy/default/store/i/with_linked_dep___build-825869e7/doc\\"
-export cur__man=\\"%projectPath%/_esy/default/store/i/with_linked_dep___build-825869e7/man\\"
-export cur__lib=\\"%projectPath%/_esy/default/store/i/with_linked_dep___build-825869e7/lib\\"
-export cur__sbin=\\"%projectPath%/_esy/default/store/i/with_linked_dep___build-825869e7/sbin\\"
-export cur__bin=\\"%projectPath%/_esy/default/store/i/with_linked_dep___build-825869e7/bin\\"
-export cur__install=\\"%projectPath%/_esy/default/store/i/with_linked_dep___build-825869e7\\"
-export cur__target_dir=\\"%projectPath%/_esy/default/store/b/with_linked_dep___build-825869e7\\"
+export OCAMLFIND_DESTDIR=\\"%projectPath%/_esy/default/store/i/%id%/lib\\"
+export cur__etc=\\"%projectPath%/_esy/default/store/i/%id%/etc\\"
+export cur__share=\\"%projectPath%/_esy/default/store/i/%id%/share\\"
+export cur__toplevel=\\"%projectPath%/_esy/default/store/i/%id%/toplevel\\"
+export cur__stublibs=\\"%projectPath%/_esy/default/store/i/%id%/stublibs\\"
+export cur__doc=\\"%projectPath%/_esy/default/store/i/%id%/doc\\"
+export cur__man=\\"%projectPath%/_esy/default/store/i/%id%/man\\"
+export cur__lib=\\"%projectPath%/_esy/default/store/i/%id%/lib\\"
+export cur__sbin=\\"%projectPath%/_esy/default/store/i/%id%/sbin\\"
+export cur__bin=\\"%projectPath%/_esy/default/store/i/%id%/bin\\"
+export cur__install=\\"%projectPath%/_esy/default/store/i/%id%\\"
+export cur__target_dir=\\"%projectPath%/_esy/default/store/b/%id%\\"
 export cur__original_root=\\"%projectPath%\\"
 export cur__root=\\"%projectPath%\\"
 export cur__dev=\\"true\\"
 export cur__version=\\"1.0.0\\"
 export cur__name=\\"with-linked-dep-_build\\"
-export DUNE_BUILD_DIR=\\"%projectPath%/_esy/default/store/b/with_linked_dep___build-825869e7\\"
+export DUNE_BUILD_DIR=\\"%projectPath%/_esy/default/store/b/%id%\\"
 
 #
 # Built-in

--- a/test-e2e/esy-build/__snapshots__/with-linked-dep.test.js.snap
+++ b/test-e2e/esy-build/__snapshots__/with-linked-dep.test.js.snap
@@ -1,0 +1,75 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Build with a linked dep out of source build macos: build-env dep snapshot 1`] = `
+"# Build environment for dep@link:dep
+
+#
+# dep@1.0.0
+#
+export OCAMLFIND_LDCONF=\\"ignore\\"
+export OCAMLFIND_DESTDIR=\\"%projectPath%/_esy/default/store/i/dep-342de796/lib\\"
+export cur__etc=\\"%projectPath%/_esy/default/store/i/dep-342de796/etc\\"
+export cur__share=\\"%projectPath%/_esy/default/store/i/dep-342de796/share\\"
+export cur__toplevel=\\"%projectPath%/_esy/default/store/i/dep-342de796/toplevel\\"
+export cur__stublibs=\\"%projectPath%/_esy/default/store/i/dep-342de796/stublibs\\"
+export cur__doc=\\"%projectPath%/_esy/default/store/i/dep-342de796/doc\\"
+export cur__man=\\"%projectPath%/_esy/default/store/i/dep-342de796/man\\"
+export cur__lib=\\"%projectPath%/_esy/default/store/i/dep-342de796/lib\\"
+export cur__sbin=\\"%projectPath%/_esy/default/store/i/dep-342de796/sbin\\"
+export cur__bin=\\"%projectPath%/_esy/default/store/i/dep-342de796/bin\\"
+export cur__install=\\"%projectPath%/_esy/default/store/i/dep-342de796\\"
+export cur__target_dir=\\"%projectPath%/_esy/default/store/b/dep-342de796\\"
+export cur__original_root=\\"%projectPath%/dep\\"
+export cur__root=\\"%projectPath%/dep\\"
+export cur__dev=\\"true\\"
+export cur__version=\\"1.0.0\\"
+export cur__name=\\"dep\\"
+export DUNE_BUILD_DIR=\\"%projectPath%/_esy/default/store/b/dep-342de796\\"
+
+#
+# Built-in
+#
+export SHELL=\\"env -i /bin/bash --norc --noprofile\\"
+export PATH=\\"$PATH:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\""
+`;
+
+exports[`Build with a linked dep out of source build macos: build-env snapshot 1`] = `
+"# Build environment for with-linked-dep-_build@link:./package.json
+
+#
+# dep@1.0.0
+#
+export CAML_LD_LIBRARY_PATH=\\"%projectPath%/_esy/default/store/i/dep-342de796/stublibs:%projectPath%/_esy/default/store/i/dep-342de796/lib/stublibs:$CAML_LD_LIBRARY_PATH\\"
+export OCAMLPATH=\\"%projectPath%/_esy/default/store/i/dep-342de796/lib:$OCAMLPATH\\"
+export MAN_PATH=\\"%projectPath%/_esy/default/store/i/dep-342de796/man:$MAN_PATH\\"
+export PATH=\\"%projectPath%/_esy/default/store/i/dep-342de796/bin:$PATH\\"
+
+#
+# with-linked-dep-_build@1.0.0
+#
+export OCAMLFIND_LDCONF=\\"ignore\\"
+export OCAMLFIND_DESTDIR=\\"%projectPath%/_esy/default/store/i/with_linked_dep___build-825869e7/lib\\"
+export cur__etc=\\"%projectPath%/_esy/default/store/i/with_linked_dep___build-825869e7/etc\\"
+export cur__share=\\"%projectPath%/_esy/default/store/i/with_linked_dep___build-825869e7/share\\"
+export cur__toplevel=\\"%projectPath%/_esy/default/store/i/with_linked_dep___build-825869e7/toplevel\\"
+export cur__stublibs=\\"%projectPath%/_esy/default/store/i/with_linked_dep___build-825869e7/stublibs\\"
+export cur__doc=\\"%projectPath%/_esy/default/store/i/with_linked_dep___build-825869e7/doc\\"
+export cur__man=\\"%projectPath%/_esy/default/store/i/with_linked_dep___build-825869e7/man\\"
+export cur__lib=\\"%projectPath%/_esy/default/store/i/with_linked_dep___build-825869e7/lib\\"
+export cur__sbin=\\"%projectPath%/_esy/default/store/i/with_linked_dep___build-825869e7/sbin\\"
+export cur__bin=\\"%projectPath%/_esy/default/store/i/with_linked_dep___build-825869e7/bin\\"
+export cur__install=\\"%projectPath%/_esy/default/store/i/with_linked_dep___build-825869e7\\"
+export cur__target_dir=\\"%projectPath%/_esy/default/store/b/with_linked_dep___build-825869e7\\"
+export cur__original_root=\\"%projectPath%\\"
+export cur__root=\\"%projectPath%\\"
+export cur__dev=\\"true\\"
+export cur__version=\\"1.0.0\\"
+export cur__name=\\"with-linked-dep-_build\\"
+export DUNE_BUILD_DIR=\\"%projectPath%/_esy/default/store/b/with_linked_dep___build-825869e7\\"
+
+#
+# Built-in
+#
+export SHELL=\\"env -i /bin/bash --norc --noprofile\\"
+export PATH=\\"$PATH:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\""
+`;

--- a/test-e2e/esy-build/__snapshots__/with-linked-dep.test.js.snap
+++ b/test-e2e/esy-build/__snapshots__/with-linked-dep.test.js.snap
@@ -39,10 +39,10 @@ exports[`Build with a linked dep out of source build macos || linux: build-env s
 #
 # dep@1.0.0
 #
-export CAML_LD_LIBRARY_PATH=\\"%projectPath%/_esy/default/store/i/dep-342de796/stublibs:%projectPath%/_esy/default/store/i/dep-342de796/lib/stublibs:$CAML_LD_LIBRARY_PATH\\"
-export OCAMLPATH=\\"%projectPath%/_esy/default/store/i/dep-342de796/lib:$OCAMLPATH\\"
-export MAN_PATH=\\"%projectPath%/_esy/default/store/i/dep-342de796/man:$MAN_PATH\\"
-export PATH=\\"%projectPath%/_esy/default/store/i/dep-342de796/bin:$PATH\\"
+export CAML_LD_LIBRARY_PATH=\\"%projectPath%/_esy/default/store/i/%depid%/stublibs:%projectPath%/_esy/default/store/i/%depid%/lib/stublibs:$CAML_LD_LIBRARY_PATH\\"
+export OCAMLPATH=\\"%projectPath%/_esy/default/store/i/%depid%/lib:$OCAMLPATH\\"
+export MAN_PATH=\\"%projectPath%/_esy/default/store/i/%depid%/man:$MAN_PATH\\"
+export PATH=\\"%projectPath%/_esy/default/store/i/%depid%/bin:$PATH\\"
 
 #
 # with-linked-dep-_build@1.0.0

--- a/test-e2e/esy-build/creates-symlinks.test.js
+++ b/test-e2e/esy-build/creates-symlinks.test.js
@@ -1,10 +1,9 @@
 // @flow
 
 const helpers = require('../test/helpers');
+const {test, isWindows, isMacos} = helpers;
 
-helpers.skipSuiteOnWindows();
-
-it('Correctly handles symlinks within the installation', async () => {
+async function createTestSandbox() {
   const p = await helpers.createTestSandbox();
 
   await p.fixture(
@@ -45,29 +44,36 @@ it('Correctly handles symlinks within the installation', async () => {
       helpers.dummyExecutable('dep'),
     ),
   );
+  return p;
+}
 
-  await p.esy('install');
-  await p.esy('build');
+test.disableIf(isWindows)(
+  'Correctly handles symlinks within the installation',
+  async () => {
+    const p = await createTestSandbox();
+    await p.esy('install');
+    await p.esy('build');
 
-  const expecting = expect.stringMatching('__dep__');
+    const expecting = expect.stringMatching('__dep__');
 
-  {
-    const {stdout} = await p.esy('dep.cmd');
-    expect(stdout.trim()).toEqual('__dep__');
-  }
+    {
+      const {stdout} = await p.esy('dep.cmd');
+      expect(stdout.trim()).toEqual('__dep__');
+    }
 
-  {
-    const {stdout} = await p.esy('b dep.cmd');
-    expect(stdout.trim()).toEqual('__dep__');
-  }
+    {
+      const {stdout} = await p.esy('b dep.cmd');
+      expect(stdout.trim()).toEqual('__dep__');
+    }
 
-  {
-    const {stdout} = await p.esy('x dep.cmd');
-    expect(stdout.trim()).toEqual('__dep__');
-  }
+    {
+      const {stdout} = await p.esy('x dep.cmd');
+      expect(stdout.trim()).toEqual('__dep__');
+    }
 
-  {
-    let {stdout} = await p.esy('x creates-symlinks.cmd');
-    expect(stdout.trim()).toEqual('__creates-symlinks__');
-  }
-});
+    {
+      let {stdout} = await p.esy('x creates-symlinks.cmd');
+      expect(stdout.trim()).toEqual('__creates-symlinks__');
+    }
+  },
+);

--- a/test-e2e/esy-build/no-deps.test.js
+++ b/test-e2e/esy-build/no-deps.test.js
@@ -2,7 +2,7 @@
 
 const path = require('path');
 const helpers = require('../test/helpers');
-const {test, isWindows, isMacos} = helpers;
+const {test, isWindows, isMacos, isLinux} = helpers;
 
 function makeFixture(p, buildDep) {
   return [
@@ -85,8 +85,8 @@ describe(`'esy build': simple executable with no deps`, () => {
       }),
     );
 
-    test.enableIf(isMacos)(
-      'macos: build-env snapshot',
+    test.enableIf(isMacos || isLinux)(
+      'macos || linux: build-env snapshot',
       withProject(async function(p) {
         const id = JSON.parse((await p.esy('build-plan')).stdout).id;
         const {stdout} = await p.esy('build-env');

--- a/test-e2e/esy-build/no-deps.test.js
+++ b/test-e2e/esy-build/no-deps.test.js
@@ -88,16 +88,9 @@ describe(`'esy build': simple executable with no deps`, () => {
     test.enableIf(isMacos)(
       'macos: build-env snapshot',
       withProject(async function(p) {
+        const id = JSON.parse((await p.esy('build-plan')).stdout).id;
         const {stdout} = await p.esy('build-env');
-        expect(p.normalizePathsForSnapshot(stdout)).toMatchSnapshot();
-      }),
-    );
-
-    test.enableIf(isMacos)(
-      'macos: build-env --json snapshot',
-      withProject(async function(p) {
-        const {stdout} = await p.esy('build-env --json');
-        expect(p.normalizePathsForSnapshot(stdout)).toMatchSnapshot();
+        expect(p.normalizePathsForSnapshot(stdout, {id: id})).toMatchSnapshot();
       }),
     );
 

--- a/test-e2e/esy-build/optDependencies.test.js
+++ b/test-e2e/esy-build/optDependencies.test.js
@@ -60,13 +60,15 @@ describe('Build with optDependencies', () => {
       await p.esy('install');
 
       {
+        const id = JSON.parse((await p.esy('build-plan')).stdout).id;
         const {stdout} = await p.esy('build-env');
-        expect(p.normalizePathsForSnapshot(stdout)).toMatchSnapshot();
+        expect(p.normalizePathsForSnapshot(stdout, {id})).toMatchSnapshot();
       }
 
       {
+        const id = JSON.parse((await p.esy('build-plan dep')).stdout).id;
         const {stdout} = await p.esy('build-env dep');
-        expect(p.normalizePathsForSnapshot(stdout)).toMatchSnapshot();
+        expect(p.normalizePathsForSnapshot(stdout, {id})).toMatchSnapshot();
       }
     });
   });
@@ -122,13 +124,15 @@ describe('Build with optDependencies', () => {
       const p = await createTestSandbox();
       await p.esy('install');
       {
+        const id = JSON.parse((await p.esy('build-plan')).stdout).id;
         const {stdout} = await p.esy('build-env');
-        expect(p.normalizePathsForSnapshot(stdout)).toMatchSnapshot();
+        expect(p.normalizePathsForSnapshot(stdout, {id})).toMatchSnapshot();
       }
 
       {
+        const id = JSON.parse((await p.esy('build-plan dep')).stdout).id;
         const {stdout} = await p.esy('build-env dep');
-        expect(p.normalizePathsForSnapshot(stdout)).toMatchSnapshot();
+        expect(p.normalizePathsForSnapshot(stdout, {id})).toMatchSnapshot();
       }
     });
   });

--- a/test-e2e/esy-build/optDependencies.test.js
+++ b/test-e2e/esy-build/optDependencies.test.js
@@ -1,7 +1,7 @@
 // @flow
 
 const helpers = require('../test/helpers');
-const {test, isWindows, isMacos} = helpers;
+const {test, isWindows, isMacos, isLinux} = helpers;
 
 function makePackage(p, {name, build, dependencies, optDependencies}, ...children) {
   return [
@@ -55,7 +55,7 @@ describe('Build with optDependencies', () => {
       expect(plan.build).toEqual([['optDep.installed', 'false']]);
     });
 
-    test.enableIf(isMacos)('snapshot build-env', async () => {
+    test.enableIf(isMacos || isLinux)('snapshot build-env', async () => {
       const p = await createTestSandbox();
       await p.esy('install');
 
@@ -120,7 +120,7 @@ describe('Build with optDependencies', () => {
       expect(plan.build).toEqual([['optDep.installed', 'true']]);
     });
 
-    test.enableIf(isMacos)('snapshot build-env', async () => {
+    test.enableIf(isMacos || isLinux)('snapshot build-env', async () => {
       const p = await createTestSandbox();
       await p.esy('install');
       {

--- a/test-e2e/esy-build/optDependencies.test.js
+++ b/test-e2e/esy-build/optDependencies.test.js
@@ -61,14 +61,19 @@ describe('Build with optDependencies', () => {
 
       {
         const id = JSON.parse((await p.esy('build-plan')).stdout).id;
+        const depid = JSON.parse((await p.esy('build-plan dep')).stdout).id;
+        const optdepid = JSON.parse((await p.esy('build-plan optDep')).stdout).id;
         const {stdout} = await p.esy('build-env');
-        expect(p.normalizePathsForSnapshot(stdout, {id})).toMatchSnapshot();
+        expect(
+          p.normalizePathsForSnapshot(stdout, {id, depid, optdepid}),
+        ).toMatchSnapshot();
       }
 
       {
         const id = JSON.parse((await p.esy('build-plan dep')).stdout).id;
+        const optdepid = JSON.parse((await p.esy('build-plan optDep')).stdout).id;
         const {stdout} = await p.esy('build-env dep');
-        expect(p.normalizePathsForSnapshot(stdout, {id})).toMatchSnapshot();
+        expect(p.normalizePathsForSnapshot(stdout, {id, optdepid})).toMatchSnapshot();
       }
     });
   });
@@ -125,14 +130,19 @@ describe('Build with optDependencies', () => {
       await p.esy('install');
       {
         const id = JSON.parse((await p.esy('build-plan')).stdout).id;
+        const depid = JSON.parse((await p.esy('build-plan dep')).stdout).id;
+        const optdepid = JSON.parse((await p.esy('build-plan optDep')).stdout).id;
         const {stdout} = await p.esy('build-env');
-        expect(p.normalizePathsForSnapshot(stdout, {id})).toMatchSnapshot();
+        expect(
+          p.normalizePathsForSnapshot(stdout, {id, depid, optdepid}),
+        ).toMatchSnapshot();
       }
 
       {
         const id = JSON.parse((await p.esy('build-plan dep')).stdout).id;
+        const optdepid = JSON.parse((await p.esy('build-plan optDep')).stdout).id;
         const {stdout} = await p.esy('build-env dep');
-        expect(p.normalizePathsForSnapshot(stdout, {id})).toMatchSnapshot();
+        expect(p.normalizePathsForSnapshot(stdout, {id, optdepid})).toMatchSnapshot();
       }
     });
   });

--- a/test-e2e/esy-build/optDependencies.test.js
+++ b/test-e2e/esy-build/optDependencies.test.js
@@ -47,6 +47,16 @@ describe('Build with optDependencies', () => {
     await p.esy('install');
     const plan = JSON.parse((await p.esy('build-plan dep@path:dep')).stdout);
     expect(plan.build).toEqual([['optDep.installed', 'false']]);
+
+    {
+      const {stdout} = await p.esy('build-env');
+      expect(p.normalizePathsForSnapshot(stdout)).toMatchSnapshot();
+    }
+
+    {
+      const {stdout} = await p.esy('build-env dep');
+      expect(p.normalizePathsForSnapshot(stdout)).toMatchSnapshot();
+    }
   });
 
   it('builds w/ opt dependency installed', async () => {
@@ -88,6 +98,16 @@ describe('Build with optDependencies', () => {
     await p.esy('install');
     const plan = JSON.parse((await p.esy('build-plan dep@path:dep')).stdout);
     expect(plan.build).toEqual([['optDep.installed', 'true']]);
+
+    {
+      const {stdout} = await p.esy('build-env');
+      expect(p.normalizePathsForSnapshot(stdout)).toMatchSnapshot();
+    }
+
+    {
+      const {stdout} = await p.esy('build-env dep');
+      expect(p.normalizePathsForSnapshot(stdout)).toMatchSnapshot();
+    }
   });
 
   it('opam package builds w/ opt dependency installed', async () => {

--- a/test-e2e/esy-build/with-dep.test.js
+++ b/test-e2e/esy-build/with-dep.test.js
@@ -2,7 +2,7 @@
 
 const path = require('path');
 const helpers = require('../test/helpers');
-const {test, isWindows, isMacos} = helpers;
+const {test, isWindows, isMacos, isLinux} = helpers;
 
 function makeFixture(p, buildDep) {
   return [
@@ -115,8 +115,8 @@ describe('Build with dep', () => {
       }),
     );
 
-    test.enableIf(isMacos)(
-      'macos: build-env snapshot',
+    test.enableIf(isMacos || isLinux)(
+      'macos || linux: build-env snapshot',
       withProject(async function(p) {
         const id = JSON.parse((await p.esy('build-plan')).stdout).id;
         const {stdout} = await p.esy('build-env');
@@ -162,8 +162,8 @@ describe('Build with dep', () => {
       }),
     );
 
-    test.enableIf(isMacos)(
-      'macos: build-env dep snapshot',
+    test.enableIf(isMacos || isLinux)(
+      'macos || linux: build-env dep snapshot',
       withProject(async function(p) {
         const id = JSON.parse((await p.esy('build-plan dep')).stdout).id;
         const {stdout} = await p.esy('build-env dep');

--- a/test-e2e/esy-build/with-dep.test.js
+++ b/test-e2e/esy-build/with-dep.test.js
@@ -2,6 +2,7 @@
 
 const path = require('path');
 const helpers = require('../test/helpers');
+const {test, isWindows, isMacos} = helpers;
 
 function makeFixture(p, buildDep) {
   return [
@@ -29,8 +30,8 @@ function makeFixture(p, buildDep) {
 }
 
 describe('Build with dep', () => {
-
-  let winsysDir = process.platform === "win32" ? [helpers.getWindowsSystemDirectory()] : [];
+  let winsysDir =
+    process.platform === 'win32' ? [helpers.getWindowsSystemDirectory()] : [];
 
   async function checkDepIsInEnv(p) {
     {
@@ -114,6 +115,22 @@ describe('Build with dep', () => {
       }),
     );
 
+    test.enableIf(isMacos)(
+      'macos: build-env snapshot',
+      withProject(async function(p) {
+        const {stdout} = await p.esy('build-env');
+        expect(p.normalizePathsForSnapshot(stdout)).toMatchSnapshot();
+      }),
+    );
+
+    test.enableIf(isMacos)(
+      'macos: build-env --json snapshot',
+      withProject(async function(p) {
+        const {stdout} = await p.esy('build-env --json');
+        expect(p.normalizePathsForSnapshot(stdout)).toMatchSnapshot();
+      }),
+    );
+
     test(
       'build-env dep',
       withProject(async function(p) {
@@ -136,13 +153,35 @@ describe('Build with dep', () => {
           cur__etc: `${p.esyStorePath}/s/${depId}/etc`,
           cur__doc: `${p.esyStorePath}/s/${depId}/doc`,
           cur__bin: `${p.esyStorePath}/s/${depId}/bin`,
-          PATH: [``, `/usr/local/bin`, `/usr/bin`, `/bin`, `/usr/sbin`, `/sbin`, ...winsysDir].join(
-            path.delimiter,
-          ),
+          PATH: [
+            ``,
+            `/usr/local/bin`,
+            `/usr/bin`,
+            `/bin`,
+            `/usr/sbin`,
+            `/sbin`,
+            ...winsysDir,
+          ].join(path.delimiter),
           OCAMLFIND_LDCONF: `ignore`,
           OCAMLFIND_DESTDIR: `${p.esyStorePath}/s/${depId}/lib`,
           DUNE_BUILD_DIR: `${p.esyStorePath}/b/${depId}`,
         });
+      }),
+    );
+
+    test.enableIf(isMacos)(
+      'macos: build-env dep snapshot',
+      withProject(async function(p) {
+        const {stdout} = await p.esy('build-env dep');
+        expect(p.normalizePathsForSnapshot(stdout)).toMatchSnapshot();
+      }),
+    );
+
+    test.enableIf(isMacos)(
+      'macos: build-env --json dep snapshot',
+      withProject(async function(p) {
+        const {stdout} = await p.esy('build-env dep --json');
+        expect(p.normalizePathsForSnapshot(stdout)).toMatchSnapshot();
       }),
     );
 

--- a/test-e2e/esy-build/with-dep.test.js
+++ b/test-e2e/esy-build/with-dep.test.js
@@ -119,8 +119,9 @@ describe('Build with dep', () => {
       'macos || linux: build-env snapshot',
       withProject(async function(p) {
         const id = JSON.parse((await p.esy('build-plan')).stdout).id;
+        const depid = JSON.parse((await p.esy('build-plan dep')).stdout).id;
         const {stdout} = await p.esy('build-env');
-        expect(p.normalizePathsForSnapshot(stdout, {id: id})).toMatchSnapshot();
+        expect(p.normalizePathsForSnapshot(stdout, {id, depid})).toMatchSnapshot();
       }),
     );
 

--- a/test-e2e/esy-build/with-dep.test.js
+++ b/test-e2e/esy-build/with-dep.test.js
@@ -118,16 +118,9 @@ describe('Build with dep', () => {
     test.enableIf(isMacos)(
       'macos: build-env snapshot',
       withProject(async function(p) {
+        const id = JSON.parse((await p.esy('build-plan')).stdout).id;
         const {stdout} = await p.esy('build-env');
-        expect(p.normalizePathsForSnapshot(stdout)).toMatchSnapshot();
-      }),
-    );
-
-    test.enableIf(isMacos)(
-      'macos: build-env --json snapshot',
-      withProject(async function(p) {
-        const {stdout} = await p.esy('build-env --json');
-        expect(p.normalizePathsForSnapshot(stdout)).toMatchSnapshot();
+        expect(p.normalizePathsForSnapshot(stdout, {id: id})).toMatchSnapshot();
       }),
     );
 
@@ -172,16 +165,9 @@ describe('Build with dep', () => {
     test.enableIf(isMacos)(
       'macos: build-env dep snapshot',
       withProject(async function(p) {
+        const id = JSON.parse((await p.esy('build-plan dep')).stdout).id;
         const {stdout} = await p.esy('build-env dep');
-        expect(p.normalizePathsForSnapshot(stdout)).toMatchSnapshot();
-      }),
-    );
-
-    test.enableIf(isMacos)(
-      'macos: build-env --json dep snapshot',
-      withProject(async function(p) {
-        const {stdout} = await p.esy('build-env dep --json');
-        expect(p.normalizePathsForSnapshot(stdout)).toMatchSnapshot();
+        expect(p.normalizePathsForSnapshot(stdout, {id: id})).toMatchSnapshot();
       }),
     );
 

--- a/test-e2e/esy-build/with-dev-dep.test.js
+++ b/test-e2e/esy-build/with-dev-dep.test.js
@@ -152,14 +152,9 @@ describe('devDep workflow', () => {
 
   test.enableIf(isMacos)('macos: build-env snapshot', async function() {
     const p = await createTestSandbox();
+    const id = JSON.parse((await p.esy('build-plan')).stdout).id;
     const {stdout} = await p.esy('build-env');
-    expect(p.normalizePathsForSnapshot(stdout)).toMatchSnapshot();
-  });
-
-  test.enableIf(isMacos)('macos: build-env --json snapshot', async function() {
-    const p = await createTestSandbox();
-    const {stdout} = await p.esy('build-env --json');
-    expect(p.normalizePathsForSnapshot(stdout)).toMatchSnapshot();
+    expect(p.normalizePathsForSnapshot(stdout, {id})).toMatchSnapshot();
   });
 
   test('build-env dep', async function() {
@@ -192,14 +187,9 @@ describe('devDep workflow', () => {
 
   test.enableIf(isMacos)('macos: build-env dep snapshot', async function() {
     const p = await createTestSandbox();
+    const id = JSON.parse((await p.esy('build-plan dep')).stdout).id;
     const {stdout} = await p.esy('build-env dep');
-    expect(p.normalizePathsForSnapshot(stdout)).toMatchSnapshot();
-  });
-
-  test.enableIf(isMacos)('macos: build-env --json dep snapshot', async function() {
-    const p = await createTestSandbox();
-    const {stdout} = await p.esy('build-env --json dep');
-    expect(p.normalizePathsForSnapshot(stdout)).toMatchSnapshot();
+    expect(p.normalizePathsForSnapshot(stdout, {id})).toMatchSnapshot();
   });
 
   test('build-env devDep', async function() {
@@ -232,14 +222,9 @@ describe('devDep workflow', () => {
 
   test.enableIf(isMacos)('macos: build-env devDep snapshot', async function() {
     const p = await createTestSandbox();
+    const id = JSON.parse((await p.esy('build-plan devDep')).stdout).id;
     const {stdout} = await p.esy('build-env devDep');
-    expect(p.normalizePathsForSnapshot(stdout)).toMatchSnapshot();
-  });
-
-  test.enableIf(isMacos)('macos: build-env --json devDep snapshot', async function() {
-    const p = await createTestSandbox();
-    const {stdout} = await p.esy('build-env --json devDep');
-    expect(p.normalizePathsForSnapshot(stdout)).toMatchSnapshot();
+    expect(p.normalizePathsForSnapshot(stdout, {id})).toMatchSnapshot();
   });
 
   test('sandbox-env', async function() {

--- a/test-e2e/esy-build/with-dev-dep.test.js
+++ b/test-e2e/esy-build/with-dev-dep.test.js
@@ -2,7 +2,7 @@
 
 const path = require('path');
 const helpers = require('../test/helpers');
-const {test, isWindows, isMacos} = helpers;
+const {test, isWindows, isMacos, isLinux} = helpers;
 
 helpers.skipSuiteOnWindows('Needs investigation');
 
@@ -150,12 +150,15 @@ describe('devDep workflow', () => {
     });
   });
 
-  test.enableIf(isMacos)('macos: build-env snapshot', async function() {
-    const p = await createTestSandbox();
-    const id = JSON.parse((await p.esy('build-plan')).stdout).id;
-    const {stdout} = await p.esy('build-env');
-    expect(p.normalizePathsForSnapshot(stdout, {id})).toMatchSnapshot();
-  });
+  test.enableIf(isMacos || isLinux)(
+    'macos || linux: build-env snapshot',
+    async function() {
+      const p = await createTestSandbox();
+      const id = JSON.parse((await p.esy('build-plan')).stdout).id;
+      const {stdout} = await p.esy('build-env');
+      expect(p.normalizePathsForSnapshot(stdout, {id})).toMatchSnapshot();
+    },
+  );
 
   test('build-env dep', async function() {
     const p = await createTestSandbox();
@@ -185,12 +188,15 @@ describe('devDep workflow', () => {
     });
   });
 
-  test.enableIf(isMacos)('macos: build-env dep snapshot', async function() {
-    const p = await createTestSandbox();
-    const id = JSON.parse((await p.esy('build-plan dep')).stdout).id;
-    const {stdout} = await p.esy('build-env dep');
-    expect(p.normalizePathsForSnapshot(stdout, {id})).toMatchSnapshot();
-  });
+  test.enableIf(isMacos || isLinux)(
+    'macos || linux: build-env dep snapshot',
+    async function() {
+      const p = await createTestSandbox();
+      const id = JSON.parse((await p.esy('build-plan dep')).stdout).id;
+      const {stdout} = await p.esy('build-env dep');
+      expect(p.normalizePathsForSnapshot(stdout, {id})).toMatchSnapshot();
+    },
+  );
 
   test('build-env devDep', async function() {
     const p = await createTestSandbox();
@@ -220,12 +226,15 @@ describe('devDep workflow', () => {
     });
   });
 
-  test.enableIf(isMacos)('macos: build-env devDep snapshot', async function() {
-    const p = await createTestSandbox();
-    const id = JSON.parse((await p.esy('build-plan devDep')).stdout).id;
-    const {stdout} = await p.esy('build-env devDep');
-    expect(p.normalizePathsForSnapshot(stdout, {id})).toMatchSnapshot();
-  });
+  test.enableIf(isMacos || isLinux)(
+    'macos || linux: build-env devDep snapshot',
+    async function() {
+      const p = await createTestSandbox();
+      const id = JSON.parse((await p.esy('build-plan devDep')).stdout).id;
+      const {stdout} = await p.esy('build-env devDep');
+      expect(p.normalizePathsForSnapshot(stdout, {id})).toMatchSnapshot();
+    },
+  );
 
   test('sandbox-env', async function() {
     const p = await createTestSandbox();

--- a/test-e2e/esy-build/with-dev-dep.test.js
+++ b/test-e2e/esy-build/with-dev-dep.test.js
@@ -2,6 +2,7 @@
 
 const path = require('path');
 const helpers = require('../test/helpers');
+const {test, isWindows, isMacos} = helpers;
 
 helpers.skipSuiteOnWindows('Needs investigation');
 
@@ -149,6 +150,18 @@ describe('devDep workflow', () => {
     });
   });
 
+  test.enableIf(isMacos)('macos: build-env snapshot', async function() {
+    const p = await createTestSandbox();
+    const {stdout} = await p.esy('build-env');
+    expect(p.normalizePathsForSnapshot(stdout)).toMatchSnapshot();
+  });
+
+  test.enableIf(isMacos)('macos: build-env --json snapshot', async function() {
+    const p = await createTestSandbox();
+    const {stdout} = await p.esy('build-env --json');
+    expect(p.normalizePathsForSnapshot(stdout)).toMatchSnapshot();
+  });
+
   test('build-env dep', async function() {
     const p = await createTestSandbox();
     const depId = JSON.parse((await p.esy('build-plan dep')).stdout).id;
@@ -177,6 +190,18 @@ describe('devDep workflow', () => {
     });
   });
 
+  test.enableIf(isMacos)('macos: build-env dep snapshot', async function() {
+    const p = await createTestSandbox();
+    const {stdout} = await p.esy('build-env dep');
+    expect(p.normalizePathsForSnapshot(stdout)).toMatchSnapshot();
+  });
+
+  test.enableIf(isMacos)('macos: build-env --json dep snapshot', async function() {
+    const p = await createTestSandbox();
+    const {stdout} = await p.esy('build-env --json dep');
+    expect(p.normalizePathsForSnapshot(stdout)).toMatchSnapshot();
+  });
+
   test('build-env devDep', async function() {
     const p = await createTestSandbox();
     const devDepId = JSON.parse((await p.esy('build-plan devDep')).stdout).id;
@@ -203,6 +228,18 @@ describe('devDep workflow', () => {
       OCAMLFIND_LDCONF: `ignore`,
       OCAMLFIND_DESTDIR: `${p.esyStorePath}/s/${devDepId}/lib`,
     });
+  });
+
+  test.enableIf(isMacos)('macos: build-env devDep snapshot', async function() {
+    const p = await createTestSandbox();
+    const {stdout} = await p.esy('build-env devDep');
+    expect(p.normalizePathsForSnapshot(stdout)).toMatchSnapshot();
+  });
+
+  test.enableIf(isMacos)('macos: build-env --json devDep snapshot', async function() {
+    const p = await createTestSandbox();
+    const {stdout} = await p.esy('build-env --json devDep');
+    expect(p.normalizePathsForSnapshot(stdout)).toMatchSnapshot();
   });
 
   test('sandbox-env', async function() {

--- a/test-e2e/esy-build/with-dev-dep.test.js
+++ b/test-e2e/esy-build/with-dev-dep.test.js
@@ -155,8 +155,12 @@ describe('devDep workflow', () => {
     async function() {
       const p = await createTestSandbox();
       const id = JSON.parse((await p.esy('build-plan')).stdout).id;
+      const depid = JSON.parse((await p.esy('build-plan dep')).stdout).id;
+      const devdepid = JSON.parse((await p.esy('build-plan devDep')).stdout).id;
       const {stdout} = await p.esy('build-env');
-      expect(p.normalizePathsForSnapshot(stdout, {id})).toMatchSnapshot();
+      expect(
+        p.normalizePathsForSnapshot(stdout, {id, depid, devdepid}),
+      ).toMatchSnapshot();
     },
   );
 

--- a/test-e2e/esy-build/with-linked-dep.test.js
+++ b/test-e2e/esy-build/with-linked-dep.test.js
@@ -81,16 +81,18 @@ describe('Build with a linked dep', () => {
     test.enableIf(isMacos)(
       'macos: build-env snapshot',
       withProject(async function(p) {
+        const id = JSON.parse((await p.esy('build-plan')).stdout).id;
         const {stdout} = await p.esy('build-env');
-        expect(p.normalizePathsForSnapshot(stdout)).toMatchSnapshot();
+        expect(p.normalizePathsForSnapshot(stdout, {id})).toMatchSnapshot();
       }),
     );
 
     test.enableIf(isMacos)(
       'macos: build-env dep snapshot',
       withProject(async function(p) {
+        const id = JSON.parse((await p.esy('build-plan dep')).stdout).id;
         const {stdout} = await p.esy('build-env dep');
-        expect(p.normalizePathsForSnapshot(stdout)).toMatchSnapshot();
+        expect(p.normalizePathsForSnapshot(stdout, {id})).toMatchSnapshot();
       }),
     );
   });

--- a/test-e2e/esy-build/with-linked-dep.test.js
+++ b/test-e2e/esy-build/with-linked-dep.test.js
@@ -7,6 +7,7 @@ const open = promisify(fs.open);
 const close = promisify(fs.close);
 
 const helpers = require('../test/helpers');
+const {test, isWindows, isMacos} = helpers;
 
 function makeFixture(p, buildDep) {
   return [
@@ -76,6 +77,22 @@ describe('Build with a linked dep', () => {
     }
 
     it('package "dep" should be visible in all envs', withProject(checkDepIsInEnv));
+
+    test.enableIf(isMacos)(
+      'macos: build-env snapshot',
+      withProject(async function(p) {
+        const {stdout} = await p.esy('build-env');
+        expect(p.normalizePathsForSnapshot(stdout)).toMatchSnapshot();
+      }),
+    );
+
+    test.enableIf(isMacos)(
+      'macos: build-env dep snapshot',
+      withProject(async function(p) {
+        const {stdout} = await p.esy('build-env dep');
+        expect(p.normalizePathsForSnapshot(stdout)).toMatchSnapshot();
+      }),
+    );
   });
 
   describe('in source build', () => {

--- a/test-e2e/esy-build/with-linked-dep.test.js
+++ b/test-e2e/esy-build/with-linked-dep.test.js
@@ -7,7 +7,7 @@ const open = promisify(fs.open);
 const close = promisify(fs.close);
 
 const helpers = require('../test/helpers');
-const {test, isWindows, isMacos} = helpers;
+const {test, isWindows, isMacos, isLinux} = helpers;
 
 function makeFixture(p, buildDep) {
   return [
@@ -78,8 +78,8 @@ describe('Build with a linked dep', () => {
 
     it('package "dep" should be visible in all envs', withProject(checkDepIsInEnv));
 
-    test.enableIf(isMacos)(
-      'macos: build-env snapshot',
+    test.enableIf(isMacos || isLinux)(
+      'macos || linux: build-env snapshot',
       withProject(async function(p) {
         const id = JSON.parse((await p.esy('build-plan')).stdout).id;
         const {stdout} = await p.esy('build-env');
@@ -87,8 +87,8 @@ describe('Build with a linked dep', () => {
       }),
     );
 
-    test.enableIf(isMacos)(
-      'macos: build-env dep snapshot',
+    test.enableIf(isMacos || isLinux)(
+      'macos || linux: build-env dep snapshot',
       withProject(async function(p) {
         const id = JSON.parse((await p.esy('build-plan dep')).stdout).id;
         const {stdout} = await p.esy('build-env dep');

--- a/test-e2e/esy-build/with-linked-dep.test.js
+++ b/test-e2e/esy-build/with-linked-dep.test.js
@@ -82,8 +82,9 @@ describe('Build with a linked dep', () => {
       'macos || linux: build-env snapshot',
       withProject(async function(p) {
         const id = JSON.parse((await p.esy('build-plan')).stdout).id;
+        const depid = JSON.parse((await p.esy('build-plan dep')).stdout).id;
         const {stdout} = await p.esy('build-env');
-        expect(p.normalizePathsForSnapshot(stdout, {id})).toMatchSnapshot();
+        expect(p.normalizePathsForSnapshot(stdout, {id, depid})).toMatchSnapshot();
       }),
     );
 

--- a/test-e2e/test/helpers.js
+++ b/test-e2e/test/helpers.js
@@ -241,11 +241,19 @@ async function createTestSandbox(...fixture: Fixture): Promise<TestSandbox> {
 
   const projectPathRe = new RegExp(escapeForRegexp(projectPath), 'g');
   const esyPrefixPathRe = new RegExp(escapeForRegexp(esyPrefixPath), 'g');
+  const esyStorePathRe = new RegExp(escapeForRegexp(esyStorePath), 'g');
 
   function normalizePathsForSnapshot(data, replacements) {
     data = data
       .replace(projectPathRe, '%projectPath%')
+      .replace(esyStorePathRe, '%esyStorePath%')
       .replace(esyPrefixPathRe, '%esyPrefixPath%');
+    for (let to in replacements) {
+      data = data.replace(
+        new RegExp(escapeForRegexp(replacements[to]), 'g'),
+        '%' + to + '%',
+      );
+    }
     return data;
   }
 

--- a/test-e2e/test/helpers.js
+++ b/test-e2e/test/helpers.js
@@ -74,7 +74,7 @@ export type TestSandbox = {
   ) => Promise<void>,
   npm: (args: string) => Promise<{stderr: string, stdout: string}>,
 
-  normalizePathsForSnapshot: string => string,
+  normalizePathsForSnapshot: (string, replacements?: {[s: string]: string}) => string,
   runJavaScriptInNodeAndReturnJson: string => Promise<Object>,
 
   defineNpmPackage: (
@@ -242,10 +242,11 @@ async function createTestSandbox(...fixture: Fixture): Promise<TestSandbox> {
   const projectPathRe = new RegExp(escapeForRegexp(projectPath), 'g');
   const esyPrefixPathRe = new RegExp(escapeForRegexp(esyPrefixPath), 'g');
 
-  function normalizePathsForSnapshot(data) {
-    return data
+  function normalizePathsForSnapshot(data, replacements) {
+    data = data
       .replace(projectPathRe, '%projectPath%')
       .replace(esyPrefixPathRe, '%esyPrefixPath%');
+    return data;
   }
 
   return {
@@ -319,7 +320,7 @@ function normalizeEOL(string: string) {
 }
 
 function createDefineTest(params) {
-  function deftest(name, fn) {
+  function deftest(name: string, fn: (done: () => void) => ?Promise<mixed>) {
     if (params.disabled) {
       return test.skip(name, fn);
     } else if (params.focused) {


### PR DESCRIPTION
Will help catch possible regressions in #700.

This commit adds snapshots for build env for various sandbox setups.

~~As build env is specific to an OS (because build IDs differ on different OSes and also there are some diffs in env), unforunately these snapshots are OS-dependent.~~ Normalized ids too, enabled snapshots for Linux.

For now I commit only macOS-snapshots but going to add Linux-snapshots and Windows-snapshots later.