### PR TITLE
Azure CI: Remove now-unused 'Upload install folder' task

### DIFF
--- a/.ci/build-nix.yml
+++ b/.ci/build-nix.yml
@@ -5,26 +5,8 @@ steps:
   - script: 'esy install'
     displayName: 'esy install'
 
-  # - task: PublishBuildArtifacts@1
-  #   displayName: 'Cache: Upload source tarballs'
-  #   condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
-  #   inputs:
-  #       pathToPublish: '$(ESYCI__CACHE_INSTALL)'
-  #       artifactName: 'cache-$(Agent.OS)-source-tarballs'
-  #       parallel: true
-  #       parallelCount: 8
-
   - script: 'esy build'
     displayName: 'esy build'
-
-  - task: PublishBuildArtifacts@1
-    displayName: 'Cache: Upload install folder'
-    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
-    inputs:
-        pathToPublish: '$(ESYCI__CACHE_BUILD)'
-        artifactName: 'cache-$(Agent.OS)-install'
-        parallel: true
-        parallelCount: 8
 
   - script: 'esy bootstrap'
     displayName: 'esy bootstrap'


### PR DESCRIPTION
This is causing `master` to fail - removing this unused block.