### PR TITLE
Update Dist.parser with more informative errors

### DIFF
--- a/esy-lib/Parse.ml
+++ b/esy-lib/Parse.ml
@@ -8,6 +8,8 @@ end
 let ignore p =
   p >>| (fun _ -> ())
 
+let const v = (fun _ -> return v)
+
 let maybe p = option None (p >>| fun v -> Some v)
 
 let till c p =
@@ -28,7 +30,11 @@ let hex =
   ) <?> "hex"
 
 let parse p input =
-  parse_string (p <* end_of_input) input
+  match parse_string (p <* end_of_input) input with
+  | Ok v -> Ok v
+  | Error msg ->
+    let msg = Printf.sprintf {|parsing "%s": %s|} input msg in
+    Error msg
 
 module Test = struct
 
@@ -47,7 +53,7 @@ module Test = struct
   let parse ~sexp_of parse input =
     match parse input with
     | Error err ->
-      Format.printf "Error parsing '%s': %s@." input err
+      Format.printf "ERROR: %s@." err
     | Ok v ->
       let sexp = sexp_of v in
       Format.printf "%a@." Sexplib0.Sexp.pp_hum sexp

--- a/esyi/Source.ml
+++ b/esyi/Source.ml
@@ -96,8 +96,11 @@ module Parse = struct
     withPrefix "link:" (link ~requirePathSep:false) <|> dist
 
   let parserRelaxed =
-    let%map dist = Dist.parserRelaxed in
-    Dist dist
+    let distRelaxed =
+      let%map dist = Dist.parserRelaxed in
+      Dist dist
+    in
+    parser <|> distRelaxed
 end
 
 let parser = Parse.parser
