### PR TITLE
Allow to refer to a linked package by path to its manifest

### DIFF
--- a/docs/low-level-commands.md
+++ b/docs/low-level-commands.md
@@ -57,7 +57,7 @@ Options:
 
 - `--all` Build all dependencies (including linked packages)
 
-- `--linked-depspec=DEPSPEC` Define DEPSPEC expression for linked packages'
+- `--link-depspec=DEPSPEC` Define DEPSPEC expression for linked packages'
   build environments.
 
 - `--release` Force to use "esy.build" commands (by default "esy.buildDev"
@@ -82,7 +82,7 @@ Arguments:
 
 Options:
 
-- `--linked-depspec=DEPSPEC` Define DEPSPEC expression for linked packages'
+- `--link-depspec=DEPSPEC` Define DEPSPEC expression for linked packages'
   build environments. This is only applicable if the currently selected package
   is a linked package (including the project root package).
 
@@ -122,7 +122,7 @@ Options:
 
 - `--include-npm-bin` Include npm bin in `$PATH`.
 
-- `--linked-depspec=DEPSPEC` Define DEPSPEC expression for linked packages'
+- `--link-depspec=DEPSPEC` Define DEPSPEC expression for linked packages'
   build environments. This is only applicable if the currently selected package
   is a linked package (including the project root package).
 
@@ -149,7 +149,7 @@ Options:
 
 - `--include-npm-bin` Include npm bin in `$PATH`.
 
-- `--linked-depspec=DEPSPEC` Define DEPSPEC expression for linked packages'
+- `--link-depspec=DEPSPEC` Define DEPSPEC expression for linked packages'
   build environments. This is only applicable if the currently selected package
   is a linked package (including the project root package).
 
@@ -159,7 +159,7 @@ Options:
 
 Some commands allow to define how a build or a command environment is constructed
 for each package based on other packages in a dependency graph (see `--envspec`
-and `--linked-depspec` command options described above). This is done via
+and `--link-depspec` command options described above). This is done via
 DEPSPEC expressions.
 
 There are the following constructs available in DEPSPEC:

--- a/esy/BuildSandbox.mli
+++ b/esy/BuildSandbox.mli
@@ -41,6 +41,7 @@ module Task : sig
     env : Scope.SandboxEnvironment.t;
     build : Scope.SandboxValue.t list list;
     install : Scope.SandboxValue.t list list option;
+    dependencies : EsyInstall.PackageId.t list;
   }
 
   val installPath : Config.t -> t -> Path.t
