### PR TITLE
Add 'esy build-dependencies --devDependencies` invocation

### DIFF
--- a/esy/bin/esyCommand.ml
+++ b/esy/bin/esyCommand.ml
@@ -305,7 +305,7 @@ let runBuildDependencies
       plan
       dependencies
 
-let buildDependencies (proj : Project.WithoutWorkflow.t) release all depspec pkgspec () =
+let buildDependencies (proj : Project.WithoutWorkflow.t) release all devDependencies depspec pkgspec () =
   let open RunAsync.Syntax in
   let%bind solved = Project.solved proj in
   let%bind fetched = Project.fetched proj in
@@ -330,7 +330,7 @@ let buildDependencies (proj : Project.WithoutWorkflow.t) release all depspec pkg
     ) in
     runBuildDependencies
       ~buildLinked:all
-      ~buildDevDependencies:false
+      ~buildDevDependencies:devDependencies
       proj
       plan
       pkg
@@ -1941,6 +1941,11 @@ let makeCommands ~sandbox () =
             value
             & flag
             & info ["all"] ~doc:"Build all dependencies (including linked packages)"
+          )
+        $ Arg.(
+            value
+            & flag
+            & info ["devDependencies"] ~doc:"Build devDependencies too"
           )
         $ Arg.(
             value

--- a/test-e2e/esy-build-dependencies.test.js
+++ b/test-e2e/esy-build-dependencies.test.js
@@ -89,13 +89,34 @@ describe(`'esy build-dependencies' command`, () => {
     });
   });
 
-  it(`builds linked dependencies if --all passed`, async () => {
+  it(`doesn't build devDependencies`, async () => {
+    const p = await createTestSandbox();
+    await p.esy('install');
+    await p.esy('build-dependencies');
+    const env = await getCommandEnv(p);
+    await expect(p.run('devDep.cmd', env)).rejects.toMatchObject({
+      code: 127,
+    });
+  });
+
+  it(`builds linked dependencies if --all is passed`, async () => {
     const p = await createTestSandbox();
     await p.esy('install');
     await p.esy('build-dependencies --all');
     const env = await getCommandEnv(p);
     await expect(p.run('linkedDep.cmd', env)).resolves.toEqual({
       stdout: '__linkedDep__' + os.EOL,
+      stderr: '',
+    });
+  });
+
+  it(`builds devDependencies if --devDependencies is passed`, async () => {
+    const p = await createTestSandbox();
+    await p.esy('install');
+    await p.esy('build-dependencies --devDependencies');
+    const env = await getCommandEnv(p);
+    await expect(p.run('devDep.cmd', env)).resolves.toEqual({
+      stdout: '__devDep__' + os.EOL,
       stderr: '',
     });
   });


### PR DESCRIPTION
This allows to build devDependencies with `esy build-dependencies`
command:

```
% esy build-dependencies --devDependencies
```