@@ -117,7 +120,7 @@ let of_yojson json =
 let relaxed_of_yojson json =
   match json with
   | `String string ->
-    let parse = Parse.(parse (parser <|> parserRelaxed)) in
+    let parse = Parse.(parse parserRelaxed) in
     parse string
   | _ -> Error "expected string"
 
@@ -136,44 +139,44 @@ let%test_module "parsing" = (module struct
   let parse =
     Parse.Test.parse ~sexp_of:sexp_of_t parse
 
-  let%expect_test "github:user/repo#commit" =
-    parse "github:user/repo#commit";
-    [%expect {| (Dist (Github (user user) (repo repo) (commit commit) (manifest ()))) |}]
+  let%expect_test "github:user/repo#abc123" =
+    parse "github:user/repo#abc123";
+    [%expect {| (Dist (Github (user user) (repo repo) (commit abc123) (manifest ()))) |}]
 
-  let%expect_test "github:user/repo:lwt.opam#commit" =
-    parse "github:user/repo:lwt.opam#commit";
+  let%expect_test "github:user/repo:lwt.opam#abc123" =
+    parse "github:user/repo:lwt.opam#abc123";
     [%expect {|
       (Dist
-       (Github (user user) (repo repo) (commit commit)
+       (Github (user user) (repo repo) (commit abc123)
         (manifest ((Opam lwt.opam))))) |}]
 
-  let%expect_test "gh:user/repo#commit" =
-    parse "gh:user/repo#commit";
-    [%expect {| (Dist (Github (user user) (repo repo) (commit commit) (manifest ()))) |}]
+  let%expect_test "gh:user/repo#abc123" =
+    parse "gh:user/repo#abc123";
+    [%expect {| (Dist (Github (user user) (repo repo) (commit abc123) (manifest ()))) |}]
 
-  let%expect_test "gh:user/repo:lwt.opam#commit" =
-    parse "gh:user/repo:lwt.opam#commit";
+  let%expect_test "gh:user/repo:lwt.opam#abc123" =
+    parse "gh:user/repo:lwt.opam#abc123";
     [%expect {|
       (Dist
-       (Github (user user) (repo repo) (commit commit)
+       (Github (user user) (repo repo) (commit abc123)
         (manifest ((Opam lwt.opam))))) |}]
 
-  let%expect_test "git:http://example.com/repo#commit" =
-    parse "git:http://example.com/repo#commit";
-    [%expect {| (Dist (Git (remote http://example.com/repo) (commit commit) (manifest ()))) |}]
+  let%expect_test "git:http://example.com/repo#abc123" =
+    parse "git:http://example.com/repo#abc123";
+    [%expect {| (Dist (Git (remote http://example.com/repo) (commit abc123) (manifest ()))) |}]
 
-  let%expect_test "git:http://example.com/repo:lwt.opam#commit" =
-    parse "git:http://example.com/repo:lwt.opam#commit";
+  let%expect_test "git:http://example.com/repo:lwt.opam#abc123" =
+    parse "git:http://example.com/repo:lwt.opam#abc123";
     [%expect {|
       (Dist
-       (Git (remote http://example.com/repo) (commit commit)
+       (Git (remote http://example.com/repo) (commit abc123)
         (manifest ((Opam lwt.opam))))) |}]
 
-  let%expect_test "git:git://example.com/repo:lwt.opam#commit" =
-    parse "git:git://example.com/repo:lwt.opam#commit";
+  let%expect_test "git:git://example.com/repo:lwt.opam#abc123" =
+    parse "git:git://example.com/repo:lwt.opam#abc123";
     [%expect {|
       (Dist
-       (Git (remote git://example.com/repo) (commit commit)
+       (Git (remote git://example.com/repo) (commit abc123)
         (manifest ((Opam lwt.opam))))) |}]
 
   let%expect_test "archive:http://example.com#abc123" =
@@ -219,15 +222,15 @@ let%test_module "parsing" = (module struct
   let parseRelaxed =
     Parse.Test.parse ~sexp_of:sexp_of_t parseRelaxed
 
-  let%expect_test "user/repo#commit" =
-    parseRelaxed "user/repo#commit";
-    [%expect {| (Dist (Github (user user) (repo repo) (commit commit) (manifest ()))) |}]
+  let%expect_test "user/repo#abc123" =
+    parseRelaxed "user/repo#abc123";
+    [%expect {| (Dist (Github (user user) (repo repo) (commit abc123) (manifest ()))) |}]
 
-  let%expect_test "user/repo:lwt.opam#commit" =
-    parseRelaxed "user/repo:lwt.opam#commit";
+  let%expect_test "user/repo:lwt.opam#abc123" =
+    parseRelaxed "user/repo:lwt.opam#abc123";
     [%expect {|
       (Dist
-       (Github (user user) (repo repo) (commit commit)
+       (Github (user user) (repo repo) (commit abc123)
         (manifest ((Opam lwt.opam))))) |}]
 
   let%expect_test "http://example.com#abc123" =
@@ -255,6 +258,6 @@ let%test_module "parsing" = (module struct
 
   let%expect_test "some" =
     parseRelaxed "some";
-    [%expect {| Error parsing 'some': : not a path |}]
+    [%expect {| ERROR: parsing "some": : not a path |}]
 
 end)

--- a/esyi/Version.ml
+++ b/esyi/Version.ml
@@ -79,17 +79,17 @@ let%test_module "parsing" = (module struct
     parse ~tryAsOpam:true "no-source:";
     [%expect {| (Source (Dist NoSource)) |}]
 
-  let%expect_test "user/repo#commit" =
-    parse "user/repo#commit";
+  let%expect_test "user/repo#abc123" =
+    parse "user/repo#abc123";
     [%expect {|
       (Source
-       (Dist (Github (user user) (repo repo) (commit commit) (manifest ())))) |}]
+       (Dist (Github (user user) (repo repo) (commit abc123) (manifest ())))) |}]
 
-  let%expect_test "user/repo#commit" =
-    parse ~tryAsOpam:true "user/repo#commit";
+  let%expect_test "user/repo#abc123" =
+    parse ~tryAsOpam:true "user/repo#abc123";
     [%expect {|
       (Source
-       (Dist (Github (user user) (repo repo) (commit commit) (manifest ())))) |}]
+       (Dist (Github (user user) (repo repo) (commit abc123) (manifest ())))) |}]
 
   let%expect_test "./some/path" =
     parse "./some/path";
@@ -125,7 +125,7 @@ let%test_module "parsing" = (module struct
 
   let%expect_test "some" =
     parse "some";
-    [%expect {| Error parsing 'some': : not a path |}]
+    [%expect {| ERROR: parsing "some": : not a path |}]
 
   let%expect_test "some" =
     parse ~tryAsOpam:true "some";

--- a/test-e2e/common/solve-errors.test.js
+++ b/test-e2e/common/solve-errors.test.js
@@ -392,34 +392,6 @@ describe('"esy solve" errors', function() {
       `,
     );
   });
