### PR TITLE
Use sandbox-local tmpdir for fetching dists

### DIFF
--- a/esy-install/DistStorage.ml
+++ b/esy-install/DistStorage.ml
@@ -24,27 +24,27 @@ let cache fetched tarballPath =
   let open RunAsync.Syntax in
   match fetched with
   | Empty ->
-    let unpackPath = Path.(tarballPath |> addExt ".unpack") in
-    let tempTarballPath = Path.(tarballPath |> addExt ".stage") in
+    let%bind unpackPath = Fs.randomPathVariation tarballPath in
+    let%bind tempTarballPath = Fs.randomPathVariation tarballPath in
     let%bind () = Fs.createDir unpackPath in
     let%bind () = Tarball.create ~filename:tempTarballPath unpackPath in
     let%bind () = Fs.rename ~src:tempTarballPath tarballPath in
     let%bind () = Fs.rmPath unpackPath in
     return (Tarball {tarballPath; stripComponents = 0;})
   | SourcePath path ->
-    let tempTarballPath = Path.(tarballPath |> addExt ".stage") in
+    let%bind tempTarballPath = Fs.randomPathVariation tarballPath in
     let%bind () = Tarball.create ~filename:tempTarballPath path in
     let%bind () = Fs.rename ~src:tempTarballPath tarballPath in
     return (Tarball {tarballPath; stripComponents = 0;})
   | Path path ->
-    let tempTarballPath = Path.(tarballPath |> addExt ".stage") in
+    let%bind tempTarballPath = Fs.randomPathVariation tarballPath in
     let%bind () = Tarball.create ~filename:tempTarballPath path in
     let%bind () = Fs.rename ~src:tempTarballPath tarballPath in
     let%bind () = Fs.rmPath path in
     return (Tarball {tarballPath; stripComponents = 0;})
   | Tarball info ->
-    let tempTarballPath = Path.(tarballPath |> addExt ".stage") in
-    let unpackPath = Path.(info.tarballPath |> addExt ".unpack") in
+    let%bind tempTarballPath = Fs.randomPathVariation tarballPath in
+    let%bind unpackPath = Fs.randomPathVariation info.tarballPath in
     let%bind () = Tarball.unpack ~stripComponents:1 ~dst:unpackPath info.tarballPath in
     let%bind () = Tarball.create ~filename:tempTarballPath unpackPath in
     let%bind () = Fs.rename ~src:tempTarballPath tarballPath in

--- a/esy-install/DistStorage.ml
+++ b/esy-install/DistStorage.ml
@@ -57,6 +57,7 @@ let ofDir path = SourcePath path
 
 let fetch' sandbox dist =
   let open RunAsync.Syntax in
+  let tempPath = SandboxSpec.tempPath sandbox in
   match dist with
 
   | Dist.LocalPath { path = srcPath; manifest = _; } ->
@@ -68,7 +69,7 @@ let fetch' sandbox dist =
 
   | Dist.Archive {url; checksum}  ->
     let path = CachePaths.fetchedDist sandbox dist in
