### PR TITLE
Filter out environment according to envspec

### DIFF
--- a/esy/DepSpec.ml
+++ b/esy/DepSpec.ml
@@ -36,3 +36,15 @@ let eval solution self depspec =
     | Union (a, b) -> PackageId.Set.union (eval' a) (eval' b)
   in
   eval' depspec
+
+let rec collect' solution depspec seen id =
+  if PackageId.Set.mem id seen
+  then seen
+  else
+    let f nextid seen = collect' solution depspec seen nextid in
+    let seen = PackageId.Set.add id seen in
+    let seen = PackageId.Set.fold f (eval solution id depspec) seen in
+    seen
+
+let collect solution depspec root =
+  collect' solution depspec PackageId.Set.empty root

--- a/esy/DepSpec.mli
+++ b/esy/DepSpec.mli
@@ -20,7 +20,16 @@ val (+) : t -> t -> t
 (** [a + b] refers to all packages in [a] and in [b]. *)
 
 val eval : EsyInstall.Solution.t -> EsyInstall.PackageId.t -> t -> EsyInstall.PackageId.Set.t
-(** Eval depspec given the [Solution.t] and the current package [PackageId.t]. *)
+(**
+ * [eval solution self depspec] evals [depspec] given the [solution] and the
+ * current package id [self].
+ *)
+
+val collect : EsyInstall.Solution.t -> t -> EsyInstall.PackageId.t -> EsyInstall.PackageId.Set.t
+(**
+ * [collect solution depspec id] collects all package ids found in the
+ * [solution] starting with [id] using [depspec] expression for traverse.
+ *)
 
 val compare : t -> t -> int
 val pp : t Fmt.t

--- a/esy/Scope.ml
+++ b/esy/Scope.ml
@@ -423,16 +423,15 @@ let render ?env ?environmentVariableName ~buildIsInProgress scope expr =
   ) in
   return (SandboxValue.v v)
 
-let makeEnvBindings ~buildIsInProgress bindings scope =
+let makeEnvBindings ~buildIsInProgress ?origin bindings scope =
   let open Run.Syntax in
-  let origin = EsyInstall.PackageId.show scope.pkg.id in
   let f (name, value) =
     let%bind value =
       Run.contextf
         (render ~buildIsInProgress ~environmentVariableName:name scope value)
         "processing exportedEnv $%s" name
     in
-    return (SandboxEnvironment.Bindings.value ~origin name value)
+    return (SandboxEnvironment.Bindings.value ?origin name value)
   in
   Result.List.map ~f bindings
 
@@ -445,13 +444,15 @@ let buildEnv ~buildIsInProgress scope =
 let exportedEnvGlobal scope =
   let open Run.Syntax in
   let bindings = PackageScope.exportedEnvGlobal scope.self in
-  let%bind env = makeEnvBindings ~buildIsInProgress:false bindings scope in
+  let origin = EsyInstall.PackageId.show scope.pkg.id in
+  let%bind env = makeEnvBindings ~buildIsInProgress:false ~origin bindings scope in
   return env
 
 let exportedEnvLocal scope =
   let open Run.Syntax in
   let bindings = PackageScope.exportedEnvLocal scope.self in
-  let%bind env = makeEnvBindings ~buildIsInProgress:false bindings scope in
+  let origin = EsyInstall.PackageId.show scope.pkg.id in
+  let%bind env = makeEnvBindings ~buildIsInProgress:false ~origin bindings scope in
   return env
 
 let env ~includeBuildEnv ~buildIsInProgress scope =

