### PR TITLE
Cleanup sandbox init

### DIFF
--- a/esy-install/Config.rei
+++ b/esy-install/Config.rei
@@ -1,11 +1,12 @@
 /** Configuration for esy installer */
 
-type t = {
-  sourceArchivePath: option(Path.t),
-  sourceFetchPath: Path.t,
-  sourceStagePath: Path.t,
-  sourceInstallPath: Path.t,
-};
+type t =
+  pri {
+    sourceArchivePath: option(Path.t),
+    sourceFetchPath: Path.t,
+    sourceStagePath: Path.t,
+    sourceInstallPath: Path.t,
+  };
 
 let make:
   (

--- a/esy-install/Dist.mli
+++ b/esy-install/Dist.mli
@@ -1,6 +1,6 @@
 type local = {
   path : DistPath.t;
-  manifest : ManifestSpec.Filename.t option;
+  manifest : ManifestSpec.t option;
 }
 
 val compare_local : local -> local -> int
@@ -16,13 +16,13 @@ type t =
   | Git of {
       remote : string;
       commit : string;
-      manifest : ManifestSpec.Filename.t option;
+      manifest : ManifestSpec.t option;
     }
   | Github of {
       user : string;
       repo : string;
       commit : string;
-      manifest : ManifestSpec.Filename.t option;
+      manifest : ManifestSpec.t option;
     }
   | LocalPath of local
   | NoSource
@@ -37,7 +37,7 @@ val sexp_of_t : t -> Sexplib0.Sexp.t
 val parser : t Parse.t
 val parse : string -> (t, string) result
 
-val manifest : t -> ManifestSpec.Filename.t option
+val manifest : t -> ManifestSpec.t option
 
 val parserRelaxed : t Parse.t
 val parseRelaxed : string -> (t, string) result

--- a/esy-install/DistPath.ml
+++ b/esy-install/DistPath.ml
@@ -4,6 +4,13 @@ let ofPath p = (normalizeAndRemoveEmptySeg p)
 
 let toPath base p = normalizeAndRemoveEmptySeg (base // p)
 
+let make ~base p =
+  let base = normalizeAndRemoveEmptySeg base in
+  let p = normalizeAndRemoveEmptySeg p in
+  if compare p base = 0
+  then v "."
+  else normalizeAndRemoveEmptySeg (tryRelativize ~root:base p)
+
 let rebase ~base p = normalizeAndRemoveEmptySeg (base // p)
 
 let render path = normalizePathSlashes (show path)

--- a/esy-install/DistPath.mli
+++ b/esy-install/DistPath.mli
@@ -16,11 +16,13 @@ include S.COMPARABLE with type t := t
 val v : string -> t
 val (/) : t -> string -> t
 
+
 val toPath : Path.t -> t -> Path.t
 (** [toPath base p] converts [p] to [Path.t] by rebasing on top of [base]. *)
 
 val ofPath : Path.t -> t
 
+val make : base:Path.t -> Path.t -> t
 val rebase : base:t -> t -> t
 
 val sexp_of_t : t -> Sexplib0.Sexp.t

--- a/esy-install/DistResolver.mli
+++ b/esy-install/DistResolver.mli
@@ -20,7 +20,7 @@ type resolution = {
 }
 
 and manifest = {
-  kind : ManifestSpec.Filename.kind;
+  kind : ManifestSpec.kind;
   filename : string;
   suggestedPackageName : string;
   data : string;

--- a/esy-install/ManifestSpec.ml
+++ b/esy-install/ManifestSpec.ml
@@ -1,113 +1,51 @@
 open Sexplib0.Sexp_conv
 
-module Filename = struct
-  type t = kind * string
-    [@@deriving ord, sexp_of]
-
-  and kind =
-    | Esy
-    | Opam
-
-  let show (_, fname) = fname
-
-  let pp fmt (_, fname) = Fmt.string fmt fname
-
-  let ofString fname =
-    let open Result.Syntax in
-    match fname with
-    | "" -> errorf "empty filename"
-    | "opam" -> return (Opam, "opam")
-    | fname ->
-      begin match Path.(getExt (v fname)) with
-      | ".json" -> return (Esy, fname)
-      | ".opam" -> return (Opam, fname)
-      | _ -> errorf "invalid manifest: %s" fname
-      end
-
-  let ofStringExn fname =
-    match ofString fname with
-    | Ok fname -> fname
-    | Error msg -> failwith msg
-
-  let parser =
-    let make fname =
-      match ofString fname with
-      | Ok fname -> Parse.return fname
-      | Error msg -> Parse.fail msg
-    in
-    Parse.(take_while1 (fun _ -> true) >>= make)
-
-  let to_yojson (_, fname) = `String fname
-
-  let of_yojson json =
-    let open Result.Syntax in
-    match json with
-    | `String "opam" -> return (Opam, "opam")
-    | `String fname -> ofString fname
-    | _ -> error "invalid manifest filename"
-
-  let inferPackageName = function
-    | Opam, "opam" -> None
-    | Opam, fname -> Some ("@opam/" ^ Path.(v fname |> remExt |> show))
-    | Esy, fname -> Some Path.(v fname |> remExt |> show)
-
-end
-
-type t =
-  | One of Filename.t
-  | ManyOpam
+type t = kind * string
   [@@deriving ord, sexp_of]
 
-let show = function
-  | One fname -> Filename.show fname
-  | ManyOpam -> "*.opam"
+and kind =
+  | Esy
+  | Opam
 
-let pp fmt manifest =
-  match manifest with
-  | One fname -> Filename.pp fmt fname
-  | ManyOpam -> Fmt.unit "*.opam" fmt ()
+let show (_, fname) = fname
 
-let to_yojson manifest =
-  match manifest with
-  | One (_, fname) -> `String fname
-  | ManyOpam -> `String "*.opam"
+let pp fmt (_, fname) = Fmt.string fmt fname
 
-let ofString v =
+let ofString fname =
   let open Result.Syntax in
-  match v with
-  | "*.opam" -> return ManyOpam
-  | v ->
-    let%bind fname = Filename.ofString v in
-    return (One fname)
+  match fname with
+  | "" -> errorf "empty filename"
+  | "opam" -> return (Opam, "opam")
+  | fname ->
+    begin match Path.(getExt (v fname)) with
+    | ".json" -> return (Esy, fname)
+    | ".opam" -> return (Opam, fname)
+    | _ -> errorf "invalid manifest: %s" fname
+    end
+
+let ofStringExn fname =
+  match ofString fname with
+  | Ok fname -> fname
+  | Error msg -> failwith msg
+
+let parser =
+  let make fname =
+    match ofString fname with
+    | Ok fname -> Parse.return fname
+    | Error msg -> Parse.fail msg
+  in
+  Parse.(take_while1 (fun _ -> true) >>= make)
+
+let to_yojson (_, fname) = `String fname
 
 let of_yojson json =
   let open Result.Syntax in
   match json with
-  | `String v -> ofString v
-  | _ -> errorf "invalid manifest spec: expected string"
+  | `String "opam" -> return (Opam, "opam")
+  | `String fname -> ofString fname
+  | _ -> error "invalid manifest filename"
 
-let isOpamFilename filename =
-  Path.(hasExt ".opam" (v filename)) || filename = "opam"
-
-let findManifestsAtPath path spec =
-  let open RunAsync.Syntax in
-  match spec with
-  | One (kind, filename) -> return [kind, filename]
-  | ManyOpam ->
-    let%bind filenames = Fs.listDir path in
-    let f manifests filename =
-      if isOpamFilename filename
-      then (Filename.Opam, filename)::manifests
-      else manifests
-    in
-    return (List.fold_left ~f ~init:[] filenames)
-
-module Set = Set.Make(struct
-  type nonrec t = t
-  let compare = compare
-end)
-
-module Map = Map.Make(struct
-  type nonrec t = t
-  let compare = compare
-end)
+let inferPackageName = function
+  | Opam, "opam" -> None
+  | Opam, fname -> Some ("@opam/" ^ Path.(v fname |> remExt |> show))
+  | Esy, fname -> Some Path.(v fname |> remExt |> show)

--- a/esy-install/ManifestSpec.mli
+++ b/esy-install/ManifestSpec.mli
@@ -1,38 +1,18 @@
-module Filename : sig
-  type t =
-    kind * string
-
-  and kind =
-    | Esy
-    | Opam
-
-  include S.PRINTABLE with type t := t
-  include S.COMPARABLE with type t := t
-  include S.JSONABLE with type t := t
-
-  val sexp_of_t : t -> Sexplib0.Sexp.t
-
-  val ofString : string -> (t, string) result
-  val ofStringExn : string -> t
-  val parser : t Parse.t
-
-  val inferPackageName : t -> string option
-end
-
 type t =
-  | One of Filename.t
-  | ManyOpam
+  kind * string
 
-
-val sexp_of_t : t -> Sexplib0.Sexp.t
-
-val ofString : string -> (t, string) result
-
-val findManifestsAtPath : Path.t -> t -> Filename.t list RunAsync.t
+and kind =
+  | Esy
+  | Opam
 
 include S.PRINTABLE with type t := t
 include S.COMPARABLE with type t := t
 include S.JSONABLE with type t := t
 
-module Set : Set.S with type elt = t
-module Map : Map.S with type key = t
+val sexp_of_t : t -> Sexplib0.Sexp.t
+
+val ofString : string -> (t, string) result
+val ofStringExn : string -> t
+val parser : t Parse.t
+
+val inferPackageName : t -> string option

--- a/esy-install/PackageSource.ml
+++ b/esy-install/PackageSource.ml
@@ -37,7 +37,7 @@ let to_yojson source =
     assoc [
       field "type" string "link";
       field "path" DistPath.to_yojson path;
-      fieldOpt "manifest" ManifestSpec.Filename.to_yojson manifest;
+      fieldOpt "manifest" ManifestSpec.to_yojson manifest;
     ]
   | Install { source = source, mirrors; opam } ->
     assoc [
@@ -60,7 +60,7 @@ let of_yojson json =
     Ok (Install {source; opam;})
   | "link" ->
     let%bind path = fieldWith ~name:"path" DistPath.of_yojson json in
-    let%bind manifest = fieldOptWith ~name:"manifest" ManifestSpec.Filename.of_yojson json in
+    let%bind manifest = fieldOptWith ~name:"manifest" ManifestSpec.of_yojson json in
     Ok (Link {path; manifest;})
   | typ -> errorf "unknown source type: %s" typ
 

--- a/esy-install/Req.ml
+++ b/esy-install/Req.ml
@@ -305,7 +305,7 @@ let%test_module "parsing" = (module struct
         user = "user";
         repo = "repo";
         ref = Some "ref";
-        manifest = Some (ManifestSpec.Filename.Opam, "lwt.opam");
+        manifest = Some (ManifestSpec.Opam, "lwt.opam");
       });
     };
 
@@ -338,7 +338,7 @@ let%test_module "parsing" = (module struct
         user = "user";
         repo = "repo";
         ref = Some "ref";
-        manifest = Some (ManifestSpec.Filename.Opam, "lwt.opam");
+        manifest = Some (ManifestSpec.Opam, "lwt.opam");
       });
     };
 
@@ -371,7 +371,7 @@ let%test_module "parsing" = (module struct
         user = "user";
         repo = "repo";
         ref = Some "ref";
-        manifest = Some (ManifestSpec.Filename.Opam, "lwt.opam");
+        manifest = Some (ManifestSpec.Opam, "lwt.opam");
       });
     };
 

--- a/esy-install/Sandbox.ml
+++ b/esy-install/Sandbox.ml
@@ -2,3 +2,5 @@ type t = {
   cfg : Config.t;
   spec : SandboxSpec.t;
 }
+
+let make cfg spec = {cfg; spec;}

--- a/esy-install/Sandbox.mli
+++ b/esy-install/Sandbox.mli
@@ -1,0 +1,7 @@
+type t = private {
+  cfg : Config.t;
+  spec : SandboxSpec.t;
+}
+
+val make : Config.t -> SandboxSpec.t -> t
+

--- a/esy-install/SandboxSpec.ml
+++ b/esy-install/SandboxSpec.ml
@@ -4,8 +4,8 @@ type t = {
 } [@@deriving ord]
 
 and manifest =
-  | Manifest of ManifestSpec.Filename.t
-  | ManifestAggregate of ManifestSpec.Filename.t list
+  | Manifest of ManifestSpec.t
+  | ManifestAggregate of ManifestSpec.t list
 
 let projectName spec =
   let nameOfPath spec = Path.basename spec.path in
@@ -79,7 +79,7 @@ let ofPath path =
         | [] -> errorf "no manifests found at %a" Path.pp path
         | [fname] -> return (Manifest (Opam, fname))
         | filenames ->
-          let filenames = List.map ~f:(fun fn -> ManifestSpec.Filename.Opam, fn) filenames in
+          let filenames = List.map ~f:(fun fn -> ManifestSpec.Opam, fn) filenames in
           return (ManifestAggregate filenames)
         end
     in
@@ -117,9 +117,9 @@ let ofPath path =
 let pp fmt spec =
   match spec.manifest with
   | Manifest filename ->
-    ManifestSpec.Filename.pp fmt filename
+    ManifestSpec.pp fmt filename
   | ManifestAggregate filenames ->
-    Fmt.(list ~sep:(unit ", ") ManifestSpec.Filename.pp) fmt filenames
+    Fmt.(list ~sep:(unit ", ") ManifestSpec.pp) fmt filenames
 
 let show spec = Format.asprintf "%a" pp spec
 

--- a/esy-install/SandboxSpec.ml
+++ b/esy-install/SandboxSpec.ml
@@ -1,27 +1,33 @@
 type t = {
   path : Path.t;
-  manifest : ManifestSpec.t
+  manifest : manifest;
 } [@@deriving ord]
+
+and manifest =
+  | Manifest of ManifestSpec.Filename.t
+  | ManifestAggregate of ManifestSpec.Filename.t list
 
 let projectName spec =
   let nameOfPath spec = Path.basename spec.path in
   match spec.manifest with
-  | ManyOpam -> nameOfPath spec
-  | One (Opam, "opam") -> nameOfPath spec
-  | One (Esy, "package.json") | One (Esy, "esy.json") -> nameOfPath spec
-  | One (_, fname) -> Path.(show (remExt (v fname)))
+  | ManifestAggregate _ -> nameOfPath spec
+  | Manifest (Opam, "opam") -> nameOfPath spec
+  | Manifest (Esy, "package.json")
+  | Manifest (Esy, "esy.json") -> nameOfPath spec
+  | Manifest (_, fname) -> Path.(show (remExt (v fname)))
 
 let name spec =
   match spec.manifest with
-  | ManyOpam -> "opam"
-  | One (Opam, "opam") -> "opam"
-  | One (Esy, "package.json") | One (Esy, "esy.json") -> "default"
-  | One (_, fname) -> Path.(show (remExt (v fname)))
+  | ManifestAggregate _ -> "opam"
+  | Manifest (Opam, "opam") -> "opam"
+  | Manifest (Esy, "package.json")
+  | Manifest (Esy, "esy.json") -> "default"
+  | Manifest (_, fname) -> Path.(show (remExt (v fname)))
 
 let isDefault spec =
   match spec.manifest with
-  | One (Esy, "package.json") -> true
-  | One (Esy, "esy.json") -> true
+  | Manifest (Esy, "package.json") -> true
+  | Manifest (Esy, "esy.json") -> true
   | _ -> false
 
 let localPrefixPath spec =
@@ -29,10 +35,13 @@ let localPrefixPath spec =
   Path.(spec.path / "_esy" / name)
 
 let manifestPaths spec =
-  let open RunAsync.Syntax in
-  let%bind filenames = ManifestSpec.findManifestsAtPath spec.path spec.manifest in
-  let f (_kind, filename) = Path.(spec.path / filename) in
-  return (List.map ~f filenames)
+  match spec.manifest with
+  | Manifest (_kind, filename) ->
+    [Path.(spec.path / filename)]
+  | ManifestAggregate filenames ->
+    List.map
+      ~f:(fun (_kind, filename) -> Path.(spec.path / filename))
+      filenames
 
 let installationPath spec = Path.(localPrefixPath spec / "installation.json")
 let pnpJsPath spec = Path.(localPrefixPath spec / "pnp.js")
@@ -45,8 +54,8 @@ let tempPath spec = Path.(localPrefixPath spec / "tmp")
 
 let solutionLockPath spec =
   match spec.manifest with
-  | One (Esy, "package.json")
-  | One (Esy, "esy.json") -> Path.(spec.path / "esy.lock")
+  | Manifest (Esy, "package.json")
+  | Manifest (Esy, "esy.json") -> Path.(spec.path / "esy.lock")
   | _ -> Path.(spec.path / (name spec ^ ".esy.lock"))
 
 let ofPath path =
@@ -58,9 +67,9 @@ let ofPath path =
 
     let%bind manifest =
       if StringSet.mem "esy.json" fnames
-      then return (ManifestSpec.One (Esy, "esy.json"))
+      then return (Manifest (Esy, "esy.json"))
       else if StringSet.mem "package.json" fnames
-      then return (ManifestSpec.One (Esy, "package.json"))
+      then return (Manifest (Esy, "package.json"))
       else
         let opamFnames =
           let isOpamFname fname = Path.(hasExt ".opam" (v fname)) || fname = "opam" in
@@ -68,8 +77,10 @@ let ofPath path =
         in
         begin match opamFnames with
         | [] -> errorf "no manifests found at %a" Path.pp path
-        | [fname] -> return (ManifestSpec.One (Opam, fname))
-        | _fnames -> return ManifestSpec.ManyOpam
+        | [fname] -> return (Manifest (Opam, fname))
+        | filenames ->
+          let filenames = List.map ~f:(fun fn -> ManifestSpec.Filename.Opam, fn) filenames in
+          return (ManifestAggregate filenames)
         end
     in
     return {path; manifest}
@@ -86,11 +97,11 @@ let ofPath path =
         then (
           if fname = "opam"
           then
-            return {path = sandboxPath; manifest = One (Opam, fname);}
+            return {path = sandboxPath; manifest = Manifest (Opam, fname);}
           else
             match Path.getExt fpath with
-            | ".json" -> return {path = sandboxPath; manifest = One (Esy, fname);}
-            | ".opam" -> return {path = sandboxPath; manifest = One (Opam, fname);}
+            | ".json" -> return {path = sandboxPath; manifest = Manifest (Esy, fname);}
+            | ".opam" -> return {path = sandboxPath; manifest = Manifest (Opam, fname);}
             | _ -> tryLoad rest
         ) else
           tryLoad rest
@@ -104,7 +115,11 @@ let ofPath path =
   else ofFile path
 
 let pp fmt spec =
-  ManifestSpec.pp fmt spec.manifest
+  match spec.manifest with
+  | Manifest filename ->
+    ManifestSpec.Filename.pp fmt filename
+  | ManifestAggregate filenames ->
+    Fmt.(list ~sep:(unit ", ") ManifestSpec.Filename.pp) fmt filenames
 
 let show spec = Format.asprintf "%a" pp spec
 

--- a/esy-install/SandboxSpec.ml
+++ b/esy-install/SandboxSpec.ml
@@ -3,13 +3,6 @@ type t = {
   manifest : ManifestSpec.t
 } [@@deriving ord]
 
-let doesPathReferToConcreteManifest path =
-  Path.(
-    hasExt ".json" path
-    || hasExt ".opam" path
-    || Path.(compare path (v "opam") = 0)
-  )
-
 let projectName spec =
   let nameOfPath spec = Path.basename spec.path in
   match spec.manifest with

--- a/esy-install/SandboxSpec.ml
+++ b/esy-install/SandboxSpec.ml
@@ -73,7 +73,7 @@ let ofPath path =
       else if StringSet.mem "package.json" fnames
       then return (Manifest (Esy, "package.json"))
       else if StringSet.mem "opam" fnames
-      then return (Manifest (Esy, "opam"))
+      then return (Manifest (Opam, "opam"))
       else
         let%bind filenames =
           let f filename =

--- a/esy-install/SandboxSpec.mli
+++ b/esy-install/SandboxSpec.mli
@@ -4,8 +4,8 @@ type t = {
 }
 
 and manifest =
-  | Manifest of ManifestSpec.Filename.t
-  | ManifestAggregate of ManifestSpec.Filename.t list
+  | Manifest of ManifestSpec.t
+  | ManifestAggregate of ManifestSpec.t list
 
 include S.PRINTABLE with type t := t
 include S.COMPARABLE with type t := t

--- a/esy-install/SandboxSpec.mli
+++ b/esy-install/SandboxSpec.mli
@@ -9,7 +9,6 @@ include S.COMPARABLE with type t := t
 module Set : Set.S with type elt = t
 module Map : Map.S with type key = t
 
-val doesPathReferToConcreteManifest : Path.t -> bool
 val isDefault : t -> bool
 val projectName : t -> string
 

--- a/esy-install/SandboxSpec.mli
+++ b/esy-install/SandboxSpec.mli
@@ -1,7 +1,11 @@
 type t = {
   path : Path.t;
-  manifest : ManifestSpec.t;
+  manifest : manifest;
 }
+
+and manifest =
+  | Manifest of ManifestSpec.Filename.t
+  | ManifestAggregate of ManifestSpec.Filename.t list
 
 include S.PRINTABLE with type t := t
 include S.COMPARABLE with type t := t
@@ -12,7 +16,7 @@ module Map : Map.S with type key = t
 val isDefault : t -> bool
 val projectName : t -> string
 
-val manifestPaths : t -> Path.t list RunAsync.t
+val manifestPaths : t -> Path.t list
 val distPath : t -> Path.t
 val tempPath : t -> Path.t
 val cachePath : t -> Path.t

--- a/esy-install/Solution.ml
+++ b/esy-install/Solution.ml
@@ -24,7 +24,7 @@ let findByPath p solution =
       let path = DistPath.(path / "package.json") in
       DistPath.compare path p = 0
     | Link {path; manifest = Some filename;} ->
-      let path = DistPath.(path / ManifestSpec.Filename.show filename) in
+      let path = DistPath.(path / ManifestSpec.show filename) in
       DistPath.compare path p = 0
     | _ -> false
   in

--- a/esy-install/Source.ml
+++ b/esy-install/Source.ml
@@ -18,22 +18,22 @@ let show' ~showPath = function
   | Dist Github {user; repo; commit; manifest = None;} ->
     Printf.sprintf "github:%s/%s#%s" user repo commit
   | Dist Github {user; repo; commit; manifest = Some manifest;} ->
-    Printf.sprintf "github:%s/%s:%s#%s" user repo (ManifestSpec.Filename.show manifest) commit
+    Printf.sprintf "github:%s/%s:%s#%s" user repo (ManifestSpec.show manifest) commit
   | Dist Git {remote; commit; manifest = None;} ->
     Printf.sprintf "git:%s#%s" remote commit
   | Dist Git {remote; commit; manifest = Some manifest;} ->
-    Printf.sprintf "git:%s:%s#%s" remote (ManifestSpec.Filename.show manifest) commit
+    Printf.sprintf "git:%s:%s#%s" remote (ManifestSpec.show manifest) commit
   | Dist Archive {url; checksum} ->
     Printf.sprintf "archive:%s#%s" url (Checksum.show checksum)
   | Dist LocalPath {path; manifest = None;} ->
     Printf.sprintf "path:%s" (showPath path)
   | Dist LocalPath {path; manifest = Some manifest;} ->
-    Printf.sprintf "path:%s/%s" (showPath path) (ManifestSpec.Filename.show manifest)
+    Printf.sprintf "path:%s/%s" (showPath path) (ManifestSpec.show manifest)
   | Dist NoSource -> "no-source:"
   | Link {path; manifest = None;} ->
     Printf.sprintf "link:%s" (showPath path)
   | Link {path; manifest = Some manifest;} ->
-    Printf.sprintf "link:%s/%s" (showPath path) (ManifestSpec.Filename.show manifest)
+    Printf.sprintf "link:%s/%s" (showPath path) (ManifestSpec.show manifest)
 
 let show = show' ~showPath:DistPath.show
 let showPretty = show' ~showPath:DistPath.showPretty
@@ -54,7 +54,7 @@ module Parse = struct
     let make path =
       let path = Path.(normalizeAndRemoveEmptySeg (v path)) in
       let path, manifest =
-        match ManifestSpec.Filename.ofString (Path.basename path) with
+        match ManifestSpec.ofString (Path.basename path) with
         | Ok manifest ->
           let path = Path.(remEmptySeg (parent path)) in
           path, Some manifest

--- a/esy-install/Source.mli
+++ b/esy-install/Source.mli
@@ -15,7 +15,7 @@ val parse : string -> (t, string) result
 val parserRelaxed : t Parse.t
 val parseRelaxed : string -> (t, string) result
 
-val manifest : t -> ManifestSpec.Filename.t option
+val manifest : t -> ManifestSpec.t option
 val toDist : t -> Dist.t
 
 module Map : Map.S with type key := t

--- a/esy-install/SourceSpec.ml
+++ b/esy-install/SourceSpec.ml
@@ -8,13 +8,13 @@ type t =
   | Git of {
       remote : string;
       ref : string option;
-      manifest : ManifestSpec.Filename.t option;
+      manifest : ManifestSpec.t option;
     }
   | Github of {
       user : string;
       repo : string;
       ref : string option;
-      manifest : ManifestSpec.Filename.t option;
+      manifest : ManifestSpec.t option;
     }
   | LocalPath of Dist.local
   | NoSource
@@ -24,20 +24,20 @@ let show = function
   | Github {user; repo; ref = None; manifest = None;} ->
     Printf.sprintf "github:%s/%s" user repo
   | Github {user; repo; ref = None; manifest = Some manifest;} ->
-    Printf.sprintf "github:%s/%s:%s" user repo (ManifestSpec.Filename.show manifest)
+    Printf.sprintf "github:%s/%s:%s" user repo (ManifestSpec.show manifest)
   | Github {user; repo; ref = Some ref; manifest = None} ->
     Printf.sprintf "github:%s/%s#%s" user repo ref
   | Github {user; repo; ref = Some ref; manifest = Some manifest} ->
-    Printf.sprintf "github:%s/%s:%s#%s" user repo (ManifestSpec.Filename.show manifest) ref
+    Printf.sprintf "github:%s/%s:%s#%s" user repo (ManifestSpec.show manifest) ref
 
   | Git {remote; ref = None; manifest = None;} ->
     Printf.sprintf "git:%s" remote
   | Git {remote; ref = None; manifest = Some manifest;} ->
-    Printf.sprintf "git:%s:%s" remote (ManifestSpec.Filename.show manifest)
+    Printf.sprintf "git:%s:%s" remote (ManifestSpec.show manifest)
   | Git {remote; ref = Some ref; manifest = None} ->
     Printf.sprintf "git:%s#%s" remote ref
   | Git {remote; ref = Some ref; manifest = Some manifest} ->
-    Printf.sprintf "git:%s:%s#%s" remote (ManifestSpec.Filename.show manifest) ref
+    Printf.sprintf "git:%s:%s#%s" remote (ManifestSpec.show manifest) ref
 
   | Archive {url; checksum = Some checksum} ->
     Printf.sprintf "archive:%s#%s" url (Checksum.show checksum)
@@ -47,7 +47,7 @@ let show = function
   | LocalPath {path; manifest = None;} ->
     Printf.sprintf "path:%s" (DistPath.show path)
   | LocalPath {path; manifest = Some manifest;} ->
-    Printf.sprintf "path:%s/%s" (DistPath.show path) (ManifestSpec.Filename.show manifest)
+    Printf.sprintf "path:%s/%s" (DistPath.show path) (ManifestSpec.show manifest)
 
   | NoSource -> "no-source:"
 
@@ -73,7 +73,7 @@ module Parse = struct
   include Parse
 
   let manifestFilenameBeforeSharp =
-    till (fun c -> c <> '#') ManifestSpec.Filename.parser
+    till (fun c -> c <> '#') ManifestSpec.parser
 
   let collectString xs =
     let l = List.length xs in
@@ -134,7 +134,7 @@ module Parse = struct
     let make path =
       let path = Path.(normalizeAndRemoveEmptySeg (v path)) in
       let path, manifest =
-        match ManifestSpec.Filename.ofString (Path.basename path) with
+        match ManifestSpec.ofString (Path.basename path) with
         | Ok manifest ->
           let path = Path.(remEmptySeg (parent path)) in
           path, Some manifest

--- a/esy-install/SourceSpec.mli
+++ b/esy-install/SourceSpec.mli
@@ -11,13 +11,13 @@ type t =
   | Git of {
       remote : string;
       ref : string option;
-      manifest : ManifestSpec.Filename.t option;
+      manifest : ManifestSpec.t option;
     }
   | Github of {
       user : string;
       repo : string;
       ref : string option;
-      manifest : ManifestSpec.Filename.t option;
+      manifest : ManifestSpec.t option;
     }
   | LocalPath of Dist.local
   | NoSource

--- a/esy-lib/RunAsync.ml
+++ b/esy-lib/RunAsync.ml
@@ -117,8 +117,17 @@ module List = struct
   let mapAndWait ?concurrency ~f xs =
     waitAll (List.map ~f:(limitWithConccurrency concurrency f) xs)
 
-  let mapAndJoin ?concurrency ~f xs =
+  let map ?concurrency ~f xs =
     joinAll (List.map ~f:(limitWithConccurrency concurrency f) xs)
+
+  let filter ?concurrency ~f xs =
+    let open Syntax in
+    let f x = if%bind f x then return (Some x) else return None in
+    let f = limitWithConccurrency concurrency f in
+    let%bind xs = joinAll (List.map ~f xs) in
+    return (List.filterNone xs)
+
+  let mapAndJoin = map
 
   let rec processSeq ~f =
     let open Syntax in

--- a/esy-lib/RunAsync.mli
+++ b/esy-lib/RunAsync.mli
@@ -109,17 +109,29 @@ module List : sig
     -> 'b list
     -> 'a t
 
-  val mapAndWait :
+  val filter :
     ?concurrency:int
-    -> f:('a -> unit t)
+    -> f:('a -> bool t)
     -> 'a list
-    -> unit t
+    -> 'a list t
+
+  val map :
+    ?concurrency:int
+    -> f:('a -> 'b t)
+    -> 'a list
+    -> 'b list t
 
   val mapAndJoin :
     ?concurrency:int
     -> f:('a -> 'b t)
     -> 'a list
     -> 'b list t
+
+  val mapAndWait :
+    ?concurrency:int
+    -> f:('a -> unit t)
+    -> 'a list
+    -> unit t
 
   val waitAll : unit t list -> unit t
   val joinAll : 'a t list -> 'a list t

--- a/esy-solve/Config.re
+++ b/esy-solve/Config.re
@@ -51,30 +51,6 @@ let make =
       ),
     );
 
-  let sourcePath =
-    switch (cacheSourcesPath) {
-    | Some(path) => path
-    | None => Path.(cachePath / "source")
-    };
-  let%bind () = Fs.createDir(sourcePath);
-
-  let%bind sourceArchivePath =
-    switch (cacheTarballsPath) {
-    | Some(path) =>
-      let%bind () = Fs.createDir(path);
-      return(Some(path));
-    | None => return(None)
-    };
-
-  let sourceFetchPath = Path.(sourcePath / "f");
-  let%bind () = Fs.createDir(sourceFetchPath);
-
-  let sourceStagePath = Path.(sourcePath / "s");
-  let%bind () = Fs.createDir(sourceStagePath);
-
-  let sourceInstallPath = Path.(sourcePath / "i");
-  let%bind () = Fs.createDir(sourceInstallPath);
-
   let opamRepository = {
     let defaultRemote = "https://github.com/ocaml/opam-repository";
     let defaultLocal = Path.(cachePath / "opam-repository");
@@ -90,12 +66,13 @@ let make =
   let npmRegistry =
     Option.orDefault(~default="http://registry.npmjs.org/", npmRegistry);
 
-  let installCfg = {
-    EsyInstall.Config.sourceArchivePath,
-    sourceFetchPath,
-    sourceStagePath,
-    sourceInstallPath,
-  };
+  let%bind installCfg =
+    EsyInstall.Config.make(
+      ~cachePath,
+      ~cacheTarballsPath?,
+      ~cacheSourcesPath?,
+      (),
+    );
 
   return({
     installCfg,

--- a/esy-solve/Config.rei
+++ b/esy-solve/Config.rei
@@ -1,14 +1,15 @@
 /** Configuration for esy installer */
 
-type t = {
-  installCfg: EsyInstall.Config.t,
-  esySolveCmd: Cmd.t,
-  esyOpamOverride: checkout,
-  opamRepository: checkout,
-  npmRegistry: string,
-  solveTimeout: float,
-  skipRepositoryUpdate: bool,
-}
+type t =
+  pri {
+    installCfg: EsyInstall.Config.t,
+    esySolveCmd: Cmd.t,
+    esyOpamOverride: checkout,
+    opamRepository: checkout,
+    npmRegistry: string,
+    solveTimeout: float,
+    skipRepositoryUpdate: bool,
+  }
 /** This described how a reposoitory should be used */
 and checkout =
   | Local(Path.t)

--- a/esy-solve/Resolver.ml
+++ b/esy-solve/Resolver.ml
@@ -223,7 +223,7 @@ let packageOfSource ~name ~overrides (source : EsyInstall.Source.t) resolver =
   let readPackage ~name ~source {EsyInstall.DistResolver. kind; filename = _; data; suggestedPackageName} =
     let open RunAsync.Syntax in
     match kind with
-    | EsyInstall.ManifestSpec.Filename.Esy ->
+    | EsyInstall.ManifestSpec.Esy ->
       let%bind pkg = RunAsync.ofRun (
         let open Run.Syntax in
         let%bind json = Json.parse data in
@@ -236,7 +236,7 @@ let packageOfSource ~name ~overrides (source : EsyInstall.Source.t) resolver =
           json
       ) in
       return (Ok pkg)
-    | EsyInstall.ManifestSpec.Filename.Opam ->
+    | EsyInstall.ManifestSpec.Opam ->
       let%bind opamname = RunAsync.ofRun (
         ensureOpamName suggestedPackageName
       ) in

--- a/esy-solve/Sandbox.ml
+++ b/esy-solve/Sandbox.ml
@@ -1,3 +1,7 @@
+module Version = EsyInstall.Version
+module Source = EsyInstall.Source
+module PackageConfig = EsyInstall.PackageConfig
+
 type t = {
   cfg : Config.t;
   spec : EsyInstall.SandboxSpec.t;
@@ -8,161 +12,16 @@ type t = {
   resolver : Resolver.t;
 }
 
-let ocamlReqAny =
-  let spec = EsyInstall.VersionSpec.Npm EsyInstall.SemverVersion.Formula.any in
-  EsyInstall.Req.make ~name:"ocaml" ~spec
+let makeResolution source = {
+  EsyInstall.PackageConfig.Resolution.
+  name = "root";
+  resolution = Version (Version.Source source);
+}
 
-let ofMultiplOpamFiles ~cfg ~spec _projectPath (paths : Path.t list) =
+let ofResolution cfg spec resolver resolution =
   let open RunAsync.Syntax in
-
-  let%bind resolver = Resolver.make ~cfg ~sandbox:spec () in
-
-  let%bind opams =
-
-    let readOpam (path : Path.t) =
-      let%bind data = Fs.readFile path in
-      if String.trim data = ""
-      then return None
-      else
-        let name = Path.(path |> remExt |> basename) in
-        let%bind manifest =
-          let version = OpamPackage.Version.of_string "dev" in
-          OpamManifest.ofPath ~name:(OpamPackage.Name.of_string name) ~version path
-        in
-        return (Some (name, manifest, path))
-    in
-
-    let%bind opams =
-      paths
-      |> List.map ~f:readOpam
-      |> RunAsync.List.joinAll
-    in
-
-    return (List.filterNone opams)
-  in
-
-  let namesPresent =
-    let f names (name, _, _) = StringSet.add ("@opam/" ^ name) names in
-    List.fold_left ~f ~init:StringSet.empty opams
-  in
-
-  let filterFormulaWithNamesPresent (deps : Package.Dep.t list list) =
-    let filterDep (dep : Package.Dep.t) = not (StringSet.mem dep.name namesPresent) in
-    let filterDisj deps =
-      match List.filter ~f:filterDep deps with
-      | [] -> None
-      | f -> Some f
-    in
-    deps
-    |> List.map ~f:filterDisj
-    |> List.filterNone
-  in
-
-  let source = EsyInstall.Source.Link {
-    path = EsyInstall.DistPath.v ".";
-    manifest = None;
-  } in
-  let version = EsyInstall.Version.Source source in
-
-  match opams with
-  | [] ->
-    let dependencies = Package.Dependencies.NpmFormula [] in
-    return {
-      cfg;
-      spec;
-      root = {
-        name = "empty";
-        version;
-        originalVersion = None;
-        originalName = None;
-        source = EsyInstall.PackageSource.Link {
-          path = EsyInstall.DistPath.v ".";
-          manifest = None;
-        };
-        overrides = EsyInstall.Overrides.empty;
-        dependencies;
-        devDependencies = dependencies;
-        peerDependencies = EsyInstall.PackageConfig.NpmFormula.empty;
-        optDependencies = StringSet.empty;
-        resolutions = EsyInstall.PackageConfig.Resolutions.empty;
-        kind = Esy;
-      };
-      resolver;
-      resolutions = EsyInstall.PackageConfig.Resolutions.empty;
-      dependencies = Package.Dependencies.NpmFormula [];
-      ocamlReq = Some ocamlReqAny;
-    }
-  | opams ->
-    let%bind pkgs =
-      let f (name, opam, _) =
-        match%bind OpamManifest.toPackage ~name ~version opam with
-        | Ok pkg -> return pkg
-        | Error err -> error err
-      in
-      RunAsync.List.joinAll (List.map ~f opams)
-    in
-    let dependencies, devDependencies =
-      let f (dependencies, devDependencies) (pkg : Package.t) =
-        match pkg.dependencies, pkg.devDependencies with
-        | Package.Dependencies.OpamFormula du, Package.Dependencies.OpamFormula ddu ->
-          (filterFormulaWithNamesPresent du) @ dependencies,
-          (filterFormulaWithNamesPresent ddu) @ devDependencies
-        | _ -> assert false
-      in
-      List.fold_left ~f ~init:([], []) pkgs
-    in
-    let root = {
-      Package.
-      name = "root";
-      version;
-      originalVersion = None;
-      originalName = None;
-      source = EsyInstall.PackageSource.Link {
-        path = EsyInstall.DistPath.v ".";
-        manifest = None;
-      };
-      overrides = EsyInstall.Overrides.empty;
-      dependencies = Package.Dependencies.OpamFormula dependencies;
-      devDependencies = Package.Dependencies.OpamFormula devDependencies;
-      peerDependencies = EsyInstall.PackageConfig.NpmFormula.empty;
-      optDependencies = StringSet.empty;
-      resolutions = EsyInstall.PackageConfig.Resolutions.empty;
-      kind = Package.Esy;
-    } in
-
-    let dependencies =
-      Package.Dependencies.OpamFormula (dependencies @ devDependencies)
-    in
-
-    return {
-      cfg;
-      spec;
-      root;
-      resolutions = EsyInstall.PackageConfig.Resolutions.empty;
-      resolver;
-      dependencies;
-      ocamlReq = Some ocamlReqAny;
-    }
-
-let ofSource ~cfg ~spec source =
-  let open RunAsync.Syntax in
-
-  let%bind resolution =
-    let version = EsyInstall.Version.Source source in
-    return {
-      EsyInstall.PackageConfig.Resolution.
-      name = "root";
-      resolution = Version version;
-    }
-  in
-
-  let%bind resolver =
-    Resolver.make ~cfg ~sandbox:spec ()
-  in
-
   match%bind Resolver.package ~resolution resolver with
   | Ok root ->
-
     let root =
       let name =
         match root.Package.originalName with
@@ -186,8 +45,6 @@ let ofSource ~cfg ~spec source =
         failwith "mixing npm and opam dependencies"
     in
 
-    Resolver.setResolutions root.resolutions resolver;
-
     return {
       cfg;
       spec;
@@ -199,17 +56,76 @@ let ofSource ~cfg ~spec source =
     }
   | Error msg -> errorf "unable to construct sandbox: %s" msg
 
+let anyOpam = EsyInstall.VersionSpec.Opam (EsyInstall.OpamPackageVersion.Formula.any)
+
 let make ~cfg (spec : EsyInstall.SandboxSpec.t) =
+  let open RunAsync.Syntax in
+  let path = EsyInstall.DistPath.make ~base:spec.path spec.path in
+  let makeSource manifest =
+    Source.Link {path; manifest = Some manifest;}
+  in
   RunAsync.contextf (
+    let%bind resolver = Resolver.make ~cfg ~sandbox:spec () in
     match spec.manifest with
-    | EsyInstall.SandboxSpec.Manifest (Esy, fname)
-    | EsyInstall.SandboxSpec.Manifest (Opam, fname) ->
-      let source = "link:" ^ fname in
-      begin match EsyInstall.Source.parse source with
-      | Ok source -> ofSource ~cfg ~spec source
-      | Error msg -> RunAsync.errorf "unable to construct sandbox: %s" msg
-      end
-    | EsyInstall.SandboxSpec.ManifestAggregate _ ->
-      let paths = EsyInstall.SandboxSpec.manifestPaths spec in
-      ofMultiplOpamFiles ~cfg ~spec spec.path paths
+    | EsyInstall.SandboxSpec.Manifest manifest ->
+      let source = makeSource manifest in
+      let resolution = makeResolution source in
+      let%bind sandbox = ofResolution cfg spec resolver resolution in
+      Resolver.setResolutions sandbox.resolutions sandbox.resolver;
+      return sandbox
+    | EsyInstall.SandboxSpec.ManifestAggregate manifests ->
+      let%bind resolutions, reqs, devDeps =
+        let f (resolutions, reqs, devDeps) manifest  =
+          let source = makeSource manifest in
+          let resolution = makeResolution source in
+          match%bind Resolver.package ~resolution resolver with
+          | Error msg -> errorf "unable to read %a: %s" EsyInstall.ManifestSpec.pp manifest msg
+          | Ok pkg ->
+            let name =
+              match EsyInstall.ManifestSpec.inferPackageName manifest with
+              | None -> failwith "TODO"
+              | Some name -> name
+            in
+            let resolutions =
+              let resolution = PackageConfig.Resolution.Version (EsyInstall.Version.Source source) in
+              PackageConfig.Resolutions.add name resolution resolutions
+            in
+            let reqs = (EsyInstall.Req.make ~name ~spec:anyOpam)::reqs in
+            let devDeps =
+              match pkg.Package.devDependencies with
+              | Package.Dependencies.OpamFormula deps -> deps @ devDeps
+              | Package.Dependencies.NpmFormula _ -> devDeps
+            in
+            return (resolutions, reqs, devDeps)
+        in
+        RunAsync.List.foldLeft ~f ~init:(PackageConfig.Resolutions.empty, [], []) manifests
+      in
+      Resolver.setResolutions resolutions resolver;
+      let root = {
+        Package.
+        name = Path.basename spec.path;
+        version = EsyInstall.Version.Source (Dist NoSource);
+        originalVersion = None;
+        originalName = None;
+        source = EsyInstall.PackageSource.Install {
+          source = NoSource, [];
+          opam = None;
+        };
+        overrides = EsyInstall.Overrides.empty;
+        dependencies = Package.Dependencies.NpmFormula reqs;
+        devDependencies = Package.Dependencies.OpamFormula devDeps;
+        peerDependencies = EsyInstall.PackageConfig.NpmFormula.empty;
+        optDependencies = StringSet.empty;
+        resolutions;
+        kind = Npm;
+      } in
+      return {
+        cfg;
+        spec;
+        root;
+        resolutions = root.resolutions;
+        ocamlReq = None;
+        dependencies = Package.Dependencies.NpmFormula reqs;
+        resolver;
+      }
   ) "loading root package metadata"

--- a/esy-solve/Sandbox.ml
+++ b/esy-solve/Sandbox.ml
@@ -200,19 +200,16 @@ let ofSource ~cfg ~spec source =
   | Error msg -> errorf "unable to construct sandbox: %s" msg
 
 let make ~cfg (spec : EsyInstall.SandboxSpec.t) =
-  let open RunAsync.Syntax in
-
   RunAsync.contextf (
     match spec.manifest with
-    | EsyInstall.ManifestSpec.One (Esy, fname)
-    | EsyInstall.ManifestSpec.One (Opam, fname) ->
+    | EsyInstall.SandboxSpec.Manifest (Esy, fname)
+    | EsyInstall.SandboxSpec.Manifest (Opam, fname) ->
       let source = "link:" ^ fname in
       begin match EsyInstall.Source.parse source with
       | Ok source -> ofSource ~cfg ~spec source
       | Error msg -> RunAsync.errorf "unable to construct sandbox: %s" msg
       end
-    | EsyInstall.ManifestSpec.ManyOpam ->
-      let%bind paths = EsyInstall.ManifestSpec.findManifestsAtPath spec.path spec.manifest in
-      let paths = List.map ~f:(fun (_, filename) -> Path.(spec.path / filename)) paths in
+    | EsyInstall.SandboxSpec.ManifestAggregate _ ->
+      let paths = EsyInstall.SandboxSpec.manifestPaths spec in
       ofMultiplOpamFiles ~cfg ~spec spec.path paths
   ) "loading root package metadata"

--- a/esy/BuildManifest.ml
+++ b/esy/BuildManifest.ml
@@ -296,10 +296,10 @@ let discoverManifest path =
   let filenames =
     let dirname = Path.basename path in
     [
-      ManifestSpec.Filename.Esy, "esy.json";
-      ManifestSpec.Filename.Esy, "package.json";
-      ManifestSpec.Filename.Opam, Path.(v dirname |> addExt ".opam" |> show);
-      ManifestSpec.Filename.Opam, "opam";
+      ManifestSpec.Esy, "esy.json";
+      ManifestSpec.Esy, "package.json";
+      ManifestSpec.Opam, Path.(v dirname |> addExt ".opam" |> show);
+      ManifestSpec.Opam, "opam";
     ]
   in
 
@@ -309,14 +309,14 @@ let discoverManifest path =
       Logs_lwt.debug (fun m ->
         m "trying %a %a"
         Path.pp path
-        ManifestSpec.Filename.pp (kind, fname)
+        ManifestSpec.pp (kind, fname)
       );%lwt
       let fname = Path.(path / fname) in
       if%bind Fs.exists fname
       then
         match kind with
-        | ManifestSpec.Filename.Esy -> EsyBuild.ofFile fname
-        | ManifestSpec.Filename.Opam -> OpamBuild.ofFile fname
+        | ManifestSpec.Esy -> EsyBuild.ofFile fname
+        | ManifestSpec.Opam -> OpamBuild.ofFile fname
       else tryLoad rest
   in
 
@@ -325,7 +325,7 @@ let discoverManifest path =
 let ofPath ?manifest (path : Path.t) =
   Logs_lwt.debug (fun m ->
     m "BuildManifest.ofPath %a %a"
-    Fmt.(option ManifestSpec.Filename.pp) manifest
+    Fmt.(option ManifestSpec.pp) manifest
     Path.pp path
   );%lwt
 
@@ -334,10 +334,10 @@ let ofPath ?manifest (path : Path.t) =
     | None -> discoverManifest path
     | Some spec ->
       begin match spec with
-      | ManifestSpec.Filename.Esy, fname ->
+      | ManifestSpec.Esy, fname ->
         let path = Path.(path / fname) in
         EsyBuild.ofFile path
-      | ManifestSpec.Filename.Opam, fname ->
+      | ManifestSpec.Opam, fname ->
         let path = Path.(path / fname) in
         OpamBuild.ofFile path
       end
@@ -361,9 +361,9 @@ let ofInstallationLocation ~cfg (pkg : Package.t) (loc : Installation.location) 
     let overrides = Overrides.merge pkg.overrides res.DistResolver.overrides in
     let%bind manifest =
       begin match res.DistResolver.manifest with
-      | Some {kind = ManifestSpec.Filename.Esy; filename = _; data; suggestedPackageName = _;} ->
+      | Some {kind = ManifestSpec.Esy; filename = _; data; suggestedPackageName = _;} ->
         RunAsync.ofRun (EsyBuild.ofData data)
-      | Some {kind = ManifestSpec.Filename.Opam; filename = _; data; suggestedPackageName;} ->
+      | Some {kind = ManifestSpec.Opam; filename = _; data; suggestedPackageName;} ->
         RunAsync.ofRun (OpamBuild.ofData ~nameFallback:(Some suggestedPackageName) data)
       | None ->
         let manifest = empty ~name:None ~version:None () in

--- a/esy/BuildManifest.ml
+++ b/esy/BuildManifest.ml
@@ -293,15 +293,10 @@ end
 let discoverManifest path =
   let open RunAsync.Syntax in
 
-  let filenames =
-    let dirname = Path.basename path in
-    [
-      ManifestSpec.Esy, "esy.json";
-      ManifestSpec.Esy, "package.json";
-      ManifestSpec.Opam, Path.(v dirname |> addExt ".opam" |> show);
-      ManifestSpec.Opam, "opam";
-    ]
-  in
+  let filenames = [
+    ManifestSpec.Esy, "esy.json";
+    ManifestSpec.Esy, "package.json";
+  ] in
 
   let rec tryLoad = function
     | [] -> return (None, Path.Set.empty)

--- a/esy/Config.mli
+++ b/esy/Config.mli
@@ -1,6 +1,6 @@
 (** Configuration *)
 
-type t = {
+type t = private {
   esyVersion : string;
   spec : EsyInstall.SandboxSpec.t;
   installCfg : EsyInstall.Config.t;

--- a/esy/SandboxEnv.ml
+++ b/esy/SandboxEnv.ml
@@ -20,11 +20,11 @@ let ofSandbox spec =
   let open RunAsync.Syntax in
   match spec.EsyInstall.SandboxSpec.manifest with
 
-  | EsyInstall.ManifestSpec.One (EsyInstall.ManifestSpec.Filename.Esy, filename) ->
+  | EsyInstall.SandboxSpec.Manifest (Esy, filename) ->
     let%bind json = Fs.readJsonFile Path.(spec.path / filename) in
     let%bind pkgJson = RunAsync.ofRun (Json.parseJsonWith OfPackageJson.of_yojson json) in
     return pkgJson.OfPackageJson.esy.sandboxEnv
 
-  | EsyInstall.ManifestSpec.One (EsyInstall.ManifestSpec.Filename.Opam, _)
-  | EsyInstall.ManifestSpec.ManyOpam ->
+  | EsyInstall.SandboxSpec.Manifest (Opam, _)
+  | EsyInstall.SandboxSpec.ManifestAggregate _ ->
     return BuildManifest.Env.empty

--- a/esy/Scripts.ml
+++ b/esy/Scripts.ml
@@ -44,11 +44,11 @@ let ofSandbox (spec : EsyInstall.SandboxSpec.t) =
   let open RunAsync.Syntax in
   match spec.manifest with
 
-  | EsyInstall.ManifestSpec.One (EsyInstall.ManifestSpec.Filename.Esy, filename) ->
+  | EsyInstall.SandboxSpec.Manifest (Esy, filename) ->
     let%bind json = Fs.readJsonFile Path.(spec.path / filename) in
     let%bind pkgJson = RunAsync.ofRun (Json.parseJsonWith OfPackageJson.of_yojson json) in
     return pkgJson.OfPackageJson.scripts
 
-  | EsyInstall.ManifestSpec.One (EsyInstall.ManifestSpec.Filename.Opam, _)
-  | EsyInstall.ManifestSpec.ManyOpam ->
+  | EsyInstall.SandboxSpec.Manifest (Opam, _)
+  | EsyInstall.SandboxSpec.ManifestAggregate _ ->
     return Scripts.empty

--- a/esy/bin/NpmReleaseCommand.ml
+++ b/esy/bin/NpmReleaseCommand.ml
@@ -72,10 +72,10 @@ let configure (cfg : Config.t) () =
   let open RunAsync.Syntax in
   let docs = "https://esy.sh/docs/release.html" in
   match cfg.spec.manifest with
-  | EsyInstall.ManifestSpec.ManyOpam
-  | EsyInstall.ManifestSpec.One (EsyInstall.ManifestSpec.Filename.Opam, _) ->
+  | EsyInstall.SandboxSpec.ManifestAggregate _
+  | EsyInstall.SandboxSpec.Manifest (Opam, _) ->
     errorf "could not create releases without package.json, see %s for details" docs
-  | EsyInstall.ManifestSpec.One (EsyInstall.ManifestSpec.Filename.Esy, filename) ->
+  | EsyInstall.SandboxSpec.Manifest (Esy, filename) ->
     let%bind json = Fs.readJsonFile Path.(cfg.spec.path / filename) in
     let%bind pkgJson = RunAsync.ofStringError (OfPackageJson.of_yojson json) in
     match pkgJson.OfPackageJson.esy.release with

--- a/esy/bin/NpmReleaseCommand.ml
+++ b/esy/bin/NpmReleaseCommand.ml
@@ -585,7 +585,7 @@ let make
   let%lwt () = Logs_lwt.app (fun m -> m "Done!") in
   return ()
 
-let run (proj : Project.WithWorkflow.t) () =
+let run (proj : Project.WithWorkflow.t) =
   let open RunAsync.Syntax in
 
   let%bind solved = Project.solved proj in

--- a/esy/bin/NpmReleaseCommand.mli
+++ b/esy/bin/NpmReleaseCommand.mli
@@ -1,1 +1,1 @@
-val run : Project.WithWorkflow.t -> unit -> unit RunAsync.t
+val run : Project.WithWorkflow.t -> unit RunAsync.t

--- a/esy/bin/Project.ml
+++ b/esy/bin/Project.ml
@@ -60,6 +60,7 @@ module type PROJECT = sig
   type t
 
   val make : ProjectConfig.t -> (t * FileInfo.t list) RunAsync.t
+  val setProjecyConfig : ProjectConfig.t -> t -> t
   val cachePath : ProjectConfig.t -> Path.t
   val writeAuxCache : t -> unit RunAsync.t
 end
@@ -91,6 +92,7 @@ end = struct
     let f ic =
       try%lwt
         let%lwt v, files = (Lwt_io.read_value ic : (P.t * FileInfo.t list) Lwt.t) in
+        let v = P.setProjecyConfig projcfg v in
         if%bind checkStaleness files
         then return None
         else return (Some v)
@@ -244,6 +246,7 @@ module WithoutWorkflow = struct
   include MakeProject(struct
     type nonrec t = t
     let make = make
+    let setProjecyConfig projcfg proj = {proj with projcfg;}
     let cachePath = makeCachePath "WithoutWorkflow"
     let writeAuxCache _ = RunAsync.return ()
   end)
@@ -375,6 +378,7 @@ module WithWorkflow = struct
   include MakeProject(struct
     type nonrec t = t
     let make = make
+    let setProjecyConfig projcfg proj = {proj with projcfg;}
     let cachePath = makeCachePath "WithWorkflow"
     let writeAuxCache = writeAuxCache
   end)

--- a/esy/bin/Project.ml
+++ b/esy/bin/Project.ml
@@ -184,7 +184,7 @@ let makeSolved makeFetched (projcfg : ProjectConfig.t) files =
   let%bind info = FileInfo.ofPath Path.(path / "index.json") in
   files := info::!files;
   let%bind checksum = ProjectConfig.computeSolutionChecksum projcfg in
-  match%bind SolutionLock.ofPath ~checksum ~sandbox:projcfg.sandbox path with
+  match%bind SolutionLock.ofPath ~checksum ~sandbox:projcfg.installSandbox path with
   | Some solution ->
     let%lwt fetched = makeFetched projcfg solution files in
     return {solution; fetched;}

--- a/esy/bin/Project.ml
+++ b/esy/bin/Project.ml
@@ -173,7 +173,7 @@ let configured proj = Lwt.return (
 let makeProject makeSolved projcfg =
   let open RunAsync.Syntax in
   let%bind files =
-    let%bind paths = SandboxSpec.manifestPaths projcfg.spec in
+    let paths = SandboxSpec.manifestPaths projcfg.spec in
     RunAsync.List.mapAndJoin ~f:FileInfo.ofPath paths
   in
   let files = ref files in

--- a/esy/bin/ProjectConfig.ml
+++ b/esy/bin/ProjectConfig.ml
@@ -7,8 +7,8 @@ type t = {
   installCfg : EsyInstall.Config.t;
   solveCfg : EsySolve.Config.t;
   spec : EsyInstall.SandboxSpec.t;
-  installSandbox : EsySolve.Sandbox.t;
-  sandbox : EsyInstall.Sandbox.t;
+  solveSandbox : EsySolve.Sandbox.t;
+  installSandbox : EsyInstall.Sandbox.t;
 }
 
 let findSandboxPathStartingWith currentPath =
@@ -187,7 +187,7 @@ let make
     )
   in
 
-  let%bind installSandbox =
+  let%bind solveSandbox =
     EsySolve.Sandbox.make ~cfg:solveCfg spec
   in
 
@@ -196,10 +196,10 @@ let make
     cfg;
     solveCfg;
     installCfg;
-    installSandbox;
-    sandbox = {
+    solveSandbox;
+    installSandbox = {
       EsyInstall.Sandbox.
-      cfg = installSandbox.cfg.installCfg;
+      cfg = solveSandbox.cfg.installCfg;
       spec;
     };
     spec;
@@ -208,7 +208,7 @@ let make
 let computeSolutionChecksum projcfg =
   let open RunAsync.Syntax in
 
-  let sandbox = projcfg.installSandbox in
+  let sandbox = projcfg.solveSandbox in
 
   let ppDependencies fmt deps =
 

--- a/esy/bin/ProjectConfig.ml
+++ b/esy/bin/ProjectConfig.ml
@@ -288,7 +288,7 @@ let promiseTerm sandboxPath =
     npmRegistry
     solveTimeout
     skipRepositoryUpdate
-    solveCudfCommand =
+    solveCudfCommand () =
     make
       sandboxPath
       mainprg
@@ -314,6 +314,7 @@ let promiseTerm sandboxPath =
     $ solveTimeoutArg
     $ skipRepositoryUpdateArg
     $ solveCudfCommandArg
+    $ Cli.setupLogTerm
   )
 
 let term sandboxPath =

--- a/esy/bin/ProjectConfig.ml
+++ b/esy/bin/ProjectConfig.ml
@@ -4,8 +4,6 @@ open Cmdliner
 type t = {
   mainprg : string;
   cfg : Config.t;
-  installCfg : EsyInstall.Config.t;
-  solveCfg : EsySolve.Config.t;
   spec : EsyInstall.SandboxSpec.t;
   solveSandbox : EsySolve.Sandbox.t;
   installSandbox : EsyInstall.Sandbox.t;
@@ -193,8 +191,6 @@ let make
   return {
     mainprg;
     cfg;
-    solveCfg;
-    installCfg;
     solveSandbox;
     installSandbox;
     spec;

--- a/esy/bin/ProjectConfig.ml
+++ b/esy/bin/ProjectConfig.ml
@@ -187,9 +187,8 @@ let make
     )
   in
 
-  let%bind solveSandbox =
-    EsySolve.Sandbox.make ~cfg:solveCfg spec
-  in
+  let%bind solveSandbox = EsySolve.Sandbox.make ~cfg:solveCfg spec in
+  let installSandbox = EsyInstall.Sandbox.make installCfg spec in
 
   return {
     mainprg;
@@ -197,11 +196,7 @@ let make
     solveCfg;
     installCfg;
     solveSandbox;
-    installSandbox = {
-      EsyInstall.Sandbox.
-      cfg = solveSandbox.cfg.installCfg;
-      spec;
-    };
+    installSandbox;
     spec;
   }
 

--- a/esy/bin/ProjectConfig.mli
+++ b/esy/bin/ProjectConfig.mli
@@ -11,8 +11,6 @@ open Esy
 type t = {
   mainprg : string;
   cfg : Config.t;
-  installCfg : EsyInstall.Config.t;
-  solveCfg : EsySolve.Config.t;
   spec : SandboxSpec.t;
   solveSandbox : EsySolve.Sandbox.t;
   installSandbox : EsyInstall.Sandbox.t;

--- a/esy/bin/ProjectConfig.mli
+++ b/esy/bin/ProjectConfig.mli
@@ -14,8 +14,8 @@ type t = {
   installCfg : EsyInstall.Config.t;
   solveCfg : EsySolve.Config.t;
   spec : SandboxSpec.t;
-  installSandbox : EsySolve.Sandbox.t;
-  sandbox : EsyInstall.Sandbox.t;
+  solveSandbox : EsySolve.Sandbox.t;
+  installSandbox : EsyInstall.Sandbox.t;
 }
 
 val computeSolutionChecksum : t -> string RunAsync.t

--- a/esy/bin/esyCommand.ml
+++ b/esy/bin/esyCommand.ml
@@ -852,8 +852,8 @@ let getSandboxSolution (projcfg : ProjectConfig.t) =
           m "resolution %a is unused (defined in %a)"
           Fmt.(quote string)
           resolution
-          EsyInstall.ManifestSpec.pp
-          projcfg.installSandbox.spec.manifest
+          EsyInstall.SandboxSpec.pp
+          projcfg.installSandbox.spec
       )
     in
     Lwt_list.iter_s log unused
@@ -948,9 +948,9 @@ let add (reqs : string list) (proj : Project.WithWorkflow.t) =
     let%bind path =
       let spec = projcfg.solveSandbox.Sandbox.spec in
       match spec.manifest with
-      | EsyInstall.ManifestSpec.One (Esy, fname) -> return Path.(spec.SandboxSpec.path / fname)
-      | One (Opam, _) -> error opamError
-      | ManyOpam -> error opamError
+      | EsyInstall.SandboxSpec.Manifest (Esy, fname) -> return Path.(spec.SandboxSpec.path / fname)
+      | Manifest (Opam, _) -> error opamError
+      | ManifestAggregate _ -> error opamError
       in
       return (addedDependencies, path)
     in

--- a/esy/bin/esyCommand.ml
+++ b/esy/bin/esyCommand.ml
@@ -1127,21 +1127,21 @@ let show _asJson req (projcfg : ProjectConfig.t) =
 let printHeader ?spec name =
   match spec with
   | Some spec ->
-    Logs.app (fun m -> m "%s %s (using %a)" name EsyRuntime.version EsyInstall.SandboxSpec.pp spec)
+    Logs_lwt.app (fun m -> m "%s %s (using %a)" name EsyRuntime.version EsyInstall.SandboxSpec.pp spec)
   | None ->
-    Logs.app (fun m -> m "%s %s" name EsyRuntime.version)
+    Logs_lwt.app (fun m -> m "%s %s" name EsyRuntime.version)
 
 let default cmd (proj : Project.WithWorkflow.t) =
   let open RunAsync.Syntax in
   let%lwt fetched = Project.fetched proj in
   match fetched, cmd with
   | Ok _, None ->
-    printHeader ~spec:proj.projcfg.spec "esy";
+    printHeader ~spec:proj.projcfg.spec "esy";%lwt
     build proj None ()
   | Ok _, Some cmd ->
     devExec proj cmd ()
   | Error _, None ->
-    printHeader ~spec:proj.projcfg.spec "esy";
+    printHeader ~spec:proj.projcfg.spec "esy";%lwt
     let%bind () = solveAndFetch proj in
     let%bind proj, _ = Project.WithWorkflow.make proj.projcfg in
     build proj None ()
@@ -1172,7 +1172,7 @@ let makeCommand
     let f comp =
       let () =
         match header with
-        | `Standard -> printHeader name
+        | `Standard -> Lwt_main.run (printHeader name)
         | `No -> ()
       in
       Cli.runAsyncToCmdlinerRet comp
@@ -1207,7 +1207,7 @@ let makeCommands ~sandbox () =
       let run cmd project =
         let () =
           match header with
-          | `Standard -> printHeader ~spec:project.Project.projcfg.spec name
+          | `Standard -> Lwt_main.run (printHeader ~spec:project.Project.projcfg.spec name)
           | `No -> ()
         in
         cmd project
@@ -1222,7 +1222,7 @@ let makeCommands ~sandbox () =
       let run cmd project =
         let () =
           match header with
-          | `Standard -> printHeader ~spec:project.Project.projcfg.spec name
+          | `Standard -> Lwt_main.run (printHeader ~spec:project.Project.projcfg.spec name)
           | `No -> ()
         in
         cmd project
@@ -1253,7 +1253,7 @@ let makeCommands ~sandbox () =
       let run cmd proj =
         let () =
           match cmd with
-          | None -> printHeader ~spec:proj.Project.projcfg.spec "esy build"
+          | None -> Lwt_main.run (printHeader ~spec:proj.Project.projcfg.spec "esy build")
           | Some _ -> ()
         in
         build ~buildOnly:true proj cmd ()

--- a/test-e2e/common/solve-errors.test.js
+++ b/test-e2e/common/solve-errors.test.js
@@ -55,7 +55,7 @@ describe('"esy solve" errors', function() {
     const err = await expectAndReturnRejection(p.esy('install --skip-repository-update'));
     expect(err.stderr.trim()).toEqual(
       outdent`
-      info install ${version}
+      info install ${version} (using package.json)
       info resolving esy packages: done
       info solving esy constraints: done
       error: No solution found:
@@ -99,7 +99,7 @@ describe('"esy solve" errors', function() {
     const err = await expectAndReturnRejection(p.esy('install --skip-repository-update'));
     expect(err.stderr.trim()).toEqual(
       outdent`
-      info install ${version}
+      info install ${version} (using package.json)
       info resolving esy packages: done
       info solving esy constraints: done
       error: No solution found:
@@ -167,7 +167,7 @@ describe('"esy solve" errors', function() {
     const err = await expectAndReturnRejection(p.esy('install --skip-repository-update'));
     expect(err.stderr.trim()).toEqual(
       outdent`
-      info install ${version}
+      info install ${version} (using package.json)
       info resolving esy packages: done
       info solving esy constraints: done
       error: No solution found:
@@ -226,7 +226,7 @@ describe('"esy solve" errors', function() {
     const err = await expectAndReturnRejection(p.esy('install --skip-repository-update'));
     expect(err.stderr.trim()).toEqual(
       outdent`
-      info install ${version}
+      info install ${version} (using package.json)
       info resolving esy packages: done
       info solving esy constraints: done
       error: No solution found:
@@ -280,7 +280,7 @@ describe('"esy solve" errors', function() {
     const err = await expectAndReturnRejection(p.esy('install --skip-repository-update'));
     expect(err.stderr.trim()).toEqual(
       outdent`
-      info install ${version}
+      info install ${version} (using package.json)
       info resolving esy packages: done
       info solving esy constraints: done
       error: No solution found:
@@ -321,7 +321,7 @@ describe('"esy solve" errors', function() {
     const err = await expectAndReturnRejection(p.esy('install --skip-repository-update'));
     expect(err.stderr.trim()).toEqual(
       outdent`
-      info install ${version}
+      info install ${version} (using package.json)
       info resolving esy packages: done
       info solving esy constraints: done
       error: No solution found:
@@ -353,7 +353,7 @@ describe('"esy solve" errors', function() {
     const err = await expectAndReturnRejection(p.esy('install --skip-repository-update'));
     expect(err.stderr.trim()).toEqual(
       outdent`
-      info install ${version}
+      info install ${version} (using package.json)
       info resolving esy packages: done
       info solving esy constraints: done
       error: No solution found:
@@ -385,7 +385,7 @@ describe('"esy solve" errors', function() {
     const err = await expectAndReturnRejection(p.esy('install --skip-repository-update'));
     expect(err.stderr.trim()).toEqual(
       outdent`
-      info install ${version}
+      info install ${version} (using package.json)
       error: path 'missing' does not exist
         resolving missing@path:missing
       esy: exiting due to errors above
@@ -470,7 +470,7 @@ describe('"resolutions" misconfiguration errors', function() {
     const err = await expectAndReturnRejection(p.esy('install --skip-repository-update'));
     expect(err.stderr.trim()).toEqual(
       outdent`
-      info install ${version}
+      info install ${version} (using package.json)
       error: somepath/pkg doesn't exist
         reading package metadata from link:somepath/pkg
       esy: exiting due to errors above
@@ -497,7 +497,7 @@ describe('"resolutions" misconfiguration errors', function() {
     const err = await expectAndReturnRejection(p.esy('install --skip-repository-update'));
     expect(err.stderr.trim()).toEqual(
       outdent`
-      info install ${version}
+      info install ${version} (using package.json)
       error: unable to read manifests from some.json
         reading package metadata from link:somepath/some.json
       esy: exiting due to errors above

--- a/test-e2e/complete/opam-sandbox.test.js
+++ b/test-e2e/complete/opam-sandbox.test.js
@@ -143,7 +143,7 @@ describe('complete flow for opam sandboxes', () => {
         outdent`
           opam-version: "1.2"
           build: [
-            ["false"]
+            ["true"]
           ]
           depends: [
             "ocaml"
@@ -157,7 +157,7 @@ describe('complete flow for opam sandboxes', () => {
         outdent`
           opam-version: "1.2"
           build: [
-            ["false"]
+            ["true"]
           ]
           depends: [
             "ocaml"
@@ -168,8 +168,6 @@ describe('complete flow for opam sandboxes', () => {
 
     const p = await createTestSandbox(...fixture);
     await p.esy('install --skip-repository-update');
-
-    // build shouldn't execute build commands from *.opam files
     await p.esy('build');
   });
 

--- a/test-e2e/esy-build/circular-deps-error.test.js
+++ b/test-e2e/esy-build/circular-deps-error.test.js
@@ -52,7 +52,7 @@ describe(`'esy build' command: circular dependency error`, () => {
     await p.esy('install');
     await expect(p.esy('build')).rejects.toMatchObject({
       stderr: outdent`
-        info esy build ${helpers.esyVersion}
+        info esy build ${helpers.esyVersion} (using package.json)
         error: found circular dependency on: dep@path:dep
           processing depOfDep@path:depOfDep
           processing dep@path:dep

--- a/test-e2e/esy-build/opam-sandbox.test.js
+++ b/test-e2e/esy-build/opam-sandbox.test.js
@@ -45,7 +45,7 @@ describe('build opam sandbox', () => {
         `
         opam-version: "1.2"
         build: [
-          ["false"]
+          ["true"]
         ]
         install: [
           ["true"]
@@ -57,7 +57,7 @@ describe('build opam sandbox', () => {
         `
         opam-version: "1.2"
         build: [
-          ["false"]
+          ["true"]
         ]
         install: [
           ["true"]

--- a/test-e2e/esy-install/offline.test.js
+++ b/test-e2e/esy-install/offline.test.js
@@ -47,7 +47,7 @@ describe('offline installation workflow', function() {
     await p.esy(`fetch --cache-tarballs-path ${tarballsPath}`);
   });
 
-  test('it can checks that cached tarballs are downloaded', async function() {
+  test('it checks that cached tarballs are downloaded', async function() {
     const p = await helpers.createTestSandbox();
 
     await p.fixture(


### PR DESCRIPTION
This cleans up sandbox init and CLI further:

- Make config types private: `EsyInstall.Config.t`, `EsySolve.Config.t` and `Esy.Config.t`.
- Add info about which manifests as used for the root:

  ```
  % esy
  info esy 0.4.8 (using package.json)
  ```

- Fix CLI to init logging eariler so we don't miss important logging before commands start running (configuration phase).

- Refactor `SandboxSpec.t` so we can merge `ManifestSpec.t` and `ManifestSpec.Filename.t`.

Then we refactor how we init sandbox for opam aggragte case `*.opam`: as we now have better support for monorepos instead of previusly creating a single aggregate package we create a set of package with an artificial root and all `*.opam` files linked to it. `*.opam` is now an autoconfigurable monorepo.