### PR TITLE
Mark as linguist-generated

### DIFF
--- a/esy.lock/.gitattributes
+++ b/esy.lock/.gitattributes
@@ -1,3 +1,4 @@
 
 # Set eol to LF so files aren't converted to CRLF-eol on Windows.
 * text eol=lf
+* linguist-generated=true


### PR DESCRIPTION
adds linguist-generated=true to the gitattributes file, so that changes
won't be displayed in the diff by default

Resolves Issue #679 