### PR TITLE
Add `esy status` command

### DIFF
--- a/esy-lib/Graph.ml
+++ b/esy-lib/Graph.ml
@@ -6,6 +6,7 @@ module type GRAPH = sig
 
   val empty : id -> t
   val add : node -> t -> t
+  val nodes : t -> node list
 
   val mem : id -> t -> bool
   val isRoot : node -> t -> bool
@@ -78,6 +79,10 @@ module Make (Node : GRAPH_NODE) : GRAPH
     Node.Id.compare (Node.id node) graph.root = 0
 
   let mem id graph = Node.Id.Map.mem id graph.nodes
+
+  let nodes graph =
+    let f (_, node) = node in
+    List.map ~f (Node.Id.Map.bindings graph.nodes)
 
   let dependencies ?(traverse=Node.traverse) node graph =
     let dependencies = traverse node in

--- a/esy-lib/Json.ml
+++ b/esy-lib/Json.ml
@@ -158,3 +158,69 @@ module Encode = struct
     | None -> None
     | Some value -> Some (name, encode value)
 end
+
+module Print : sig
+  val pp :
+    ?ppListBox:(?indent:int -> t list Fmt.t -> t list Fmt.t)
+    -> ?ppAssocBox:(?indent:int -> (string * t) list Fmt.t -> (string * t) list Fmt.t)
+    -> t Fmt.t
+end = struct
+  let ppComma = Fmt.unit ",@ "
+
+  let quotedString fmt v =
+    Format.fprintf fmt "\"%a\"" Fmt.string v
+
+  let pp ?(ppListBox=Fmt.hvbox) ?(ppAssocBox=Fmt.hvbox) fmt json =
+    let rec pp fmt json =
+      Fmt.(vbox ppSyn) fmt json
+
+    and ppSyn fmt json =
+      match json with
+      | `Bool v -> Fmt.bool fmt v
+      | `Float v -> Fmt.float fmt v
+      | `Int v -> Fmt.int fmt v
+      | `Intlit v -> Fmt.string fmt v
+      | `String v -> quotedString fmt v
+      | `Null -> Fmt.unit "null" fmt ()
+      | `Variant (tag, args) ->
+        begin match args with
+        | None -> ppSyn fmt (`List [`String tag])
+        | Some args -> ppSyn fmt (`List [`String tag; args])
+        end
+      | `Tuple items
+      | `List items ->
+        let pp fmt items =
+          Format.fprintf
+            fmt "[@;<0 0>%a@;<0 -2>]"
+            (Fmt.list ~sep:ppComma ppListItem) items;
+        in
+        ppListBox ~indent:2 pp fmt items
+      | `Assoc items ->
+        let pp fmt items =
+          Format.fprintf
+            fmt "{@;<0 0>%a@;<0 -2>}"
+            (Fmt.list ~sep:ppComma ppAssocItem) items
+        in
+        ppAssocBox ~indent:2 pp fmt items
+
+    and ppListItem fmt item =
+      Format.fprintf fmt "%a" pp item
+
+    and ppAssocItem fmt (k, v) =
+      match v with
+      | `List items ->
+        Format.fprintf
+          fmt "@[<hv 2>%a: [@,%a@;<0 -2>]@]"
+          quotedString k (Fmt.list ~sep:ppComma ppListItem) items
+      | `Assoc items ->
+        Format.fprintf
+          fmt "@[<hv 2>%a: {@,%a@;<0 -2>}@]"
+          quotedString k (Fmt.list ~sep:ppComma ppAssocItem) items
+      | _ ->
+        Format.fprintf
+          fmt "@[<h 0>%a:@ %a@]"
+          quotedString k pp v
+    in
+
+    pp fmt json
+end

--- a/esy-lib/Json.mli
+++ b/esy-lib/Json.mli
@@ -46,3 +46,10 @@ module Encode : sig
   val field : string -> 'a encoder -> 'a -> field
   val fieldOpt : string -> 'a encoder -> 'a option -> field
 end
+
+module Print : sig
+  val pp :
+    ?ppListBox:(?indent:int -> t list Fmt.t -> t list Fmt.t)
+    -> ?ppAssocBox:(?indent:int -> (string * t) list Fmt.t -> (string * t) list Fmt.t)
+    -> t Fmt.t
+end

--- a/esy-lib/Result.re
+++ b/esy-lib/Result.re
@@ -19,10 +19,24 @@ let map = (~f) =>
   | Ok(v) => Ok(f(v))
   | Error(err) => Error(err);
 
+let isOk =
+  fun
+  | Ok(_) => true
+  | Error(_) => false;
+
+let isError =
+  fun
+  | Ok(_) => false
+  | Error(_) => true;
+
+let getOr = onError =>
+  fun
+  | Ok(v) => v
+  | Error(_) => onError;
+
 module List = {
   let map =
-      (~f: 'a => result('b, 'err), xs: list('a))
-      : result(list('b), 'err) => {
+      (~f: 'a => result('b, 'err), xs: list('a)): result(list('b), 'err) => {
     let f = (prev, x) =>
       switch (prev) {
       | Ok(xs) =>

--- a/esy-lib/Result.rei
+++ b/esy-lib/Result.rei
@@ -1,29 +1,31 @@
-type t('v, 'err) = result('v, 'err) =
-  | Ok('v)
-  | Error('err)
+type t('v, 'err) = result('v, 'err) = | Ok('v) | Error('err);
 
 let return: 'v => t('v, _);
 let error: 'err => t(_, 'err);
-let errorf : format4('a, Format.formatter, unit, t(_, string)) => 'a;
+let errorf: format4('a, Format.formatter, unit, t(_, string)) => 'a;
 
-let map : (~f:'a => 'b, result('a, 'err)) => result('b, 'err);
-let join : t(t('a, 'b), 'b) => t('a, 'b);
+let map: (~f: 'a => 'b, result('a, 'err)) => result('b, 'err);
+let join: t(t('a, 'b), 'b) => t('a, 'b);
 
-module List : {
+let isOk: result(_, _) => bool;
+let isError: result(_, _) => bool;
+
+let getOr: ('a, result('a, _)) => 'a;
+
+module List: {
   let map: (~f: 'a => t('b, 'err), list('a)) => t(list('b), 'err);
-  let foldLeft: (~f: ('a, 'b) => t('a, 'err), ~init: 'a, list('b)) => t('a, 'err);
+  let foldLeft:
+    (~f: ('a, 'b) => t('a, 'err), ~init: 'a, list('b)) => t('a, 'err);
 };
 
-module Syntax : {
+module Syntax: {
   let return: 'v => t('v, _);
   let error: 'err => t(_, 'err);
-  let errorf : format4('a, Format.formatter, unit, t(_, string)) => 'a;
+  let errorf: format4('a, Format.formatter, unit, t(_, string)) => 'a;
 
   module Let_syntax: {
     let bind: (~f: 'a => t('b, 'err), t('a, 'err)) => t('b, 'err);
     let map: (~f: 'a => 'b, t('a, 'err)) => t('b, 'err);
-    module Open_on_rhs: {
-      let return: 'a => t('a, 'b);
-    };
+    module Open_on_rhs: {let return: 'a => t('a, 'b);};
   };
 };

--- a/test-e2e/esy-status.test.js
+++ b/test-e2e/esy-status.test.js
@@ -1,0 +1,105 @@
+// @flow
+
+const helpers = require('./test/helpers.js');
+
+describe(`'esy status' command`, function() {
+  it('can be run outside of esy project', async function() {
+    const p = await helpers.createTestSandbox();
+    await p.fixture();
+
+    const {stdout} = await p.esy('status --json');
+    const status = JSON.parse(stdout);
+    expect(status).toEqual({
+      isProject: false,
+      isProjectFetched: false,
+      isProjectReadyForDev: false,
+      isProjectSolved: false,
+      rootBuildPath: null,
+      rootInstallPath: null,
+    });
+  });
+
+  const fixture = [
+    helpers.packageJson({
+      name: 'root',
+      dependencies: {
+        dep: 'path:./dep',
+      },
+    }),
+    helpers.dir(
+      'dep',
+      helpers.packageJson({
+        name: 'dep',
+        esy: {},
+      }),
+    ),
+  ];
+
+  it('can be run inside project, not solved', async function() {
+    const p = await helpers.createTestSandbox();
+    await p.fixture(...fixture);
+
+    const {stdout} = await p.esy('status --json');
+    const status = JSON.parse(stdout);
+    expect(status).toEqual({
+      isProject: true,
+      isProjectFetched: false,
+      isProjectReadyForDev: false,
+      isProjectSolved: false,
+      rootBuildPath: null,
+      rootInstallPath: null,
+    });
+  });
+
+  it('can be run inside project, not fetched', async function() {
+    const p = await helpers.createTestSandbox();
+    await p.fixture(...fixture);
+    await p.esy('solve');
+
+    const {stdout} = await p.esy('status --json');
+    const status = JSON.parse(stdout);
+    expect(status).toEqual({
+      isProject: true,
+      isProjectFetched: false,
+      isProjectReadyForDev: false,
+      isProjectSolved: true,
+      rootBuildPath: null,
+      rootInstallPath: null,
+    });
+  });
+
+  it('can be run inside project, not ready', async function() {
+    const p = await helpers.createTestSandbox();
+    await p.fixture(...fixture);
+    await p.esy('install');
+
+    const {stdout} = await p.esy('status --json');
+    const status = JSON.parse(stdout);
+    expect(status).toMatchObject({
+      isProject: true,
+      isProjectFetched: true,
+      isProjectReadyForDev: false,
+      isProjectSolved: true,
+    });
+    expect(status.rootBuildPath).not.toBe(null);
+    expect(status.rootInstallPath).not.toBe(null);
+  });
+
+  it('can be run inside project, ready', async function() {
+    const p = await helpers.createTestSandbox();
+    await p.fixture(...fixture);
+    await p.esy('install');
+    await p.esy('build');
+
+    const {stdout} = await p.esy('status --json');
+    const status = JSON.parse(stdout);
+    expect(status).toMatchObject({
+      isProject: true,
+      isProjectFetched: true,
+      isProjectReadyForDev: true,
+      isProjectSolved: true,
+    });
+    expect(status.rootBuildPath).not.toBe(null);
+    expect(status.rootInstallPath).not.toBe(null);
+  });
+});


### PR DESCRIPTION
This adds `esy status` command which prints information about esy project status
and additonal info needed for external tooling (specifically IDEs/editors).

Example invocation:
```
% esy status
{
  "isProject": true,
  "isProjectSolved": true,
  "isProjectFetched": true,
  "isProjectReadyForDev": true,
  "rootBuildPath": "/Users/andreypopp/Workspace/esy-ocaml/esy/_esy/default/store/b/esy-2c954c6a",
  "rootInstallPath": "/Users/andreypopp/Workspace/esy-ocaml/esy/_esy/default/store/i/esy-2c954c6a"
}
```

The type of the data structure returned is:
```
{
  isProject: bool,
  isProjectSolved: bool,
  isProjectFetched: bool,
  isProjectReadyForDev: bool,
  rootBuildPath: option(Path.t),
  rootInstallPath: option(Path.t)
}
```

The command is designed that it completes w/o error even if `esy` couldn't find
a project at all or fails at some step.

- `isProject` is `true` if `esy` was able to find the project, otherwise it is `false`.
- `isProjectSolved` is `true` if lockfile is present and corresponds to the
  constraints specificed in `package.json`.
- `isProjectFetched` is `true` if esy sees all sources fetched for each package found in a lockfile
  constraints specificed in `package.json`.
- `isProjectReadyForDev` is `true` if all non-linked packages are built, this
  means `esy CMD` will execute `  CMD` immediately without waiting for some builds
  to complete.

- `rootBuildPath` is a path to root's package build dir (can be null in case it can't be determined).
- `rootInstallPath` is a path to root's package install dir (can be null in case it can't be determined).