### PR TITLE
Fix reading override info from esy.lock

### DIFF
--- a/esy-install/File.ml
+++ b/esy-install/File.ml
@@ -1,7 +1,10 @@
 type t = {
-  name : string;
   root : Path.t;
+  name : string;
 }
+
+let pp fmt file =
+  Fmt.pf fmt "%a/%s" Path.pp file.root file.name
 
 let digest file =
   let path = Path.(file.root / file.name) in

--- a/esy-install/File.mli
+++ b/esy-install/File.mli
@@ -1,5 +1,6 @@
 type t
 
+val pp : t Fmt.t
 val digest : t -> Digestv.t RunAsync.t
 
 val ofDir : Path.t -> t list RunAsync.t

--- a/esy-install/SolutionLock.ml
+++ b/esy-install/SolutionLock.ml
@@ -110,8 +110,8 @@ let readOverride sandbox override =
   match override with
   | OfJson {json;} -> return (Override.OfJson {json;})
   | OfOpamOverride {path;} ->
-    let path = DistPath.toPath sandbox.Sandbox.spec.path DistPath.(path / "package.json") in
-    let%bind json = Fs.readJsonFile path in
+    let path = DistPath.toPath sandbox.Sandbox.spec.path path in
+    let%bind json = Fs.readJsonFile Path.(path / "package.json") in
     return (Override.OfOpamOverride {json; path;})
   | OfPath local ->
     let filename =

--- a/test-e2e/esy-build/opam-dependencies.test.js
+++ b/test-e2e/esy-build/opam-dependencies.test.js
@@ -3,8 +3,6 @@
 const outdent = require('outdent');
 const helpers = require('../test/helpers.js');
 
-helpers.skipSuiteOnWindows();
-
 describe('building @opam/* dependencies', () => {
   it('builds opam dependencies with patches', async () => {
     const p = await helpers.createTestSandbox();

--- a/test-e2e/esy-build/opam-dependencies.test.js
+++ b/test-e2e/esy-build/opam-dependencies.test.js
@@ -1,7 +1,9 @@
 // @flow
 
+const path = require('path');
 const outdent = require('outdent');
 const helpers = require('../test/helpers.js');
+const FixtureUtils = require('../test/FixtureUtils.js');
 
 describe('building @opam/* dependencies', () => {
   it('builds opam dependencies with patches', async () => {
@@ -54,6 +56,74 @@ describe('building @opam/* dependencies', () => {
         ),
       ],
     );
+
+    await p.esy('install');
+    await p.esy('build');
+
+    {
+      const {stdout} = await p.esy('x hello.cmd');
+      expect(stdout.trim()).toEqual('__hello-patched__');
+    }
+  });
+
+  it('builds opam dependencies with patches (from overrides)', async () => {
+    const p = await helpers.createTestSandbox();
+
+    await p.fixture(
+      helpers.packageJson({
+        name: 'root',
+        esy: {},
+        dependencies: {
+          '@opam/pkg': '*',
+        },
+      }),
+    );
+
+    await p.defineNpmPackage({
+      name: '@esy-ocaml/substs',
+      version: '0.0.0',
+      esy: {},
+    });
+
+    await p.defineOpamPackageOfFixture(
+      {
+        name: 'pkg',
+        version: '1.0.0',
+        opam: outdent`
+          opam-version: "2.0"
+          patches: [
+            "some.patch"
+          ]
+          build: [
+            ${helpers.buildCommandInOpam('hello.js')}
+            ["cp" "hello.cmd" "%{bin}%/hello.cmd"]
+            ["cp" "hello.js" "%{bin}%/hello.js"]
+          ]
+        `,
+      },
+      [helpers.dummyExecutable('hello')],
+    );
+
+    await FixtureUtils.initialize(path.join(p.opamRegistry.overridePath, 'packages'), [
+      helpers.dir(
+        'pkg',
+        helpers.packageJson({}),
+        helpers.dir(
+          'files',
+          helpers.file(
+            'some.patch',
+            outdent`
+            --- a/hello.js
+            +++ b/hello.js
+            @@ -1 +1 @@
+            -console.log("__" + "hello" + "__");
+            +console.log("__" + "hello-patched" + "__");
+
+          `,
+          ),
+        ),
+      ),
+    ]);
 
     await p.esy('install');
     await p.esy('build');

--- a/test-e2e/test/helpers.js
+++ b/test-e2e/test/helpers.js
@@ -45,6 +45,7 @@ function dummyExecutable(name: string) {
     `${name}.js`,
     outdent`
       console.log("__" + ${JSON.stringify(name)} + "__");
+
     `,
   );
 }

--- a/test-e2e/test/helpers.js
+++ b/test-e2e/test/helpers.js
@@ -4,6 +4,7 @@ jest.setTimeout(120000);
 
 import type {Fixture} from './FixtureUtils.js';
 import type {PackageRegistry} from './NpmRegistryMock.js';
+import type {OpamRegistry} from './OpamRegistryMock.js.js';
 const path = require('path');
 const fs = require('fs-extra');
 const fsUtils = require('./fs.js');
@@ -58,6 +59,7 @@ export type TestSandbox = {
   esyStorePath: string,
   npmPrefixPath: string,
   npmRegistry: PackageRegistry,
+  opamRegistry: OpamRegistry,
 
   fixture: (...fixture: Fixture) => Promise<void>,
 
@@ -271,6 +273,7 @@ async function createTestSandbox(...fixture: Fixture): Promise<TestSandbox> {
     printEsy,
     npm,
     npmRegistry,
+    opamRegistry,
     normalizePathsForSnapshot,
     fixture: async (...fixture) => {
       await FixtureUtils.initialize(projectPath, fixture);


### PR DESCRIPTION
Fixes #743.

We incorrectly read path info from esy.lock for opam overrides and thus didn't
place files from overrides into packages' source locations.

This fixes that and also adds a missing test case which checks that patches from
overrides are handled correctly.