### PR TITLE
Make Dist.local store ManifestSpec.Filename.t

### DIFF
--- a/esy-install/Dist.ml
+++ b/esy-install/Dist.ml
@@ -2,7 +2,7 @@ open Sexplib0.Sexp_conv
 
 type local = {
   path : DistPath.t;
-  manifest : ManifestSpec.t option;
+  manifest : ManifestSpec.Filename.t option;
 } [@@deriving ord, sexp_of]
 
 type t =
@@ -27,9 +27,9 @@ type t =
 
 let manifest (dist : t) =
   match dist with
-  | Git { manifest = Some manifest; _ } -> Some (ManifestSpec.One manifest)
+  | Git { manifest = Some manifest; _ } -> Some manifest
   | Git _ -> None
-  | Github { manifest = Some manifest; _ } -> Some (ManifestSpec.One manifest)
+  | Github { manifest = Some manifest; _ } -> Some manifest
   | Github _ -> None
   | LocalPath info -> info.manifest
   | Archive _ -> None
@@ -49,7 +49,7 @@ let show' ~showPath = function
   | LocalPath {path; manifest = None;} ->
     Printf.sprintf "path:%s" (showPath path)
   | LocalPath {path; manifest = Some manifest;} ->
-    Printf.sprintf "path:%s/%s" (showPath path) (ManifestSpec.show manifest)
+    Printf.sprintf "path:%s/%s" (showPath path) (ManifestSpec.Filename.show manifest)
   | NoSource -> "no-source:"
 
 let show = show' ~showPath:DistPath.show
@@ -141,7 +141,7 @@ module Parse = struct
     let make path =
       let path = Path.(normalizeAndRemoveEmptySeg (v path)) in
       let path, manifest =
-        match ManifestSpec.ofString (Path.basename path) with
+        match ManifestSpec.Filename.ofString (Path.basename path) with
         | Ok manifest ->
           let path = Path.(remEmptySeg (parent path)) in
           path, Some manifest