--- a/test-e2e/esy-build/__snapshots__/no-deps.test.js.snap
+++ b/test-e2e/esy-build/__snapshots__/no-deps.test.js.snap
@@ -12,7 +12,7 @@ exports[`'esy build': simple executable with no deps out of source build macos |
 
 
 #
-# no-deps@link:./package.json
+# Built-in
 #
 export OCAMLFIND_LDCONF=\\"ignore\\"
 export OCAMLFIND_DESTDIR=\\"%projectPath%/_esy/default/store/i/%id%/lib\\"
@@ -33,10 +33,6 @@ export cur__dev=\\"true\\"
 export cur__version=\\"1.0.0\\"
 export cur__name=\\"no-deps\\"
 export DUNE_BUILD_DIR=\\"%projectPath%/_esy/default/store/b/%id%\\"
-
-#
-# Built-in
-#
 export SHELL=\\"env -i /bin/bash --norc --noprofile\\"
 export PATH=\\"$PATH:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\""
 `;

--- a/test-e2e/esy-build/__snapshots__/optDependencies.test.js.snap
+++ b/test-e2e/esy-build/__snapshots__/optDependencies.test.js.snap
@@ -28,7 +28,7 @@ export MAN_PATH=\\"%esyStorePath%/i/%depid%/man:$MAN_PATH\\"
 export PATH=\\"%esyStorePath%/i/%depid%/bin:$PATH\\"
 
 #
-# root@link:./package.json
+# Built-in
 #
 export OCAMLFIND_LDCONF=\\"ignore\\"
 export OCAMLFIND_DESTDIR=\\"%projectPath%/_esy/default/store/i/%id%/lib\\"
@@ -49,10 +49,6 @@ export cur__dev=\\"true\\"
 export cur__version=\\"1.0.0\\"
 export cur__name=\\"root\\"
 export DUNE_BUILD_DIR=\\"%projectPath%/_esy/default/store/b/%id%\\"
-
-#
-# Built-in
-#
 export SHELL=\\"env -i /bin/bash --norc --noprofile\\"
 export PATH=\\"$PATH:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\""
 `;
@@ -77,7 +73,7 @@ export MAN_PATH=\\"%esyStorePath%/i/%optdepid%/man:$MAN_PATH\\"
 export PATH=\\"%esyStorePath%/i/%optdepid%/bin:$PATH\\"
 
 #
-# dep@path:dep@d41d8cd9
+# Built-in
 #
 export OCAMLFIND_LDCONF=\\"ignore\\"
 export OCAMLFIND_DESTDIR=\\"%esyStorePath%/s/%id%/lib\\"
@@ -98,10 +94,6 @@ export cur__dev=\\"false\\"
 export cur__version=\\"1.0.0\\"
 export cur__name=\\"dep\\"
 export DUNE_BUILD_DIR=\\"%esyStorePath%/b/%id%\\"
-
-#
-# Built-in
-#
 export SHELL=\\"env -i /bin/bash --norc --noprofile\\"
 export PATH=\\"$PATH:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\""
 `;
@@ -126,7 +118,7 @@ export MAN_PATH=\\"%esyStorePath%/i/%depid%/man:$MAN_PATH\\"
 export PATH=\\"%esyStorePath%/i/%depid%/bin:$PATH\\"
 
 #
-# root@link:./package.json
+# Built-in
 #
 export OCAMLFIND_LDCONF=\\"ignore\\"
 export OCAMLFIND_DESTDIR=\\"%projectPath%/_esy/default/store/i/%id%/lib\\"
@@ -147,10 +139,6 @@ export cur__dev=\\"true\\"
 export cur__version=\\"1.0.0\\"
 export cur__name=\\"root\\"
 export DUNE_BUILD_DIR=\\"%projectPath%/_esy/default/store/b/%id%\\"
-
-#
-# Built-in
-#
 export SHELL=\\"env -i /bin/bash --norc --noprofile\\"
 export PATH=\\"$PATH:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\""
 `;
@@ -167,7 +155,7 @@ exports[`Build with optDependencies builds w/o opt dependency installed snapshot
 
 
 #
-# dep@path:dep@d41d8cd9
+# Built-in
 #
 export OCAMLFIND_LDCONF=\\"ignore\\"
 export OCAMLFIND_DESTDIR=\\"%esyStorePath%/s/%id%/lib\\"
@@ -188,10 +176,6 @@ export cur__dev=\\"false\\"
 export cur__version=\\"1.0.0\\"
 export cur__name=\\"dep\\"
 export DUNE_BUILD_DIR=\\"%esyStorePath%/b/%id%\\"
-
-#
-# Built-in
-#
 export SHELL=\\"env -i /bin/bash --norc --noprofile\\"
 export PATH=\\"$PATH:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\""
 `;

--- a/test-e2e/esy-build/__snapshots__/with-dep.test.js.snap
+++ b/test-e2e/esy-build/__snapshots__/with-dep.test.js.snap
@@ -12,7 +12,7 @@ exports[`Build with dep out of source build macos || linux: build-env dep snapsh
 
 
 #
-# dep@path:dep@d41d8cd9
+# Built-in
 #
 export OCAMLFIND_LDCONF=\\"ignore\\"
 export OCAMLFIND_DESTDIR=\\"%esyStorePath%/s/%id%/lib\\"
@@ -33,10 +33,6 @@ export cur__dev=\\"false\\"
 export cur__version=\\"1.0.0\\"
 export cur__name=\\"dep\\"
 export DUNE_BUILD_DIR=\\"%esyStorePath%/b/%id%\\"
-
-#
-# Built-in
-#
 export SHELL=\\"env -i /bin/bash --norc --noprofile\\"
 export PATH=\\"$PATH:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\""
 `;
@@ -61,7 +57,7 @@ export MAN_PATH=\\"%esyStorePath%/i/%depid%/man:$MAN_PATH\\"
 export PATH=\\"%esyStorePath%/i/%depid%/bin:$PATH\\"
 
 #
-# withDep@link:./package.json
+# Built-in
 #
 export OCAMLFIND_LDCONF=\\"ignore\\"
 export OCAMLFIND_DESTDIR=\\"%projectPath%/_esy/default/store/i/%id%/lib\\"
@@ -82,10 +78,6 @@ export cur__dev=\\"true\\"
 export cur__version=\\"1.0.0\\"
 export cur__name=\\"withDep\\"
 export DUNE_BUILD_DIR=\\"%projectPath%/_esy/default/store/b/%id%\\"
-
-#
-# Built-in
-#
 export SHELL=\\"env -i /bin/bash --norc --noprofile\\"
 export PATH=\\"$PATH:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\""
 `;

--- a/test-e2e/esy-build/__snapshots__/with-dev-dep.test.js.snap
+++ b/test-e2e/esy-build/__snapshots__/with-dev-dep.test.js.snap
@@ -12,7 +12,7 @@ exports[`devDep workflow macos || linux: build-env dep snapshot 1`] = `
 
 
 #
-# dep@path:dep@d41d8cd9
+# Built-in
 #
 export OCAMLFIND_LDCONF=\\"ignore\\"
 export OCAMLFIND_DESTDIR=\\"%esyStorePath%/s/%id%/lib\\"
@@ -32,10 +32,6 @@ export cur__root=\\"%esyStorePath%/b/%id%\\"
 export cur__dev=\\"false\\"
 export cur__version=\\"1.0.0\\"
 export cur__name=\\"dep\\"
-
-#
-# Built-in
-#
 export SHELL=\\"env -i /bin/bash --norc --noprofile\\"
 export PATH=\\"$PATH:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\""
 `;
@@ -52,7 +48,7 @@ exports[`devDep workflow macos || linux: build-env devDep snapshot 1`] = `
 
 
 #
-# devDep@path:devDep@d41d8cd9
+# Built-in
 #
 export OCAMLFIND_LDCONF=\\"ignore\\"
 export OCAMLFIND_DESTDIR=\\"%esyStorePath%/s/%id%/lib\\"
@@ -72,10 +68,6 @@ export cur__root=\\"%esyStorePath%/b/%id%\\"
 export cur__dev=\\"false\\"
 export cur__version=\\"1.0.0\\"
 export cur__name=\\"devDep\\"
-
-#
-# Built-in
-#
 export SHELL=\\"env -i /bin/bash --norc --noprofile\\"
 export PATH=\\"$PATH:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\""
 `;
@@ -100,7 +92,7 @@ export MAN_PATH=\\"%esyStorePath%/i/%depid%/man:$MAN_PATH\\"
 export PATH=\\"%esyStorePath%/i/%depid%/bin:$PATH\\"
 
 #
-# withDevDep@link:./package.json
+# Built-in
 #
 export OCAMLFIND_LDCONF=\\"ignore\\"
 export OCAMLFIND_DESTDIR=\\"%projectPath%/_esy/default/store/i/%id%/lib\\"
@@ -121,10 +113,6 @@ export cur__dev=\\"true\\"
 export cur__version=\\"1.0.0\\"
 export cur__name=\\"withDevDep\\"
 export DUNE_BUILD_DIR=\\"%projectPath%/_esy/default/store/b/%id%\\"
-
-#
-# Built-in
-#
 export SHELL=\\"env -i /bin/bash --norc --noprofile\\"
 export PATH=\\"$PATH:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\""
 `;

--- a/test-e2e/esy-build/__snapshots__/with-linked-dep.test.js.snap
+++ b/test-e2e/esy-build/__snapshots__/with-linked-dep.test.js.snap
@@ -12,7 +12,7 @@ exports[`Build with a linked dep out of source build macos || linux: build-env d
 
 
 #
-# dep@link:dep
+# Built-in
 #
 export OCAMLFIND_LDCONF=\\"ignore\\"
 export OCAMLFIND_DESTDIR=\\"%projectPath%/_esy/default/store/i/%id%/lib\\"
@@ -33,10 +33,6 @@ export cur__dev=\\"true\\"
 export cur__version=\\"1.0.0\\"
 export cur__name=\\"dep\\"
 export DUNE_BUILD_DIR=\\"%projectPath%/_esy/default/store/b/%id%\\"
-
-#
-# Built-in
-#
 export SHELL=\\"env -i /bin/bash --norc --noprofile\\"
 export PATH=\\"$PATH:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\""
 `;
@@ -61,7 +57,7 @@ export MAN_PATH=\\"%projectPath%/_esy/default/store/i/%depid%/man:$MAN_PATH\\"
 export PATH=\\"%projectPath%/_esy/default/store/i/%depid%/bin:$PATH\\"
 
 #
-# with-linked-dep-_build@link:./package.json
+# Built-in
 #
 export OCAMLFIND_LDCONF=\\"ignore\\"
 export OCAMLFIND_DESTDIR=\\"%projectPath%/_esy/default/store/i/%id%/lib\\"
@@ -82,10 +78,6 @@ export cur__dev=\\"true\\"
 export cur__version=\\"1.0.0\\"
 export cur__name=\\"with-linked-dep-_build\\"
 export DUNE_BUILD_DIR=\\"%projectPath%/_esy/default/store/b/%id%\\"
-
-#
-# Built-in
-#
 export SHELL=\\"env -i /bin/bash --norc --noprofile\\"
 export PATH=\\"$PATH:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\""
 `;


### PR DESCRIPTION
This commit allows envspec (`esy command-exec` and `esy print-env` commands) to narrow down the environment include only those exported vaars which were exactly specified by envspec expression.

For example this

    % esy print-env --envspec self root

will print only exports of the root package alone excluding its dependencies.