-
-  it('reports errors about missing link: packages (path does not exist)', async () => {
-    const p = await helpers.createTestSandbox();
-
-    await p.fixture(
-      packageJson({
-        name: 'root',
-        esy: {},
-        dependencies: {
-          missing: '*',
-        },
-        resolutions: {
-          missing: 'link:./missing',
-        },
-      }),
-    );
-
-    const err = await expectAndReturnRejection(p.esy('install --skip-repository-update'));
-    expect(err.stderr.trim()).toEqual(
-      outdent`
-      info install ${version}
-      error: no manifest found at link:missing
-        reading package metadata from link:missing
-        resolving metadata missing@link:missing
-      esy: exiting due to errors above
-      `,
-    );
-  });
 });
 
 describe('"resolutions" misconfiguration errors', function() {
@@ -475,6 +447,61 @@ describe('"resolutions" misconfiguration errors', function() {
       error: parsing "author/pkg#ref": <author>/<repo>(:<manifest>)?#<commit>: missing or incorrect <commit>
         reading package metadata from link:./package.json
         loading root package metadata
+      esy: exiting due to errors above
+      `,
+    );
+  });
+
+  it('link to a non-existent path', async function() {
+    const p = await helpers.createTestSandbox();
+
+    await p.fixture(
+      packageJson({
+        name: 'root',
+        esy: {},
+        dependencies: {
+          pkg: '*',
+        },
+        resolutions: {
+          pkg: 'link:./somepath/pkg',
+        },
+      }),
+    );
+    const err = await expectAndReturnRejection(p.esy('install --skip-repository-update'));
+    expect(err.stderr.trim()).toEqual(
+      outdent`
+      info install ${version}
+      error: somepath/pkg doesn't exist
+        reading package metadata from link:somepath/pkg
+        resolving metadata pkg@link:somepath/pkg
+      esy: exiting due to errors above
+      `,
+    );
+  });
+
+  it('link to a non-existent manifest', async function() {
+    const p = await helpers.createTestSandbox();
+
+    await p.fixture(
+      packageJson({
+        name: 'root',
+        esy: {},
+        dependencies: {
+          pkg: '*',
+        },
+        resolutions: {
+          pkg: 'link:./somepath/some.json',
+        },
+      }),
+      dir('somepath', packageJson({name: 'some'})),
+    );
+    const err = await expectAndReturnRejection(p.esy('install --skip-repository-update'));
+    expect(err.stderr.trim()).toEqual(
+      outdent`
+      info install ${version}
+      error: unable to read manifests from some.json
+        reading package metadata from link:somepath/some.json
+        resolving metadata pkg@link:somepath/some.json
       esy: exiting due to errors above
       `,
     );


### PR DESCRIPTION
- Adds commit points to prevent it from backtracking too much
- Better annotations and parse errors
- Better validation for commit sha / checksum

Example while parsing `author/pkg#ref` in resolutions:

```
error: parsing "author/pkg#ref": <author>/<repo>(:<manifest>)?#<commit>: missing or incorrect <commit>
  reading package metadata from link:./package.json
  loading root package metadata
esy: exiting due to errors above
```