@@ -491,7 +491,7 @@ let local_of_yojson json =
 let local_to_yojson local =
   match local.manifest with
   | None -> `String (DistPath.show local.path)
-  | Some m -> `String (DistPath.(show (local.path / ManifestSpec.show m)))
+  | Some m -> `String (DistPath.(show (local.path / ManifestSpec.Filename.show m)))
 
 module Map = Map.Make(struct
   type nonrec t = t

--- a/esy-install/Dist.mli
+++ b/esy-install/Dist.mli
@@ -1,3 +1,13 @@
+type local = {
+  path : DistPath.t;
+  manifest : ManifestSpec.Filename.t option;
+}
+
+val compare_local : local -> local -> int
+val sexp_of_local : local -> Sexplib0.Sexp.t
+val local_of_yojson : local Json.decoder
+val local_to_yojson : local Json.encoder
+
 type t =
   | Archive of {
       url : string;
@@ -17,14 +27,6 @@ type t =
   | LocalPath of local
   | NoSource
 
-and local = {
-  path : DistPath.t;
-  manifest : ManifestSpec.t option;
-}
-
-val local_of_yojson : local Json.decoder
-val local_to_yojson : local Json.encoder
-
 include S.PRINTABLE with type t := t
 include S.JSONABLE with type t := t
 include S.COMPARABLE with type t := t
@@ -35,7 +37,7 @@ val sexp_of_t : t -> Sexplib0.Sexp.t
 val parser : t Parse.t
 val parse : string -> (t, string) result
 
-val manifest : t -> ManifestSpec.t option
+val manifest : t -> ManifestSpec.Filename.t option
 
 val parserRelaxed : t Parse.t
 val parseRelaxed : string -> (t, string) result

--- a/esy-install/DistResolver.ml
+++ b/esy-install/DistResolver.ml
@@ -161,12 +161,11 @@ let ofPath ?manifest (path : Path.t) =
   match manifest with
   | Some manifest ->
     let%bind tried, state =
-      let%bind filenames = ManifestSpec.findManifestsAtPath path manifest in
-      tryManifests Path.Set.empty filenames
+      tryManifests Path.Set.empty [manifest]
     in
     begin match state with
     | EmptyManifest ->
-      errorf "unable to read manifests from %a" ManifestSpec.pp manifest
+      errorf "unable to read manifests from %a" ManifestSpec.Filename.pp manifest
     | state ->
       return (tried, state)
     end
@@ -197,7 +196,6 @@ let resolve
         return (pkg, tried)
       end
     | Git {remote; commit; manifest;} ->
-      let manifest = Option.map ~f:(fun m -> ManifestSpec.One m) manifest in
       Fs.withTempDir begin fun repo ->
         let%bind () = Git.clone ~dst:repo ~remote () in
         let%bind () = Git.checkout ~ref:commit ~repo () in

--- a/esy-install/PackageSource.ml
+++ b/esy-install/PackageSource.ml
@@ -24,7 +24,7 @@ let opamfiles opam =
   File.ofDir Path.(opam.path / "files")
 
 type t =
-  | Link of Source.link
+  | Link of Dist.local
   | Install of {
       source : Dist.t * Dist.t list;
       opam : opam option;
@@ -37,7 +37,7 @@ let to_yojson source =
     assoc [
       field "type" string "link";
       field "path" DistPath.to_yojson path;
-      fieldOpt "manifest" ManifestSpec.to_yojson manifest;
+      fieldOpt "manifest" ManifestSpec.Filename.to_yojson manifest;
     ]
   | Install { source = source, mirrors; opam } ->
     assoc [
@@ -60,7 +60,7 @@ let of_yojson json =
     Ok (Install {source; opam;})
   | "link" ->
     let%bind path = fieldWith ~name:"path" DistPath.of_yojson json in
-    let%bind manifest = fieldOptWith ~name:"manifest" ManifestSpec.of_yojson json in
+    let%bind manifest = fieldOptWith ~name:"manifest" ManifestSpec.Filename.of_yojson json in
     Ok (Link {path; manifest;})
   | typ -> errorf "unknown source type: %s" typ
 

--- a/esy-install/PackageSource.mli
+++ b/esy-install/PackageSource.mli
@@ -1,5 +1,5 @@
 type t =
-  | Link of Source.link
+  | Link of Dist.local
   | Install of {
       source : Dist.t * Dist.t list;
       opam : opam option;

--- a/esy-install/Solution.ml
+++ b/esy-install/Solution.ml
@@ -24,7 +24,7 @@ let findByPath p solution =
       let path = DistPath.(path / "package.json") in
       DistPath.compare path p = 0
     | Link {path; manifest = Some filename;} ->
-      let path = DistPath.(path / ManifestSpec.show filename) in
+      let path = DistPath.(path / ManifestSpec.Filename.show filename) in
       DistPath.compare path p = 0
     | _ -> false
   in

--- a/esy-install/SolutionLock.ml
+++ b/esy-install/SolutionLock.ml
@@ -117,9 +117,8 @@ let readOverride sandbox override =
     let filename =
       match local.manifest with
       | None -> "package.json"
-      | Some One (Esy, filename) -> filename
-      | Some One (Opam, _filename) -> failwith "cannot load override from opam file"
-      | Some ManyOpam -> failwith "cannot load override from opam files"
+      | Some (Esy, filename) -> filename
+      | Some (Opam, _filename) -> failwith "cannot load override from opam file"
     in
     let dist = Dist.LocalPath local in
     let path = DistPath.toPath sandbox.Sandbox.spec.path DistPath.(local.path / filename) in

--- a/esy-install/Source.ml
+++ b/esy-install/Source.ml
@@ -1,13 +1,7 @@
 open Sexplib0.Sexp_conv
-
-type link = {
-  path : DistPath.t;
-  manifest : ManifestSpec.t option;
-} [@@deriving ord, sexp_of, yojson]
-
 type t =
   | Dist of Dist.t
-  | Link of link
+  | Link of Dist.local
   [@@deriving ord, sexp_of]
 
 let manifest (src : t) =
@@ -34,12 +28,12 @@ let show' ~showPath = function
   | Dist LocalPath {path; manifest = None;} ->
     Printf.sprintf "path:%s" (showPath path)
   | Dist LocalPath {path; manifest = Some manifest;} ->
-    Printf.sprintf "path:%s/%s" (showPath path) (ManifestSpec.show manifest)
+    Printf.sprintf "path:%s/%s" (showPath path) (ManifestSpec.Filename.show manifest)
   | Dist NoSource -> "no-source:"
   | Link {path; manifest = None;} ->
     Printf.sprintf "link:%s" (showPath path)
   | Link {path; manifest = Some manifest;} ->
-    Printf.sprintf "link:%s/%s" (showPath path) (ManifestSpec.show manifest)
+    Printf.sprintf "link:%s/%s" (showPath path) (ManifestSpec.Filename.show manifest)
 
 let show = show' ~showPath:DistPath.show
 let showPretty = show' ~showPath:DistPath.showPretty
@@ -60,7 +54,7 @@ module Parse = struct
     let make path =
       let path = Path.(normalizeAndRemoveEmptySeg (v path)) in
       let path, manifest =
-        match ManifestSpec.ofString (Path.basename path) with
+        match ManifestSpec.Filename.ofString (Path.basename path) with
         | Ok manifest ->
           let path = Path.(remEmptySeg (parent path)) in
           path, Some manifest

--- a/esy-install/Source.mli
+++ b/esy-install/Source.mli
@@ -1,14 +1,6 @@
-type link = {
-  path : DistPath.t;
-  manifest : ManifestSpec.t option;
-}
-
-val link_to_yojson : link Json.encoder
-val link_of_yojson : link Json.decoder
-
 type t =
   | Dist of Dist.t
-  | Link of link
+  | Link of Dist.local
 
 include S.COMMON with type t := t
 
@@ -23,7 +15,7 @@ val parse : string -> (t, string) result
 val parserRelaxed : t Parse.t
 val parseRelaxed : string -> (t, string) result
 
-val manifest : t -> ManifestSpec.t option
+val manifest : t -> ManifestSpec.Filename.t option
 val toDist : t -> Dist.t
 
 module Map : Map.S with type key := t

--- a/esy-install/SourceSpec.ml
+++ b/esy-install/SourceSpec.ml
@@ -16,10 +16,7 @@ type t =
       ref : string option;
       manifest : ManifestSpec.Filename.t option;
     }
-  | LocalPath of {
-      path : DistPath.t;
-      manifest : ManifestSpec.t option;
-    }
+  | LocalPath of Dist.local
   | NoSource
   [@@deriving ord, sexp_of]
 
@@ -50,7 +47,7 @@ let show = function
   | LocalPath {path; manifest = None;} ->
     Printf.sprintf "path:%s" (DistPath.show path)
   | LocalPath {path; manifest = Some manifest;} ->
-    Printf.sprintf "path:%s/%s" (DistPath.show path) (ManifestSpec.show manifest)
+    Printf.sprintf "path:%s/%s" (DistPath.show path) (ManifestSpec.Filename.show manifest)
 
   | NoSource -> "no-source:"
 
@@ -137,7 +134,7 @@ module Parse = struct
     let make path =
       let path = Path.(normalizeAndRemoveEmptySeg (v path)) in
       let path, manifest =
-        match ManifestSpec.ofString (Path.basename path) with
+        match ManifestSpec.Filename.ofString (Path.basename path) with
         | Ok manifest ->
           let path = Path.(remEmptySeg (parent path)) in
           path, Some manifest

--- a/esy-install/SourceSpec.mli
+++ b/esy-install/SourceSpec.mli
@@ -19,10 +19,7 @@ type t =
       ref : string option;
       manifest : ManifestSpec.Filename.t option;
     }
-  | LocalPath of {
-      path : DistPath.t;
-      manifest : ManifestSpec.t option;
-    }
+  | LocalPath of Dist.local
   | NoSource
 
 include S.PRINTABLE with type t := t

--- a/esy-solve/Resolver.ml
+++ b/esy-solve/Resolver.ml
@@ -260,7 +260,7 @@ let packageOfSource ~name ~overrides (source : EsyInstall.Source.t) resolver =
       match source, resolvedDist with
       | EsyInstall.Source.Dist _, _ -> return (EsyInstall.Source.Dist resolvedDist)
       | EsyInstall.Source.Link _, EsyInstall.Dist.LocalPath {path; manifest;} ->
-        return (EsyInstall.Source.Link {path;manifest;})
+        return (EsyInstall.Source.Link {path; manifest;})
       | EsyInstall.Source.Link _, dist -> errorf "unable to link to %a" EsyInstall.Dist.pp dist
     in
 


### PR DESCRIPTION
Previously we allowed ManifestSpec.t there but this is not correct as we
didn't handle `ManyOpam` case there - we failed with an error instead.