### PR TITLE
Fix how we lookup packages in a solution graph

### DIFF
--- a/esy-lib/Graph.ml
+++ b/esy-lib/Graph.ml
@@ -14,7 +14,7 @@ module type GRAPH = sig
   val root : t -> node
   val get : id -> t -> node option
   val getExn : id -> t -> node
-  val find : (id -> node -> bool) -> t -> (id * node) option
+  val findBy : (id -> node -> bool) -> t -> (id * node) option
   val dependencies : ?traverse:traverse -> node -> t -> node list
   val allDependenciesBFS :
     ?traverse:traverse
@@ -130,12 +130,10 @@ module Make (Node : GRAPH_NODE) : GRAPH
 
     List.rev dependencies
 
-  let find f graph =
-    let f id =
-      let node = Node.Id.Map.find id graph.nodes in
-      f id node
-    in
-    Node.Id.Map.find_first_opt f graph.nodes
+  let findBy f graph =
+    let f (id, node) = f id node in
+    let bindings = Node.Id.Map.bindings graph.nodes in
+    List.find_opt ~f bindings
 
   let fold ~f ~init graph =
     let f _id node v =

--- a/esy/BuildSandbox.ml
+++ b/esy/BuildSandbox.ml
@@ -248,8 +248,6 @@ let makeScope
   =
   let open Run.Syntax in
 
-  Logs.debug (fun m -> m "makeScope %a" PackageId.pp id);
-
   let updateSeen seen id =
     match List.find_opt ~f:(fun p -> PackageId.compare p id = 0) seen with
     | Some _ -> errorf "@[<h>found circular dependency on: %a@]" PackageId.pp id
@@ -291,15 +289,6 @@ let makeScope
     let matched =
       DepSpec.eval sandbox.solution pkg.Package.id deps
     in
-    Logs.debug (fun m ->
-      m "depspec %a at %a matches %a"
-        DepSpec.pp
-        deps
-        PackageId.pp
-        pkg.Package.id
-        Fmt.(list ~sep:(unit ", ") PackageId.pp)
-        (PackageId.Set.elements matched)
-    );
 
     let directDependencies =
       (* remove self here so we don't call into itself *)

--- a/esyi/Solution.ml
+++ b/esyi/Solution.ml
@@ -48,28 +48,28 @@ let findByPath p solution =
     match pkg.Package.source with
     | Link {path; manifest = None;} ->
       let path = DistPath.(path / "package.json") in
-      DistPath.compare path p >= 0
+      DistPath.compare path p = 0
     | Link {path; manifest = Some filename;} ->
       let path = DistPath.(path / ManifestSpec.show filename) in
-      DistPath.compare path p >= 0
+      DistPath.compare path p = 0
     | _ -> false
   in
-  let%map _id, pkg = find f solution in
+  let%map _id, pkg = findBy f solution in
   pkg
 
 let findByName name solution =
   let open Option.Syntax in
   let f _id pkg =
-    String.compare pkg.Package.name name >= 0
+    String.compare pkg.Package.name name = 0
   in
-  let%map _id, pkg = find f solution in
+  let%map _id, pkg = findBy f solution in
   pkg
 
 let findByNameVersion name version solution =
   let open Option.Syntax in
   let compare = [%derive.ord: string * Version.t] in
   let f _id pkg =
-    compare (pkg.Package.name, pkg.Package.version) (name, version) >= 0
+    compare (pkg.Package.name, pkg.Package.version) (name, version) = 0
   in
-  let%map _id, pkg = find f solution in
+  let%map _id, pkg = findBy f solution in
   pkg

--- a/test-e2e/common/build-errors.test.js
+++ b/test-e2e/common/build-errors.test.js
@@ -109,7 +109,7 @@ describe('build errors', function() {
 
     await p.esy('install');
 
-    const depBuildPlan = JSON.parse((await p.esy('build-plan dep@0.0.0')).stdout);
+    const depBuildPlan = JSON.parse((await p.esy('build-plan dep@path:dep')).stdout);
 
     const err = await expectAndReturnRejection(p.esy('build'));
     expect(err.stderr).toMatch(

--- a/test-e2e/esy-build-env.test.js
+++ b/test-e2e/esy-build-env.test.js
@@ -174,7 +174,7 @@ describe(`'esy build-env' command`, () => {
 
     await p.esy('install');
 
-    const env = JSON.parse((await p.esy('build-env --json dep@1.0.0')).stdout);
+    const env = JSON.parse((await p.esy('build-env --json dep@path:dep')).stdout);
     expect(env.cur__name).toBe('dep');
   });
 });

--- a/test-e2e/esy-build-plan.test.js
+++ b/test-e2e/esy-build-plan.test.js
@@ -37,7 +37,7 @@ describe('esy build-plan', () => {
     await p.esy('install');
     await p.esy('build');
 
-    const plan = JSON.parse((await p.esy('build-plan dep@1.0.0')).stdout);
+    const plan = JSON.parse((await p.esy('build-plan dep@path:dep')).stdout);
     expect(plan.name).toBe('dep');
   });
 });

--- a/test-e2e/esy-build/optDependencies.test.js
+++ b/test-e2e/esy-build/optDependencies.test.js
@@ -62,18 +62,14 @@ describe('Build with optDependencies', () => {
       {
         const id = JSON.parse((await p.esy('build-plan')).stdout).id;
         const depid = JSON.parse((await p.esy('build-plan dep')).stdout).id;
-        const optdepid = JSON.parse((await p.esy('build-plan optDep')).stdout).id;
         const {stdout} = await p.esy('build-env');
-        expect(
-          p.normalizePathsForSnapshot(stdout, {id, depid, optdepid}),
-        ).toMatchSnapshot();
+        expect(p.normalizePathsForSnapshot(stdout, {id, depid})).toMatchSnapshot();
       }
 
       {
         const id = JSON.parse((await p.esy('build-plan dep')).stdout).id;
-        const optdepid = JSON.parse((await p.esy('build-plan optDep')).stdout).id;
         const {stdout} = await p.esy('build-env dep');
-        expect(p.normalizePathsForSnapshot(stdout, {id, optdepid})).toMatchSnapshot();
+        expect(p.normalizePathsForSnapshot(stdout, {id})).toMatchSnapshot();
       }
     });
   });


### PR DESCRIPTION
We used `Map.S.find_first_opt` previously which is incorrect.