### PR TITLE
Fix `esy CMD` to fail if sandbox isn't installed

### DIFF
--- a/test-e2e/esy-CMD.test.js
+++ b/test-e2e/esy-CMD.test.js
@@ -1,5 +1,6 @@
 // @flow
 
+const outdent = require('outdent');
 const path = require('path');
 const fs = require('fs-extra');
 const os = require('os');
@@ -68,6 +69,15 @@ describe(`'esy CMD' invocation`, () => {
     await expect(p.esy('devDep.cmd')).resolves.toEqual({
       stdout: '__devDep__' + os.EOL,
       stderr: '',
+    });
+  });
+
+  it(`fails if project is not installed`, async () => {
+    const p = await createTestSandbox();
+    await expect(p.esy('dep.cmd')).rejects.toMatchObject({
+      message: expect.stringMatching(
+        'error: project is missing a lock, run `esy install`',
+      ),
     });
   });
 

--- a/test-e2e/esy-CMD.test.js
+++ b/test-e2e/esy-CMD.test.js
@@ -1,6 +1,5 @@
 // @flow
 
-const outdent = require('outdent');
 const path = require('path');
 const fs = require('fs-extra');
 const os = require('os');

--- a/test-e2e/test/helpers.js
+++ b/test-e2e/test/helpers.js
@@ -400,6 +400,7 @@ module.exports = {
   buildCommandInOpam,
   esyVersion: pkgJson.version,
 
+  ESY,
   isWindows,
   isLinux,
   isMacos,


### PR DESCRIPTION
This is a regression in nightlies. Added a test to fix that behaviour.