@@ -76,7 +77,7 @@ val buildShell :
   -> Unix.process_status RunAsync.t
 (** [shell task ()] shells into [task]'s build environment. *)
 
-val build :
+val buildOnly :
   force:bool
   -> ?quiet:bool
   -> ?buildOnly:bool
@@ -87,19 +88,20 @@ val build :
   -> unit RunAsync.t
 (** [build task ()] builds the [task]. *)
 
+val build :
+  ?concurrency:int
+  -> buildLinked:bool
+  -> t
+  -> Plan.t
+  -> EsyInstall.PackageId.t list
+  -> unit RunAsync.t
+
+
 val buildRoot :
   ?quiet:bool
   -> ?buildOnly:bool
   -> t
   -> Plan.t
-  -> unit RunAsync.t
-
-val buildDependencies :
-  ?concurrency:int
-  -> buildLinked:bool
-  -> t
-  -> Plan.t
-  -> EsyInstall.PackageId.t
   -> unit RunAsync.t
 
 val isBuilt :

--- a/esy/BuildSpec.ml
+++ b/esy/BuildSpec.ml
@@ -1,8 +1,9 @@
 module Package = EsyInstall.Solution.Package
 
 type t = {
-  buildLinked : build option;
-  buildAll : build;
+  build : build;
+  buildLink : build option;
+  buildRoot : build option;
 }
 
 and build = {
@@ -31,8 +32,22 @@ let mode_of_yojson = function
   | `String "buildDev" -> Ok BuildDev
   | _json -> Result.errorf {|invalid BuildSpec.mode: expected "build" or "buildDev"|}
 
-let classify spec pkg =
-  match pkg.Package.source, spec.buildLinked with
-  | Install _, _ -> spec.buildAll
-  | Link _, None -> spec.buildAll
-  | Link _, Some buildLinked -> buildLinked
+let classify spec solution pkg =
+  let root = EsyInstall.Solution.root solution in
+  let isRoot = Package.compare root pkg = 0 in
+  let kind =
+    if isRoot
+    then `Root
+    else match pkg.Package.source with
+    | Link _ -> `Link
+    | Install _ -> `All
+  in
+  match kind, spec.buildRoot, spec.buildLink with
+  | `All,     _,              _               -> spec.build
+
+  | `Link,    _,              None            -> spec.build
+  | `Link,    _,              Some buildLink  -> buildLink
+
+  | `Root,    Some buildRoot, _               -> buildRoot
+  | `Root,    None,           Some buildLink  -> buildLink
+  | `Root,    None,           None            -> spec.build

--- a/esy/BuildSpec.mli
+++ b/esy/BuildSpec.mli
@@ -1,12 +1,22 @@
 (** This describes how a project should be built. *)
 
 type t = {
+  build : build;
+  (** Define how we build packages. *)
 
-  buildLinked : build option;
-  (** Optionally define if we need to treat linked packages in a specific way. *)
+  buildLink : build option;
+  (**
+   * Optionally define if we need to treat linked packages in a specific way.
+   *
+   * (this overrides buildLink and build)
+   *)
 
-  buildAll : build;
-  (** Define how we treat all other packages. *)
+  buildRoot : build option;
+  (**
+   * Optionally define if we need to treat the root packag in a specific way.
+   *
+   * (this overrides buildLink and build)
+   *)
 }
 
 and build = {
@@ -27,4 +37,4 @@ val show_mode : mode -> string
 val mode_to_yojson : mode Json.encoder
 val mode_of_yojson : mode Json.decoder
 
-val classify : t -> EsyInstall.Solution.Package.t -> build
+val classify : t -> EsyInstall.Solution.t -> EsyInstall.Solution.Package.t -> build

--- a/esy/NpmRelease.ml
+++ b/esy/NpmRelease.ml
@@ -121,8 +121,9 @@ let envspec = {
 }
 let buildspec = {
   BuildSpec.
-  buildAll = {mode = Build; deps = DepSpec.(dependencies self);};
-  buildLinked = Some {mode = Build; deps = DepSpec.(dependencies self);};
+  build = {mode = Build; deps = DepSpec.(dependencies self);};
+  buildLink = Some {mode = Build; deps = DepSpec.(dependencies self);};
+  buildRoot = Some {mode = Build; deps = DepSpec.(dependencies self);};
 }
 
 let make
@@ -165,24 +166,12 @@ let make
   (* Make sure all packages are built *)
   let%bind () =
     let%lwt () = Logs_lwt.app (fun m -> m "Building packages") in
-    let%bind () =
-      BuildSandbox.buildDependencies
-        ~buildLinked:true
-        ~concurrency
-        sandbox
-        plan
-        root.EsyInstall.Solution.Package.id
-    in
-    let%bind () =
-      BuildSandbox.build
-        ~buildOnly:false
-        ~quiet:true
-        ~force:true
-        sandbox
-        plan
-        root.EsyInstall.Solution.Package.id
-    in
-    return ()
+    BuildSandbox.build
+      ~buildLinked:true
+      ~concurrency
+      sandbox
+      plan
+      [root.EsyInstall.Solution.Package.id]
   in
 
   let%bind () = Fs.createDir outputPath in

--- a/esy/bin/Project.ml
+++ b/esy/bin/Project.ml
@@ -154,7 +154,12 @@ let makeFetched makeConfigured (projcfg : ProjectConfig.t) solution files =
       let checkPackageIsInInstallation isActual pkg =
         if not isActual
         then isActual
-        else Installation.mem pkg.Solution.Package.id installation
+        else (
+          let check = Installation.mem pkg.Solution.Package.id installation in
+          if not check
+          then Logs.debug (fun m -> m "missing from installation %a" Solution.Package.pp pkg);
+          check
+        )
       in
       List.fold_left ~f:checkPackageIsInInstallation ~init:true nodes
     in

--- a/esy/bin/Workflow.ml
+++ b/esy/bin/Workflow.ml
@@ -7,17 +7,21 @@ type t = {
   buildenvspec : EnvSpec.t;
 }
 
-let defaultDepspecForAll = DepSpec.(dependencies self)
-let defaultDepspecForLinked = DepSpec.(dependencies self)
+let defaultDepspec = DepSpec.(dependencies self)
+let defaultDepspecForLink = DepSpec.(dependencies self)
+let defaultDepspecForRoot = DepSpec.(dependencies self)
 
 let default =
+
   (* This defines how project is built. *)
   let buildspec = {
     BuildSpec.
-    (* build linked packages using "buildDev" command with dependencies in the env *)
-    buildLinked = Some {mode = BuildDev; deps = defaultDepspecForLinked};
     (* build all other packages using "build" command with dependencies in the env *)
-    buildAll = {mode = Build; deps = defaultDepspecForAll};
+    build = {mode = Build; deps = defaultDepspec};
+    (* build linked packages using "buildDev" command with dependencies in the env *)
+    buildLink = Some {mode = BuildDev; deps = defaultDepspecForLink};
+    (* build linked packages using "buildDev" command with dependencies in the env *)
+    buildRoot = Some {mode = BuildDev; deps = defaultDepspecForRoot};
   } in
 
   (* This defines environment for "esy x CMD" invocation. *)

--- a/esy/bin/Workflow.mli
+++ b/esy/bin/Workflow.mli
@@ -7,7 +7,8 @@ type t = {
   buildenvspec : EnvSpec.t;
 }
 
-val defaultDepspecForAll : DepSpec.t
-val defaultDepspecForLinked : DepSpec.t
+val defaultDepspec : DepSpec.t
+val defaultDepspecForLink : DepSpec.t
+val defaultDepspecForRoot : DepSpec.t
 
 val default : t

--- a/esy/bin/esyCommand.ml
+++ b/esy/bin/esyCommand.ml
@@ -96,7 +96,7 @@ module TermPp = struct
       Fmt.pf fmt
         "%a%a"
         ppMode mode
-        (ppOption "--linked-depspec" DepSpec.pp) (Some deps)
+        (ppOption "--link-depspec" DepSpec.pp) (Some deps)
 end
 
 let resolvePackage ~pkgName (proj : Project.WithWorkflow.t) =
@@ -1886,7 +1886,7 @@ let makeCommands ~sandbox () =
         $ Arg.(
             value
             & opt (some depspecConv) None
-            & info ["linked-depspec"] ~doc:"What to add to the env" ~docv:"DEPSPEC"
+            & info ["link-depspec"] ~doc:"What to add to the env" ~docv:"DEPSPEC"
           )
         $ Arg.(
             value
@@ -1917,7 +1917,7 @@ let makeCommands ~sandbox () =
         $ Arg.(
             value
             & opt (some depspecConv) None
-            & info ["linked-depspec"]
+            & info ["link-depspec"]
               ~doc:"Define DEPSPEC expression for linked packages' build environments"
               ~docv:"DEPSPEC"
           )
@@ -1955,7 +1955,7 @@ let makeCommands ~sandbox () =
         $ Arg.(
             value
             & opt (some depspecConv) None
-            & info ["linked-depspec"]
+            & info ["link-depspec"]
               ~doc:"Define DEPSPEC expression for linked packages' build environments"
               ~docv:"DEPSPEC"
           )
@@ -1993,7 +1993,7 @@ let makeCommands ~sandbox () =
         $ Arg.(
             value
             & opt (some depspecConv) None
-            & info ["linked-depspec"]
+            & info ["link-depspec"]
               ~doc:"Define DEPSPEC expression for linked packages' build environments"
               ~docv:"DEPSPEC"
           )

--- a/esyi/DistPath.ml
+++ b/esyi/DistPath.ml
@@ -8,6 +8,8 @@ let rebase ~base p = normalizeAndRemoveEmptySeg (base // p)
 
 let render path = normalizePathSlashes (show path)
 
+let (/) path seg = normalizeAndRemoveEmptySeg (path / seg)
+
 let show = render
 let showPretty path = Path.(normalizePathSlashes (showPretty path))
 

--- a/esyi/DistPath.mli
+++ b/esyi/DistPath.mli
@@ -14,6 +14,7 @@ include S.JSONABLE with type t := t
 include S.COMPARABLE with type t := t
 
 val v : string -> t
+val (/) : t -> string -> t
 
 val toPath : Path.t -> t -> Path.t
 (** [toPath base p] converts [p] to [Path.t] by rebasing on top of [base]. *)
@@ -24,5 +25,6 @@ val rebase : base:t -> t -> t
 
 val sexp_of_t : t -> Sexplib0.Sexp.t
 
+val pp : t Fmt.t
 val show : t -> string
 val showPretty : t -> string

--- a/esyi/PkgSpec.ml
+++ b/esyi/PkgSpec.ml
@@ -15,25 +15,25 @@ let parse =
   function
   | "root" -> return Root
   | v ->
-  let split = Astring.String.cut ~sep:"@" in
-  let rec parsename v =
-    match split v with
-    | Some ("", v) ->
-      let name, rest = parsename v in
-      "@" ^ name, rest
-    | Some (name, rest) ->
-      name, Some rest
-    | None -> v, None
-  in
-  match parsename v with
-  | name, Some ""
-  | name, None -> return (ByName name)
-  | name, Some rest ->
-    begin match split rest with
-    | Some _ ->
-      let%bind id = PackageId.parse v in
-      return (ById id)
-    | None ->
-      let%bind version = Version.parse rest in
-      return (ByNameVersion (name, version))
-    end
+    let split = Astring.String.cut ~sep:"@" in
+    let rec parsename v =
+      match split v with
+      | Some ("", v) ->
+        let name, rest = parsename v in
+        "@" ^ name, rest
+      | Some (name, rest) ->
+        name, Some rest
+      | None -> v, None
+    in
+    match parsename v with
+    | name, Some ""
+    | name, None -> return (ByName name)
+    | name, Some rest ->
+      begin match split rest with
+      | Some _ ->
+        let%bind id = PackageId.parse v in
+        return (ById id)
+      | None ->
+        let%bind version = Version.parse rest in
+        return (ByNameVersion (name, version))
+      end

--- a/esyi/Solution.ml
+++ b/esyi/Solution.ml
@@ -42,6 +42,20 @@ include Graph.Make(struct
   module Id = PackageId
 end)
 
+let findByPath p solution =
+  let open Option.Syntax in
+  let f _id pkg =
+    match pkg.Package.source with
+    | Link {path; manifest = None;} ->
+      DistPath.compare path p >= 0
+    | Link {path; manifest = Some filename;} ->
+      let path = DistPath.(path / ManifestSpec.show filename) in
+      DistPath.compare path p >= 0
+    | _ -> false
+  in
+  let%map _id, pkg = find f solution in
+  pkg
+
 let findByName name solution =
   let open Option.Syntax in
   let f _id pkg =

--- a/esyi/Solution.ml
+++ b/esyi/Solution.ml
@@ -47,6 +47,7 @@ let findByPath p solution =
   let f _id pkg =
     match pkg.Package.source with
     | Link {path; manifest = None;} ->
+      let path = DistPath.(path / "package.json") in
       DistPath.compare path p >= 0
     | Link {path; manifest = Some filename;} ->
       let path = DistPath.(path / ManifestSpec.show filename) in

--- a/esyi/Solution.mli
+++ b/esyi/Solution.mli
@@ -29,6 +29,7 @@ include Graph.GRAPH
     type node = Package.t
     and type id = PackageId.t
 
+val findByPath : DistPath.t -> t -> Package.t option
 val findByName : string -> t -> Package.t option
 val findByNameVersion : string -> Version.t -> t -> Package.t option
 

--- a/test-e2e/complete/monorepo-workflow.test.js
+++ b/test-e2e/complete/monorepo-workflow.test.js
@@ -136,11 +136,11 @@ describe('Monorepo workflow using low level commands', function() {
     // now try to build with a custom DEPSPEC
     const p = await createTestSandbox();
 
-    await p.esy(`build-dependencies --all --linked-depspec "${depspec}"`);
+    await p.esy(`build-dependencies --all --link-depspec "${depspec}"`);
 
     for (const pkg of ['pkga', 'pkgb', 'pkgc']) {
       const {stdout} = await p.esy(
-        `exec-command --include-current-env --linked-depspec "${depspec}" root -- ${pkg}.cmd`,
+        `exec-command --include-current-env --link-depspec "${depspec}" root -- ${pkg}.cmd`,
       );
       expect(stdout.trim()).toBe(`__${pkg}__`);
     }
@@ -164,7 +164,7 @@ describe('Monorepo workflow using low level commands', function() {
     // run commands in a specified package environment.
     const p = await createTestSandbox();
     const {stdout} = await p.esy(
-      `exec-command --linked-depspec "${depspec}" pkga -- echo '#{self.name}'`,
+      `exec-command --link-depspec "${depspec}" pkga -- echo '#{self.name}'`,
     );
 
     expect(stdout.trim()).toBe('pkga');
@@ -174,7 +174,7 @@ describe('Monorepo workflow using low level commands', function() {
     // we can also refer to linked package by its manifest path
     const p = await createTestSandbox();
     const {stdout} = await p.esy(
-      `exec-command --linked-depspec "${depspec}" ./pkgb/package.json -- echo '#{self.name}'`,
+      `exec-command --link-depspec "${depspec}" ./pkgb/package.json -- echo '#{self.name}'`,
     );
 
     expect(stdout.trim()).toBe('pkgb');

--- a/test-e2e/complete/monorepo-workflow.test.js
+++ b/test-e2e/complete/monorepo-workflow.test.js
@@ -16,7 +16,7 @@
 //
 
 const helpers = require('../test/helpers.js');
-const {packageJson, dir, dummyExecutable} = helpers;
+const {test, isWindows, packageJson, dir, dummyExecutable} = helpers;
 
 async function createTestSandbox() {
   const p = await helpers.createTestSandbox();
@@ -160,23 +160,29 @@ describe('Monorepo workflow using low level commands', function() {
     }
   });
 
-  test('running command in monorepo package env (referring to a package by name)', async function() {
-    // run commands in a specified package environment.
-    const p = await createTestSandbox();
-    const {stdout} = await p.esy(
-      `exec-command --link-depspec "${depspec}" pkga -- echo '#{self.name}'`,
-    );
+  test.disableIf(isWindows)(
+    'running command in monorepo package env (referring to a package by name)',
+    async function() {
+      // run commands in a specified package environment.
+      const p = await createTestSandbox();
+      const {stdout} = await p.esy(
+        `exec-command --link-depspec "${depspec}" pkga -- echo '#{self.name}'`,
+      );
 
-    expect(stdout.trim()).toBe('pkga');
-  });
+      expect(stdout.trim()).toBe('pkga');
+    },
+  );
 
-  test('running command in monorepo package env (referring to a package by path)', async function() {
-    // we can also refer to linked package by its manifest path
-    const p = await createTestSandbox();
-    const {stdout} = await p.esy(
-      `exec-command --link-depspec "${depspec}" ./pkgb/package.json -- echo '#{self.name}'`,
-    );
+  test.disableIf(isWindows)(
+    'running command in monorepo package env (referring to a package by path)',
+    async function() {
+      // we can also refer to linked package by its manifest path
+      const p = await createTestSandbox();
+      const {stdout} = await p.esy(
+        `exec-command --link-depspec "${depspec}" ./pkgb/package.json -- echo '#{self.name}'`,
+      );
 
-    expect(stdout.trim()).toBe('pkgb');
-  });
+      expect(stdout.trim()).toBe('pkgb');
+    },
+  );
 });

--- a/test-e2e/complete/monorepo-workflow.test.js
+++ b/test-e2e/complete/monorepo-workflow.test.js
@@ -132,7 +132,7 @@ describe('Monorepo workflow using low level commands', function() {
     );
   });
 
-  test.only('that the build is ok with custom DEPSPEC config', async function() {
+  test('that the build is ok with custom DEPSPEC config', async function() {
     // now try to build with a custom DEPSPEC
     const p = await createTestSandbox();
 

--- a/test-e2e/complete/monorepo-workflow.test.js
+++ b/test-e2e/complete/monorepo-workflow.test.js
@@ -112,16 +112,17 @@ async function createTestSandbox() {
     dir('devDep', ...devDep),
   ];
   await p.fixture(...fixture);
+  await p.esy('install');
   return p;
 }
 
-test('Monorepo workflow using low level commands', async function() {
-  const p = await createTestSandbox();
+describe('Monorepo workflow using low level commands', function() {
+  const depspec = 'dependencies(self)+devDependencies(root)';
 
-  await p.esy('install');
+  test('that the build is failing with default config', async function() {
+    const p = await createTestSandbox();
 
-  // simple build doesn't work as we are using devDep of the root in "buildDev"
-  {
+    // simple build doesn't work as we are using devDep of the root in "buildDev"
     await expect(p.esy('build')).rejects.toThrowError(
       'unable to resolve command: devDep.cmd',
     );
@@ -129,11 +130,12 @@ test('Monorepo workflow using low level commands', async function() {
     await expect(p.esy('build-dependencies --all')).rejects.toThrowError(
       'unable to resolve command: devDep.cmd',
     );
-  }
+  });
 
-  // now try to build with a custom DEPSPEC
-  {
-    const depspec = 'dependencies(self)+devDependencies(root)';
+  test.only('that the build is ok with custom DEPSPEC config', async function() {
+    // now try to build with a custom DEPSPEC
+    const p = await createTestSandbox();
+
     await p.esy(`build-dependencies --all --linked-depspec "${depspec}"`);
 
     for (const pkg of ['pkga', 'pkgb', 'pkgc']) {
@@ -142,11 +144,12 @@ test('Monorepo workflow using low level commands', async function() {
       );
       expect(stdout.trim()).toBe(`__${pkg}__`);
     }
-  }
+  });
 
-  // release build should work as-is as we are building using `"esy.build"`
-  // commands.
-  {
+  test('that the release build is ok with custom DEPSPEC config', async function() {
+    // release build should work as-is as we are building using `"esy.build"`
+    // commands.
+    const p = await createTestSandbox();
     await p.esy('build-dependencies --all --release');
 
     for (const pkg of ['pkga', 'pkgb', 'pkgc']) {
@@ -155,5 +158,25 @@ test('Monorepo workflow using low level commands', async function() {
       );
       expect(stdout.trim()).toBe(`__${pkg}__`);
     }
-  }
+  });
+
+  test('running command in monorepo package env (referring to a package by name)', async function() {
+    // run commands in a specified package environment.
+    const p = await createTestSandbox();
+    const {stdout} = await p.esy(
+      `exec-command --linked-depspec "${depspec}" pkga -- echo '#{self.name}'`,
+    );
+
+    expect(stdout.trim()).toBe('pkga');
+  });
+
+  test('running command in monorepo package env (referring to a package by path)', async function() {
+    // we can also refer to linked package by its manifest path
+    const p = await createTestSandbox();
+    const {stdout} = await p.esy(
+      `exec-command --linked-depspec "${depspec}" ./pkgb/package.json -- echo '#{self.name}'`,
+    );
+
+    expect(stdout.trim()).toBe('pkgb');
+  });
 });

--- a/test-e2e/complete/opam-sandbox.test.js
+++ b/test-e2e/complete/opam-sandbox.test.js
@@ -134,7 +134,7 @@ describe('complete flow for opam sandboxes', () => {
     expect(stdout.trim()).toEqual('__hello__');
   });
 
-  it.skip('multiple <pkg>.opam files', async () => {
+  it('multiple <pkg>.opam files', async () => {
     const fixture = [
       // this define "false" as build command to make sure esy doesn't execute
       // it
@@ -144,6 +144,9 @@ describe('complete flow for opam sandboxes', () => {
           opam-version: "1.2"
           build: [
             ["false"]
+          ]
+          depends: [
+            "ocaml"
           ]
         `,
       ),
@@ -155,6 +158,9 @@ describe('complete flow for opam sandboxes', () => {
           opam-version: "1.2"
           build: [
             ["false"]
+          ]
+          depends: [
+            "ocaml"
           ]
         `,
       ),

--- a/test-e2e/complete/opam-sandbox.test.js
+++ b/test-e2e/complete/opam-sandbox.test.js
@@ -134,7 +134,7 @@ describe('complete flow for opam sandboxes', () => {
     expect(stdout.trim()).toEqual('__hello__');
   });
 
-  it('multiple <pkg>.opam files', async () => {
+  it.skip('multiple <pkg>.opam files', async () => {
     const fixture = [
       // this define "false" as build command to make sure esy doesn't execute
       // it
@@ -167,7 +167,7 @@ describe('complete flow for opam sandboxes', () => {
     await p.esy('build');
   });
 
-  it.only('ocaml constraints should be translated to npm versions (root)', async () => {
+  it('ocaml constraints should be translated to npm versions (root)', async () => {
     const p = await createTestSandbox();
 
     await p.fixture(
@@ -216,7 +216,7 @@ describe('complete flow for opam sandboxes', () => {
     });
   });
 
-  it.only('ocaml constraints should be translated to npm versions (dep)', async () => {
+  it('ocaml constraints should be translated to npm versions (dep)', async () => {
     const p = await createTestSandbox();
 
     await p.fixture(

--- a/test-e2e/esy-build-dependencies.test.js
+++ b/test-e2e/esy-build-dependencies.test.js
@@ -79,17 +79,6 @@ describe(`'esy build-dependencies' command`, () => {
     });
   });
 
-  it(`builds devDependencies`, async () => {
-    const p = await createTestSandbox();
-    await p.esy('install');
-    await p.esy('build-dependencies');
-    const env = await getCommandEnv(p);
-    await expect(p.run('devDep.cmd', env)).resolves.toEqual({
-      stdout: '__devDep__' + os.EOL,
-      stderr: '',
-    });
-  });
-
   it(`doesn't build linked dependencies`, async () => {
     const p = await createTestSandbox();
     await p.esy('install');


### PR DESCRIPTION
This PR makes it possible to refer to a link packages in a projecy by the path
to its manifest:

```
% esy build-env ./linked/package.json
```

This is especially useful in monorepo.

Also this fixes a bug with build ordering: previosuly build order didn't respect DEPSPEC expression which was used to produce builds.