### PR TITLE
Fixes for 'esy npm-release' command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## NEXT
+
+- Cleanup linked packages built by `esy npm-release` from global store.
+
 ## 0.4.6 @ latest
 
 - Fix cache keys for fetched package distributions. They were not respecting

--- a/esy/bin/NpmReleaseCommand.ml
+++ b/esy/bin/NpmReleaseCommand.ml
@@ -240,9 +240,11 @@ let makeBinWrapper ~destPrefix ~bin ~(environment : Environment.Bindings.t) =
       resolve_path Sys.executable_name
     ;;
 
+    (** this expands not rewritten store prefix _______ into a local release path *)
     let expandFallback storePrefix =
+      let dummyPrefix = String.make (String.length storePrefix) '_' in
       let dirname = Filename.dirname this_executable in
-      let pattern = Str.regexp storePrefix in
+      let pattern = Str.regexp dummyPrefix in
       let storePrefix =
         let (/) = Filename.concat in
         normalize (dirname / ".." / "3")

--- a/esy/bin/NpmReleaseCommand.ml
+++ b/esy/bin/NpmReleaseCommand.ml
@@ -583,8 +583,7 @@ let run (proj : Project.WithWorkflow.t) () =
     return outputPath
   in
 
-  let%bind () =
-
+  let%bind ocamlopt =
     let%bind () =
       Project.buildDependencies
         ~buildLinked:true
@@ -593,16 +592,6 @@ let run (proj : Project.WithWorkflow.t) () =
         configured.Project.WithWorkflow.plan
         configured.Project.WithWorkflow.root.pkg
     in
-    Project.buildPackage
-      ~quiet:true
-      ~buildOnly:false
-      proj.projcfg
-      fetched.Project.sandbox
-      configured.Project.WithWorkflow.plan
-      configured.Project.WithWorkflow.root.pkg
-  in
-
-  let%bind ocamlopt =
     let%bind p = Project.WithWorkflow.ocaml proj in
     return Path.(p / "bin" / "ocamlopt")
   in


### PR DESCRIPTION
- Clean up built linked packages from global store after the release.
- Fix `rewritePrefix: true` mode.