-    Fs.withTempDir (fun stagePath ->
+    Fs.withTempDir ~tempPath (fun stagePath ->
       let%bind () = Fs.createDir stagePath in
       let tarballPath = Path.(stagePath / "archive") in
       let%bind () = Curl.download ~output:tarballPath url in
@@ -81,7 +82,7 @@ let fetch' sandbox dist =
   | Dist.Github github ->
     let path = CachePaths.fetchedDist sandbox dist in
     let%bind () = Fs.createDir (Path.parent path) in
-    Fs.withTempDir (fun stagePath ->
+    Fs.withTempDir ~tempPath (fun stagePath ->
       let%bind () = Fs.createDir stagePath in
       let tarballPath = Path.(stagePath / "archive.tgz") in
       let url =
@@ -97,7 +98,7 @@ let fetch' sandbox dist =
   | Dist.Git git ->
     let path = CachePaths.fetchedDist sandbox dist in
     let%bind () = Fs.createDir (Path.parent path) in
-    Fs.withTempDir (fun stagePath ->
+    Fs.withTempDir ~tempPath (fun stagePath ->
       let%bind () = Fs.createDir stagePath in
       let%bind () = Git.clone ~dst:stagePath ~remote:git.remote () in
       let%bind () = Git.checkout ~ref:git.commit ~repo:stagePath () in

--- a/esy-install/SandboxSpec.ml
+++ b/esy-install/SandboxSpec.ml
@@ -42,6 +42,7 @@ let storePath spec = Path.(localPrefixPath spec / "store")
 let buildPath spec = Path.(localPrefixPath spec / "build")
 let binPath spec = Path.(localPrefixPath spec / "bin")
 let distPath spec = Path.(localPrefixPath spec / "dist")
+let tempPath spec = Path.(localPrefixPath spec / "tmp")
 
 let solutionLockPath spec =
   match spec.manifest with

--- a/esy-install/SandboxSpec.mli
+++ b/esy-install/SandboxSpec.mli
@@ -14,6 +14,7 @@ val isDefault : t -> bool
 val projectName : t -> string
 
 val distPath : t -> Path.t
+val tempPath : t -> Path.t
 val cachePath : t -> Path.t
 val storePath : t -> Path.t
 val buildPath : t -> Path.t

--- a/esy-lib/Fs.ml
+++ b/esy-lib/Fs.ml
@@ -321,11 +321,10 @@ let withTempDir ?tempPath f =
   Lwt.finalize
     (fun () -> f path)
     (fun () ->
-      Lwt.return ()
       (* never fail on removing a temp folder. *)
-      (* match%lwt rmPath path with *)
-      (* | Ok () -> Lwt.return () *)
-      (* | Error _ -> Lwt.return () *)
+      match%lwt rmPath path with
+      | Ok () -> Lwt.return ()
+      | Error _ -> Lwt.return ()
     )
 
 let withTempFile ~data f =

--- a/esy-lib/Fs.ml
+++ b/esy-lib/Fs.ml
@@ -310,19 +310,23 @@ let randPath dir pat =
   let rand = Random.State.bits (Lazy.force randGen) land 0xFFFFFF in
   Fpath.(dir / Astring.strf pat (Astring.strf "%06x" rand))
 
-let withTempDir ?tempDir f =
-  let tempDir = match tempDir with
-  | Some tempDir -> tempDir
-  | None -> Filename.get_temp_dir_name ()
+let withTempDir ?tempPath f =
+  let open RunAsync.Syntax in
+  let tempPath = match tempPath with
+    | Some tempPath -> tempPath
+    | None -> Path.v (Filename.get_temp_dir_name ())
   in
-  let path = randPath (Path.v tempDir) "esy-%s" in
-  let%lwt () = Lwt_unix.mkdir (Path.show path) 0o700 in
+  let path = randPath tempPath "esy-%s" in
+  let%bind () = createDir path in
   Lwt.finalize
     (fun () -> f path)
-    (fun () -> 
-       (* never fail on removing a temp folder. *)
-       try%lwt rmPathLwt path
-       with Unix.Unix_error _ -> Lwt.return ())
+    (fun () ->
+      Lwt.return ()
+      (* never fail on removing a temp folder. *)
+      (* match%lwt rmPath path with *)
+      (* | Ok () -> Lwt.return () *)
+      (* | Error _ -> Lwt.return () *)
+    )
 
 let withTempFile ~data f =
   let path = Filename.temp_file "esy" "tmp" in

--- a/esy-lib/Fs.ml
+++ b/esy-lib/Fs.ml
@@ -310,6 +310,21 @@ let randPath dir pat =
   let rand = Random.State.bits (Lazy.force randGen) land 0xFFFFFF in
   Fpath.(dir / Astring.strf pat (Astring.strf "%06x" rand))
 
+let randomPathVariation path =
+  let open RunAsync.Syntax in
+  let rec make retry =
+    let rand = Random.State.bits (Lazy.force randGen) land 0xFFFFFF in
+    let ext = (Astring.strf ".%06x" rand) in
+    let rpath = Path.(path |> addExt ext) in
+    if%bind exists rpath
+    then
+      if retry <= 0
+      then errorf "unable to generate a random path for %a" Path.pp path
+      else make (retry - 1)
+    else return rpath
+  in
+  make 3
+
 let withTempDir ?tempPath f =
   let open RunAsync.Syntax in
   let tempPath = match tempPath with

--- a/esy-lib/Fs.mli
+++ b/esy-lib/Fs.mli
@@ -59,5 +59,5 @@ val copyPath : src:Path.t -> dst:Path.t -> unit RunAsync.t
 val rmPath : Path.t -> unit RunAsync.t
 val rmPathLwt : Path.t -> unit Lwt.t
 
-val withTempDir : ?tempDir:string -> (Path.t -> 'a Lwt.t) -> 'a Lwt.t
+val withTempDir : ?tempPath:Path.t -> (Path.t -> 'a RunAsync.t) -> 'a RunAsync.t
 val withTempFile : data:string -> (Path.t -> 'a Lwt.t) -> 'a Lwt.t

--- a/esy-lib/Fs.mli
+++ b/esy-lib/Fs.mli
@@ -61,3 +61,5 @@ val rmPathLwt : Path.t -> unit Lwt.t
 
 val withTempDir : ?tempPath:Path.t -> (Path.t -> 'a RunAsync.t) -> 'a RunAsync.t
 val withTempFile : data:string -> (Path.t -> 'a Lwt.t) -> 'a Lwt.t
+
+val randomPathVariation : Fpath.t -> Fpath.t RunAsync.t

--- a/esy-lib/Json.ml
+++ b/esy-lib/Json.ml
@@ -22,8 +22,10 @@ let parseJsonWith parser json =
   Run.ofStringError (parser json)
 
 let parseStringWith parser data =
-  let json = Yojson.Safe.from_string data in
-  parseJsonWith parser json
+  try
+    let json = Yojson.Safe.from_string data in
+    parseJsonWith parser json
+  with Yojson.Json_error msg -> Run.errorf "error parsing JSON: %s" msg
 
 let mergeAssoc items update =
   let toMap items =

--- a/test/Checksum.ml
+++ b/test/Checksum.ml
@@ -1,22 +1,22 @@
 module Fs = EsyLib.Fs
 module Path = EsyLib.Path
+module RunAsync = EsyLib.RunAsync
 
 let%test "checksum validates a simple file: md5" =
-    let test () = 
+    let test () =
         let f tempPath =
+            let open RunAsync.Syntax in
             let path = Path.(tempPath / "checksum-test.txt") in
             let data = "test checksum file" in
-            let%lwt _ = Fs.writeFile ~data path in
+            let%bind () = Fs.writeFile ~data path in
 
             let expectedChecksum = EsyLib.Checksum.parse "md5:97d37ce810cfcff2665f45e9da4449b7" in
             match expectedChecksum with
-            | Error _ -> Lwt.return false
-            | Ok v -> 
-                let%lwt actualChecksum = EsyLib.Checksum.checkFile ~path v in
-                match actualChecksum with
-                | Ok _ -> Lwt.return true
-                | _ -> Lwt.return false
+            | Error _ -> return false
+            | Ok v ->
+                let%bind _actualChecksum = EsyLib.Checksum.checkFile ~path v in
+                return true
         in
         Fs.withTempDir f
     in
-    TestLwt.runLwtTest test
+    TestHarness.runRunAsyncTest test

--- a/test/Curl.ml
+++ b/test/Curl.ml
@@ -7,12 +7,13 @@ module RunAsync = EsyLib.RunAsync
 module Result = EsyLib.Result
 
 let%test "curl download simple file" =
-    let test () = 
+    let test () =
         let f tempPath =
+            let open RunAsync.Syntax in
             let fileToCurl = Path.(tempPath / "input.txt") in
             let data = "test" in
-            let%lwt _ = Fs.createDir tempPath in
-            let%lwt _ = Fs.writeFile ~data fileToCurl in
+            let%bind () = Fs.createDir tempPath in
+            let%bind () = Fs.writeFile ~data fileToCurl in
 
             (* use curl to copy the file, as opposed to hitting an external server *)
             let output = Path.(tempPath / "output.txt") in
@@ -20,44 +21,43 @@ let%test "curl download simple file" =
             (* We need to normalize the path on Windows - file:///E:/.../ won't work! *)
             (* The normalize gives us a path of the form file:///cygdrive/e/.../ which does. *)
             (* This won't impact HTTP requests though - just our test using the local file system *)
-            let url = EsyBash.normalizePathForCygwin (Path.show(fileToCurl)) in
+            let url = EsyBash.normalizePathForCygwin (Path.show fileToCurl) in
 
-            let%lwt _: unit EsyLib.Run.t = EsyLib.Curl.download ~output ("file://" ^ url) in
+            let%bind () = EsyLib.Curl.download ~output ("file://" ^ url) in
 
-            (* validate we were able to download it *) 
-            let%lwt result = Fs.exists (output) in
-            match result with
-            | Ok true -> Lwt.return true
-            | _ -> Lwt.return false
+            (* validate we were able to download it *)
+            Fs.exists output
         in
         Fs.withTempDir f
     in
-    TestLwt.runLwtTest test
+    TestHarness.runRunAsyncTest test
 
 let%test "curl gives error when failing to download" =
-    let test () = 
+    let test () =
         let f tempPath =
+            let open RunAsync.Syntax in
             let output = Path.(tempPath / "output.txt") in
             let url = "file:///some/nonexistent/file" in
             let%lwt result = EsyLib.Curl.download ~output url in
             match result with
-            | Error _ -> Lwt.return true
-            | _ -> Lwt.return false
+            | Error _ -> return true
+            | _ -> return false
         in
         Fs.withTempDir f
     in
-    TestLwt.runLwtTest test
+    TestHarness.runRunAsyncTest test
 
 let%test "curl gives error when failing to download from localhost" =
     let test () =
         let f tempPath =
+            let open RunAsync.Syntax in
             let output = Path.(tempPath / "output.txt") in
             let url = "http://localhost:5251/b/-/b-0-4-5-1.tgz" in
             let%lwt result = EsyLib.Curl.download ~output url in
             match result with
-            | Error _ -> Lwt.return true
-            | _ -> Lwt.return false
+            | Error _ -> return true
+            | _ -> return false
         in
         Fs.withTempDir f
     in
-    TestLwt.runLwtTest test
+    TestHarness.runRunAsyncTest test

--- a/test/EsyBashLwt.ml
+++ b/test/EsyBashLwt.ml
@@ -6,7 +6,7 @@ module EsyBashLwt = EsyLib.EsyBashLwt
 module RunAsync = EsyLib.RunAsync
 
 let%test "execute a simple bash command (cross-platform)" =
-    let t () = 
+    let t () =
         let f p =
             let%lwt stdout =
               Lwt.finalize
@@ -20,9 +20,6 @@ let%test "execute a simple bash command (cross-platform)" =
             % "-c"
             % "echo hello-world"
         ) in
-        let%lwt result = EsyBashLwt.with_process_full cmd f in
-        match result with
-        | Ok true -> Lwt.return  true
-        | _ -> Lwt.return false
+        EsyBashLwt.with_process_full cmd f
     in
-    TestLwt.runLwtTest t
+    TestHarness.runRunAsyncTest t

--- a/test/Fs.ml
+++ b/test/Fs.ml
@@ -1,5 +1,6 @@
 include EsyLib.Curl
 
+module RunAsync = EsyLib.RunAsync
 module Fs = EsyLib.Fs
 module Path = EsyLib.Path
 module System = EsyLib.System
@@ -7,62 +8,57 @@ module System = EsyLib.System
 let%test "copyPathLwt - copy simple file" =
     let test () =
         let f tempPath =
+            let open RunAsync.Syntax in
             let src = Path.(tempPath / "src.txt") in
             let dst = Path.(tempPath / "dst.txt") in
             let data = "test" in
-            let%lwt _ = Fs.createDir tempPath in
-            let%lwt _ = Fs.writeFile ~data src in
+            let%bind () = Fs.createDir tempPath in
+            let%bind () = Fs.writeFile ~data src in
 
-            let%lwt _ = Fs.copyPath ~src ~dst in
+            let%bind () = Fs.copyPath ~src ~dst in
 
-            let%lwt exists = Fs.exists dst in
-            match exists with
-            | Ok v -> Lwt.return v
-            | _ -> Lwt.return false
+            Fs.exists dst
         in
         Fs.withTempDir f
     in
-    TestLwt.runLwtTest test
+    TestHarness.runRunAsyncTest test
 
 let%test "copyPathLwt - copy nested file" =
     let test () =
         let f tempPath =
+            let open RunAsync.Syntax in
             let nestedSrc = Path.(tempPath / "src_root" / "nested1") in
             let nestedDest = Path.(tempPath / "dest_root" / "nested2") in
             let src = Path.(nestedSrc / "src.txt") in
             let dst = Path.(nestedDest / "dst.txt") in
             let data = "test" in
-            let%lwt _ = Fs.createDir nestedSrc in
-            let%lwt _ = Fs.writeFile ~data src in
+            let%bind () = Fs.createDir nestedSrc in
+            let%bind () = Fs.writeFile ~data src in
 
-            let%lwt _ = Fs.copyPath ~src ~dst in
+            let%bind () = Fs.copyPath ~src ~dst in
 
-            let%lwt exists = Fs.exists dst in
-            match exists with
-            | Ok v -> Lwt.return v
-            | _ -> Lwt.return false
+            Fs.exists dst
         in
         Fs.withTempDir f
     in
-    TestLwt.runLwtTest test
+    TestHarness.runRunAsyncTest test
 
 let%test "rmPathLwt - delete read only file" =
     let test () =
         let f tempPath =
+            let open RunAsync.Syntax in
             let src = Path.(tempPath / "test.txt") in
             let data = "test" in
-            let%lwt _ = Fs.writeFile ~data src in
+            let%bind () = Fs.writeFile ~data src in
 
             (* Set file as read only, and verify we can still delete it *)
             (* Tested on Windows, this sets the read-only flag there too *)
-            let _ = Unix.chmod (Path.show src) 0o444 in
+            let () = Unix.chmod (Path.show src) 0o444 in
 
-            let%lwt _ = Fs.rmPath src in
-            let%lwt exists = Fs.exists src in
-            match exists with
-            | Ok v -> Lwt.return (v == false)
-            | _ -> Lwt.return false
+            let%bind () = Fs.rmPath src in
+            let%bind exists = Fs.exists src in
+            return (not exists)
         in
         Fs.withTempDir f
     in
-    TestLwt.runLwtTest test
+    TestHarness.runRunAsyncTest test

--- a/test/Tarball.ml
+++ b/test/Tarball.ml
@@ -5,70 +5,69 @@ module RunAsync = EsyLib.RunAsync
 module Result = EsyLib.Result
 
 let%test "creates and unpacks a tarball" =
-    let test () = 
+    let test () =
         let f tempPath =
+            let open RunAsync.Syntax in
             let folderToCreate = Path.(tempPath / "test-folder") in
-            let%lwt _ = Fs.createDir folderToCreate in
+            let%bind () = Fs.createDir folderToCreate in
             let fileToCreate = Path.(folderToCreate / "test-file.txt") in
             let data = "test data" in
-            let%lwt _ = Fs.writeFile ~data fileToCreate in
+            let%bind () = Fs.writeFile ~data fileToCreate in
 
             (* package up the file into a tarball *)
             let filename = Path.(tempPath / "output.tar.gz") in
-            let%lwt _ = EsyLib.Tarball.create ~filename folderToCreate in
+            let%bind () = EsyLib.Tarball.create ~filename folderToCreate in
 
             (* unpack the tarball *)
             let dst = Path.(tempPath / "extract-folder") in
-            let%lwt _ = Fs.createDir dst in 
-            let%lwt _ = EsyLib.Tarball.unpack ~dst filename in
+            let%bind () = Fs.createDir dst in
+            let%bind () = EsyLib.Tarball.unpack ~dst filename in
 
             let expectedOutputFile = Path.(dst / "test-file.txt") in
-            let%lwt result = Fs.readFile expectedOutputFile in
-            match result with 
-            | Ok v -> Lwt.return (v = data)
-            | _ -> Lwt.return false
+            let%bind result = Fs.readFile expectedOutputFile in
+            return (result = data)
         in
         Fs.withTempDir f
     in
-    TestLwt.runLwtTest test
+    TestHarness.runRunAsyncTest test
 
 let%test "unpack tarball with stripcomponents" =
-    let test () = 
+    let test () =
         let f tempPath =
+            let open RunAsync.Syntax in
             let folderToCreate = Path.(tempPath / "test-folder" / "nested-folder-1" / "nested-folder-2") in
-            let%lwt _ = Fs.createDir folderToCreate in
+            let%bind () = Fs.createDir folderToCreate in
             let fileToCreate = Path.(folderToCreate / "test-file.txt") in
             let data = "test data" in
-            let%lwt _ = Fs.writeFile ~data fileToCreate in
+            let%bind () = Fs.writeFile ~data fileToCreate in
 
             (* package up the file into a tarball *)
             let folderToPackage = Path.(tempPath / "test-folder") in
             let filename = Path.(tempPath / "output.tar.gz") in
-            let%lwt _ = EsyLib.Tarball.create ~filename folderToPackage in
+            let%bind () = EsyLib.Tarball.create ~filename folderToPackage in
 
             (* unpack the tarball *)
             let dst = Path.(tempPath / "extract-folder") in
-            let%lwt _ = Fs.createDir dst in 
+            let%bind () = Fs.createDir dst in
             let stripComponents = 2 in
-            let%lwt _ = EsyLib.Tarball.unpack ~stripComponents ~dst filename in
+            let%bind () = EsyLib.Tarball.unpack ~stripComponents ~dst filename in
 
             let expectedOutputFile = Path.(dst / "test-file.txt") in
-            let%lwt result = Fs.readFile expectedOutputFile in
-            match result with 
-            | Ok v -> Lwt.return (v = data)
-            | _ -> Lwt.return false
+            let%bind result = Fs.readFile expectedOutputFile in
+            return (result = data)
         in
         Fs.withTempDir f
     in
-    TestLwt.runLwtTest test
+    TestHarness.runRunAsyncTest test
 
-let%test "returns error if operation was not successfully" = 
+let%test "returns error if operation was not successfully" =
     let test () =
+        let open RunAsync.Syntax in
         let dst = Path.(v "non-existent-path") in
         let fileName = Path.(v "non-existent-file.tgz") in
         let%lwt result = EsyLib.Tarball.unpack ~dst fileName in
         match result with
-        | Ok _ -> Lwt.return false
-        | _ -> Lwt.return true
+        | Ok _ -> return false
+        | Error _ -> return true
     in
-    TestLwt.runLwtTest test
+    TestHarness.runRunAsyncTest test

--- a/test/TestHarness.ml
+++ b/test/TestHarness.ml
@@ -1,0 +1,10 @@
+let runRunAsyncTest f =
+    let p =
+        let%lwt ret = f () in
+        Lwt.return ret
+    in
+    match Lwt_main.run p with
+    | Ok v -> v
+    | Error err ->
+      Format.eprintf "ERROR: %a@." EsyLib.Run.ppError err;
+      false

--- a/test/TestLwt.ml
+++ b/test/TestLwt.ml
@@ -1,7 +1,0 @@
-(* Helper to run a test that needs Lwt promises *)
-let runLwtTest f = 
-    let p: bool Lwt.t =
-        let%lwt ret = f () in
-        Lwt.return ret
-    in
-    Lwt_main.run p


### PR DESCRIPTION
This fixes `esy install` when `/tmp` is mounted onto different volume.

Fixes #707
Fixes #620