### PR TITLE
More test coverage and fixes for `Scope.t`

### DIFF
--- a/esy/Scope.ml
+++ b/esy/Scope.ml
@@ -561,6 +561,13 @@ let toOpamEnv ~buildIsInProgress (scope : t) (name : OpamVariable.Full.t) =
     | _ -> name
   in
 
+  let ensurehasOpamScope name =
+    match Astring.String.cut ~sep:"@opam/" name with
+    | Some ("", _) -> name
+    | Some _
+    | None -> "@opam/" ^ name
+  in
+
   let opamPackageScope ?namespace ~buildIsInProgress (scope : PackageScope.t) name =
     let opamname = opamname scope in
     let installPath =
@@ -656,7 +663,7 @@ let toOpamEnv ~buildIsInProgress (scope : t) (name : OpamVariable.Full.t) =
       | false -> Some (string "disable")
       end
     | name ->
-      if namespace = scope.pkg.name
+      if namespace = ensurehasOpamScope scope.pkg.name
       then opamPackageScope ~buildIsInProgress ~namespace scope.self name
       else
         begin match StringMap.find_opt namespace scope.directDependencies with

--- a/esy/Scope.ml
+++ b/esy/Scope.ml
@@ -346,7 +346,7 @@ let add ~direct ~dep scope =
     let directDependencies =
       if direct
       then
-        let name = PackageScope.name dep.self in
+        let name = dep.pkg.name in
         StringMap.add name dep scope.directDependencies
       else scope.directDependencies
     in
@@ -355,7 +355,7 @@ let add ~direct ~dep scope =
     {scope with directDependencies; dependencies; children}
   | true, Some false ->
     let directDependencies =
-      let name = PackageScope.name dep.self in
+      let name = dep.pkg.name in
       StringMap.add name dep scope.directDependencies
     in
     let children = Id.Map.add dep.pkg.id direct scope.children in
@@ -478,8 +478,9 @@ let env ~includeBuildEnv ~buildIsInProgress scope =
 
   let%bind dependenciesEnv =
     let f env dep =
-      let name = PackageScope.name dep.self in
-      if StringMap.mem name scope.directDependencies
+      let name = dep.pkg.name in
+      let isDirect = StringMap.mem name scope.directDependencies in
+      if isDirect
       then
         let%bind g = exportedEnvGlobal dep in
         let%bind l = exportedEnvLocal dep in
@@ -655,7 +656,7 @@ let toOpamEnv ~buildIsInProgress (scope : t) (name : OpamVariable.Full.t) =
       | false -> Some (string "disable")
       end
     | name ->
-      if namespace = PackageScope.name scope.self
+      if namespace = scope.pkg.name
       then opamPackageScope ~buildIsInProgress ~namespace scope.self name
       else
         begin match StringMap.find_opt namespace scope.directDependencies with

--- a/test-e2e/esy-build/__snapshots__/no-deps.test.js.snap
+++ b/test-e2e/esy-build/__snapshots__/no-deps.test.js.snap
@@ -14,8 +14,6 @@ exports[`'esy build': simple executable with no deps out of source build macos |
 #
 # Built-in
 #
-export OCAMLFIND_LDCONF=\\"ignore\\"
-export OCAMLFIND_DESTDIR=\\"%projectPath%/_esy/default/store/i/%id%/lib\\"
 export cur__etc=\\"%projectPath%/_esy/default/store/i/%id%/etc\\"
 export cur__share=\\"%projectPath%/_esy/default/store/i/%id%/share\\"
 export cur__toplevel=\\"%projectPath%/_esy/default/store/i/%id%/toplevel\\"
@@ -32,6 +30,8 @@ export cur__root=\\"%projectPath%\\"
 export cur__dev=\\"true\\"
 export cur__version=\\"1.0.0\\"
 export cur__name=\\"no-deps\\"
+export OCAMLFIND_LDCONF=\\"ignore\\"
+export OCAMLFIND_DESTDIR=\\"%projectPath%/_esy/default/store/i/%id%/lib\\"
 export DUNE_BUILD_DIR=\\"%projectPath%/_esy/default/store/b/%id%\\"
 export SHELL=\\"env -i /bin/bash --norc --noprofile\\"
 export PATH=\\"$PATH:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\""

--- a/test-e2e/esy-build/__snapshots__/optDependencies.test.js.snap
+++ b/test-e2e/esy-build/__snapshots__/optDependencies.test.js.snap
@@ -12,6 +12,26 @@ exports[`Build with optDependencies builds w/ opt dependency installed snapshot 
 
 
 #
+# Built-in
+#
+export cur__etc=\\"%projectPath%/_esy/default/store/i/%id%/etc\\"
+export cur__share=\\"%projectPath%/_esy/default/store/i/%id%/share\\"
+export cur__toplevel=\\"%projectPath%/_esy/default/store/i/%id%/toplevel\\"
+export cur__stublibs=\\"%projectPath%/_esy/default/store/i/%id%/stublibs\\"
+export cur__doc=\\"%projectPath%/_esy/default/store/i/%id%/doc\\"
+export cur__man=\\"%projectPath%/_esy/default/store/i/%id%/man\\"
+export cur__lib=\\"%projectPath%/_esy/default/store/i/%id%/lib\\"
+export cur__sbin=\\"%projectPath%/_esy/default/store/i/%id%/sbin\\"
+export cur__bin=\\"%projectPath%/_esy/default/store/i/%id%/bin\\"
+export cur__install=\\"%projectPath%/_esy/default/store/i/%id%\\"
+export cur__target_dir=\\"%projectPath%/_esy/default/store/b/%id%\\"
+export cur__original_root=\\"%projectPath%\\"
+export cur__root=\\"%projectPath%\\"
+export cur__dev=\\"true\\"
+export cur__version=\\"1.0.0\\"
+export cur__name=\\"root\\"
+
+#
 # optDep@path:optDep@d41d8cd9
 #
 export CAML_LD_LIBRARY_PATH=\\"%esyStorePath%/i/%optdepid%/stublibs:%esyStorePath%/i/%optdepid%/lib/stublibs:$CAML_LD_LIBRARY_PATH\\"
@@ -32,22 +52,6 @@ export PATH=\\"%esyStorePath%/i/%depid%/bin:$PATH\\"
 #
 export OCAMLFIND_LDCONF=\\"ignore\\"
 export OCAMLFIND_DESTDIR=\\"%projectPath%/_esy/default/store/i/%id%/lib\\"
-export cur__etc=\\"%projectPath%/_esy/default/store/i/%id%/etc\\"
-export cur__share=\\"%projectPath%/_esy/default/store/i/%id%/share\\"
-export cur__toplevel=\\"%projectPath%/_esy/default/store/i/%id%/toplevel\\"
-export cur__stublibs=\\"%projectPath%/_esy/default/store/i/%id%/stublibs\\"
-export cur__doc=\\"%projectPath%/_esy/default/store/i/%id%/doc\\"
-export cur__man=\\"%projectPath%/_esy/default/store/i/%id%/man\\"
-export cur__lib=\\"%projectPath%/_esy/default/store/i/%id%/lib\\"
-export cur__sbin=\\"%projectPath%/_esy/default/store/i/%id%/sbin\\"
-export cur__bin=\\"%projectPath%/_esy/default/store/i/%id%/bin\\"
-export cur__install=\\"%projectPath%/_esy/default/store/i/%id%\\"
-export cur__target_dir=\\"%projectPath%/_esy/default/store/b/%id%\\"
-export cur__original_root=\\"%projectPath%\\"
-export cur__root=\\"%projectPath%\\"
-export cur__dev=\\"true\\"
-export cur__version=\\"1.0.0\\"
-export cur__name=\\"root\\"
 export DUNE_BUILD_DIR=\\"%projectPath%/_esy/default/store/b/%id%\\"
 export SHELL=\\"env -i /bin/bash --norc --noprofile\\"
 export PATH=\\"$PATH:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\""
@@ -65,18 +69,8 @@ exports[`Build with optDependencies builds w/ opt dependency installed snapshot 
 
 
 #
-# optDep@path:optDep@d41d8cd9
-#
-export CAML_LD_LIBRARY_PATH=\\"%esyStorePath%/i/%optdepid%/stublibs:%esyStorePath%/i/%optdepid%/lib/stublibs:$CAML_LD_LIBRARY_PATH\\"
-export OCAMLPATH=\\"%esyStorePath%/i/%optdepid%/lib:$OCAMLPATH\\"
-export MAN_PATH=\\"%esyStorePath%/i/%optdepid%/man:$MAN_PATH\\"
-export PATH=\\"%esyStorePath%/i/%optdepid%/bin:$PATH\\"
-
-#
 # Built-in
 #
-export OCAMLFIND_LDCONF=\\"ignore\\"
-export OCAMLFIND_DESTDIR=\\"%esyStorePath%/s/%id%/lib\\"
 export cur__etc=\\"%esyStorePath%/s/%id%/etc\\"
 export cur__share=\\"%esyStorePath%/s/%id%/share\\"
 export cur__toplevel=\\"%esyStorePath%/s/%id%/toplevel\\"
@@ -93,6 +87,20 @@ export cur__root=\\"%esyPrefixPath%/esyi/source/i/dep__5d502355\\"
 export cur__dev=\\"false\\"
 export cur__version=\\"1.0.0\\"
 export cur__name=\\"dep\\"
+
+#
+# optDep@path:optDep@d41d8cd9
+#
+export CAML_LD_LIBRARY_PATH=\\"%esyStorePath%/i/%optdepid%/stublibs:%esyStorePath%/i/%optdepid%/lib/stublibs:$CAML_LD_LIBRARY_PATH\\"
+export OCAMLPATH=\\"%esyStorePath%/i/%optdepid%/lib:$OCAMLPATH\\"
+export MAN_PATH=\\"%esyStorePath%/i/%optdepid%/man:$MAN_PATH\\"
+export PATH=\\"%esyStorePath%/i/%optdepid%/bin:$PATH\\"
+
+#
+# Built-in
+#
+export OCAMLFIND_LDCONF=\\"ignore\\"
+export OCAMLFIND_DESTDIR=\\"%esyStorePath%/s/%id%/lib\\"
 export DUNE_BUILD_DIR=\\"%esyStorePath%/b/%id%\\"
 export SHELL=\\"env -i /bin/bash --norc --noprofile\\"
 export PATH=\\"$PATH:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\""
@@ -110,18 +118,8 @@ exports[`Build with optDependencies builds w/o opt dependency installed snapshot
 
 
 #
-# dep@path:dep@d41d8cd9
-#
-export CAML_LD_LIBRARY_PATH=\\"%esyStorePath%/i/%depid%/stublibs:%esyStorePath%/i/%depid%/lib/stublibs:$CAML_LD_LIBRARY_PATH\\"
-export OCAMLPATH=\\"%esyStorePath%/i/%depid%/lib:$OCAMLPATH\\"
-export MAN_PATH=\\"%esyStorePath%/i/%depid%/man:$MAN_PATH\\"
-export PATH=\\"%esyStorePath%/i/%depid%/bin:$PATH\\"
-
-#
 # Built-in
 #
-export OCAMLFIND_LDCONF=\\"ignore\\"
-export OCAMLFIND_DESTDIR=\\"%projectPath%/_esy/default/store/i/%id%/lib\\"
 export cur__etc=\\"%projectPath%/_esy/default/store/i/%id%/etc\\"
 export cur__share=\\"%projectPath%/_esy/default/store/i/%id%/share\\"
 export cur__toplevel=\\"%projectPath%/_esy/default/store/i/%id%/toplevel\\"
@@ -138,6 +136,20 @@ export cur__root=\\"%projectPath%\\"
 export cur__dev=\\"true\\"
 export cur__version=\\"1.0.0\\"
 export cur__name=\\"root\\"
+
+#
+# dep@path:dep@d41d8cd9
+#
+export CAML_LD_LIBRARY_PATH=\\"%esyStorePath%/i/%depid%/stublibs:%esyStorePath%/i/%depid%/lib/stublibs:$CAML_LD_LIBRARY_PATH\\"
+export OCAMLPATH=\\"%esyStorePath%/i/%depid%/lib:$OCAMLPATH\\"
+export MAN_PATH=\\"%esyStorePath%/i/%depid%/man:$MAN_PATH\\"
+export PATH=\\"%esyStorePath%/i/%depid%/bin:$PATH\\"
+
+#
+# Built-in
+#
+export OCAMLFIND_LDCONF=\\"ignore\\"
+export OCAMLFIND_DESTDIR=\\"%projectPath%/_esy/default/store/i/%id%/lib\\"
 export DUNE_BUILD_DIR=\\"%projectPath%/_esy/default/store/b/%id%\\"
 export SHELL=\\"env -i /bin/bash --norc --noprofile\\"
 export PATH=\\"$PATH:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\""
@@ -157,8 +169,6 @@ exports[`Build with optDependencies builds w/o opt dependency installed snapshot
 #
 # Built-in
 #
-export OCAMLFIND_LDCONF=\\"ignore\\"
-export OCAMLFIND_DESTDIR=\\"%esyStorePath%/s/%id%/lib\\"
 export cur__etc=\\"%esyStorePath%/s/%id%/etc\\"
 export cur__share=\\"%esyStorePath%/s/%id%/share\\"
 export cur__toplevel=\\"%esyStorePath%/s/%id%/toplevel\\"
@@ -175,6 +185,8 @@ export cur__root=\\"%esyPrefixPath%/esyi/source/i/dep__5d502355\\"
 export cur__dev=\\"false\\"
 export cur__version=\\"1.0.0\\"
 export cur__name=\\"dep\\"
+export OCAMLFIND_LDCONF=\\"ignore\\"
+export OCAMLFIND_DESTDIR=\\"%esyStorePath%/s/%id%/lib\\"
 export DUNE_BUILD_DIR=\\"%esyStorePath%/b/%id%\\"
 export SHELL=\\"env -i /bin/bash --norc --noprofile\\"
 export PATH=\\"$PATH:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\""

--- a/test-e2e/esy-build/__snapshots__/with-dep.test.js.snap
+++ b/test-e2e/esy-build/__snapshots__/with-dep.test.js.snap
@@ -12,18 +12,8 @@ exports[`Build with dep out of source build macos || linux: build-env dep snapsh
 
 
 #
-# depOfDep@path:depOfDep@d41d8cd9
-#
-export CAML_LD_LIBRARY_PATH=\\"%esyStorePath%/i/%depOfDepId%/stublibs:%esyStorePath%/i/%depOfDepId%/lib/stublibs:$CAML_LD_LIBRARY_PATH\\"
-export OCAMLPATH=\\"%esyStorePath%/i/%depOfDepId%/lib:$OCAMLPATH\\"
-export MAN_PATH=\\"%esyStorePath%/i/%depOfDepId%/man:$MAN_PATH\\"
-export PATH=\\"%esyStorePath%/i/%depOfDepId%/bin:$PATH\\"
-
-#
 # Built-in
 #
-export OCAMLFIND_LDCONF=\\"ignore\\"
-export OCAMLFIND_DESTDIR=\\"%esyStorePath%/s/%id%/lib\\"
 export cur__etc=\\"%esyStorePath%/s/%id%/etc\\"
 export cur__share=\\"%esyStorePath%/s/%id%/share\\"
 export cur__toplevel=\\"%esyStorePath%/s/%id%/toplevel\\"
@@ -40,6 +30,24 @@ export cur__root=\\"%esyPrefixPath%/esyi/source/i/dep__5d502355\\"
 export cur__dev=\\"false\\"
 export cur__version=\\"1.0.0\\"
 export cur__name=\\"dep\\"
+
+#
+# depOfDep@path:depOfDep@d41d8cd9
+#
+export depOfDep__local=\\"depOfDep__local\\"
+export depOfDep__local_dyn=\\"depOfDep__local_dyn:$cur__name\\"
+export depOfDep__global=\\"depOfDep__global\\"
+export depOfDep__global_dyn=\\"depOfDep__global_dyn:$cur__name\\"
+export CAML_LD_LIBRARY_PATH=\\"%esyStorePath%/i/%depOfDepId%/stublibs:%esyStorePath%/i/%depOfDepId%/lib/stublibs:$CAML_LD_LIBRARY_PATH\\"
+export OCAMLPATH=\\"%esyStorePath%/i/%depOfDepId%/lib:$OCAMLPATH\\"
+export MAN_PATH=\\"%esyStorePath%/i/%depOfDepId%/man:$MAN_PATH\\"
+export PATH=\\"%esyStorePath%/i/%depOfDepId%/bin:$PATH\\"
+
+#
+# Built-in
+#
+export OCAMLFIND_LDCONF=\\"ignore\\"
+export OCAMLFIND_DESTDIR=\\"%esyStorePath%/s/%id%/lib\\"
 export DUNE_BUILD_DIR=\\"%esyStorePath%/b/%id%\\"
 export SHELL=\\"env -i /bin/bash --norc --noprofile\\"
 export PATH=\\"$PATH:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\""
@@ -57,26 +65,8 @@ exports[`Build with dep out of source build macos || linux: build-env snapshot 1
 
 
 #
-# depOfDep@path:depOfDep@d41d8cd9
-#
-export CAML_LD_LIBRARY_PATH=\\"%esyStorePath%/i/%depOfDepId%/stublibs:%esyStorePath%/i/%depOfDepId%/lib/stublibs:$CAML_LD_LIBRARY_PATH\\"
-export OCAMLPATH=\\"%esyStorePath%/i/%depOfDepId%/lib:$OCAMLPATH\\"
-export MAN_PATH=\\"%esyStorePath%/i/%depOfDepId%/man:$MAN_PATH\\"
-export PATH=\\"%esyStorePath%/i/%depOfDepId%/bin:$PATH\\"
-
-#
-# dep@path:dep@d41d8cd9
-#
-export CAML_LD_LIBRARY_PATH=\\"%esyStorePath%/i/%depId%/stublibs:%esyStorePath%/i/%depId%/lib/stublibs:$CAML_LD_LIBRARY_PATH\\"
-export OCAMLPATH=\\"%esyStorePath%/i/%depId%/lib:$OCAMLPATH\\"
-export MAN_PATH=\\"%esyStorePath%/i/%depId%/man:$MAN_PATH\\"
-export PATH=\\"%esyStorePath%/i/%depId%/bin:$PATH\\"
-
-#
 # Built-in
 #
-export OCAMLFIND_LDCONF=\\"ignore\\"
-export OCAMLFIND_DESTDIR=\\"%projectPath%/_esy/default/store/i/%id%/lib\\"
 export cur__etc=\\"%projectPath%/_esy/default/store/i/%id%/etc\\"
 export cur__share=\\"%projectPath%/_esy/default/store/i/%id%/share\\"
 export cur__toplevel=\\"%projectPath%/_esy/default/store/i/%id%/toplevel\\"
@@ -93,6 +83,36 @@ export cur__root=\\"%projectPath%\\"
 export cur__dev=\\"true\\"
 export cur__version=\\"1.0.0\\"
 export cur__name=\\"withDep\\"
+
+#
+# depOfDep@path:depOfDep@d41d8cd9
+#
+export depOfDep__local=\\"depOfDep__local\\"
+export depOfDep__local_dyn=\\"depOfDep__local_dyn:$cur__name\\"
+export depOfDep__global=\\"depOfDep__global\\"
+export depOfDep__global_dyn=\\"depOfDep__global_dyn:$cur__name\\"
+export CAML_LD_LIBRARY_PATH=\\"%esyStorePath%/i/%depOfDepId%/stublibs:%esyStorePath%/i/%depOfDepId%/lib/stublibs:$CAML_LD_LIBRARY_PATH\\"
+export OCAMLPATH=\\"%esyStorePath%/i/%depOfDepId%/lib:$OCAMLPATH\\"
+export MAN_PATH=\\"%esyStorePath%/i/%depOfDepId%/man:$MAN_PATH\\"
+export PATH=\\"%esyStorePath%/i/%depOfDepId%/bin:$PATH\\"
+
+#
+# dep@path:dep@d41d8cd9
+#
+export dep__local=\\"dep__local\\"
+export dep__local_dyn=\\"dep__local_dyn:$cur__name\\"
+export dep__global=\\"dep__global\\"
+export dep__global_dyn=\\"dep__global_dyn:$cur__name\\"
+export CAML_LD_LIBRARY_PATH=\\"%esyStorePath%/i/%depId%/stublibs:%esyStorePath%/i/%depId%/lib/stublibs:$CAML_LD_LIBRARY_PATH\\"
+export OCAMLPATH=\\"%esyStorePath%/i/%depId%/lib:$OCAMLPATH\\"
+export MAN_PATH=\\"%esyStorePath%/i/%depId%/man:$MAN_PATH\\"
+export PATH=\\"%esyStorePath%/i/%depId%/bin:$PATH\\"
+
+#
+# Built-in
+#
+export OCAMLFIND_LDCONF=\\"ignore\\"
+export OCAMLFIND_DESTDIR=\\"%projectPath%/_esy/default/store/i/%id%/lib\\"
 export DUNE_BUILD_DIR=\\"%projectPath%/_esy/default/store/b/%id%\\"
 export SHELL=\\"env -i /bin/bash --norc --noprofile\\"
 export PATH=\\"$PATH:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\""

--- a/test-e2e/esy-build/__snapshots__/with-dep.test.js.snap
+++ b/test-e2e/esy-build/__snapshots__/with-dep.test.js.snap
@@ -87,8 +87,6 @@ export cur__name=\\"withDep\\"
 #
 # depOfDep@path:depOfDep@d41d8cd9
 #
-export depOfDep__local=\\"depOfDep__local\\"
-export depOfDep__local_dyn=\\"depOfDep__local_dyn:$cur__name\\"
 export depOfDep__global=\\"depOfDep__global\\"
 export depOfDep__global_dyn=\\"depOfDep__global_dyn:$cur__name\\"
 export CAML_LD_LIBRARY_PATH=\\"%esyStorePath%/i/%depOfDepId%/stublibs:%esyStorePath%/i/%depOfDepId%/lib/stublibs:$CAML_LD_LIBRARY_PATH\\"

--- a/test-e2e/esy-build/__snapshots__/with-dep.test.js.snap
+++ b/test-e2e/esy-build/__snapshots__/with-dep.test.js.snap
@@ -12,6 +12,14 @@ exports[`Build with dep out of source build macos || linux: build-env dep snapsh
 
 
 #
+# depOfDep@path:depOfDep@d41d8cd9
+#
+export CAML_LD_LIBRARY_PATH=\\"%esyStorePath%/i/%depOfDepId%/stublibs:%esyStorePath%/i/%depOfDepId%/lib/stublibs:$CAML_LD_LIBRARY_PATH\\"
+export OCAMLPATH=\\"%esyStorePath%/i/%depOfDepId%/lib:$OCAMLPATH\\"
+export MAN_PATH=\\"%esyStorePath%/i/%depOfDepId%/man:$MAN_PATH\\"
+export PATH=\\"%esyStorePath%/i/%depOfDepId%/bin:$PATH\\"
+
+#
 # Built-in
 #
 export OCAMLFIND_LDCONF=\\"ignore\\"
@@ -49,12 +57,20 @@ exports[`Build with dep out of source build macos || linux: build-env snapshot 1
 
 
 #
+# depOfDep@path:depOfDep@d41d8cd9
+#
+export CAML_LD_LIBRARY_PATH=\\"%esyStorePath%/i/%depOfDepId%/stublibs:%esyStorePath%/i/%depOfDepId%/lib/stublibs:$CAML_LD_LIBRARY_PATH\\"
+export OCAMLPATH=\\"%esyStorePath%/i/%depOfDepId%/lib:$OCAMLPATH\\"
+export MAN_PATH=\\"%esyStorePath%/i/%depOfDepId%/man:$MAN_PATH\\"
+export PATH=\\"%esyStorePath%/i/%depOfDepId%/bin:$PATH\\"
+
+#
 # dep@path:dep@d41d8cd9
 #
-export CAML_LD_LIBRARY_PATH=\\"%esyStorePath%/i/%depid%/stublibs:%esyStorePath%/i/%depid%/lib/stublibs:$CAML_LD_LIBRARY_PATH\\"
-export OCAMLPATH=\\"%esyStorePath%/i/%depid%/lib:$OCAMLPATH\\"
-export MAN_PATH=\\"%esyStorePath%/i/%depid%/man:$MAN_PATH\\"
-export PATH=\\"%esyStorePath%/i/%depid%/bin:$PATH\\"
+export CAML_LD_LIBRARY_PATH=\\"%esyStorePath%/i/%depId%/stublibs:%esyStorePath%/i/%depId%/lib/stublibs:$CAML_LD_LIBRARY_PATH\\"
+export OCAMLPATH=\\"%esyStorePath%/i/%depId%/lib:$OCAMLPATH\\"
+export MAN_PATH=\\"%esyStorePath%/i/%depId%/man:$MAN_PATH\\"
+export PATH=\\"%esyStorePath%/i/%depId%/bin:$PATH\\"
 
 #
 # Built-in

--- a/test-e2e/esy-build/__snapshots__/with-dev-dep.test.js.snap
+++ b/test-e2e/esy-build/__snapshots__/with-dev-dep.test.js.snap
@@ -14,8 +14,6 @@ exports[`devDep workflow macos || linux: build-env dep snapshot 1`] = `
 #
 # Built-in
 #
-export OCAMLFIND_LDCONF=\\"ignore\\"
-export OCAMLFIND_DESTDIR=\\"%esyStorePath%/s/%id%/lib\\"
 export cur__etc=\\"%esyStorePath%/s/%id%/etc\\"
 export cur__share=\\"%esyStorePath%/s/%id%/share\\"
 export cur__toplevel=\\"%esyStorePath%/s/%id%/toplevel\\"
@@ -32,6 +30,8 @@ export cur__root=\\"%esyStorePath%/b/%id%\\"
 export cur__dev=\\"false\\"
 export cur__version=\\"1.0.0\\"
 export cur__name=\\"dep\\"
+export OCAMLFIND_LDCONF=\\"ignore\\"
+export OCAMLFIND_DESTDIR=\\"%esyStorePath%/s/%id%/lib\\"
 export SHELL=\\"env -i /bin/bash --norc --noprofile\\"
 export PATH=\\"$PATH:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\""
 `;
@@ -58,8 +58,6 @@ export PATH=\\"%esyStorePath%/i/%depOfDevDepId%/bin:$PATH\\"
 #
 # Built-in
 #
-export OCAMLFIND_LDCONF=\\"ignore\\"
-export OCAMLFIND_DESTDIR=\\"%esyStorePath%/s/%id%/lib\\"
 export cur__etc=\\"%esyStorePath%/s/%id%/etc\\"
 export cur__share=\\"%esyStorePath%/s/%id%/share\\"
 export cur__toplevel=\\"%esyStorePath%/s/%id%/toplevel\\"
@@ -76,6 +74,8 @@ export cur__root=\\"%esyStorePath%/b/%id%\\"
 export cur__dev=\\"false\\"
 export cur__version=\\"1.0.0\\"
 export cur__name=\\"devDep\\"
+export OCAMLFIND_LDCONF=\\"ignore\\"
+export OCAMLFIND_DESTDIR=\\"%esyStorePath%/s/%id%/lib\\"
 export SHELL=\\"env -i /bin/bash --norc --noprofile\\"
 export PATH=\\"$PATH:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\""
 `;
@@ -92,18 +92,8 @@ exports[`devDep workflow macos || linux: build-env snapshot 1`] = `
 
 
 #
-# dep@path:dep@d41d8cd9
-#
-export CAML_LD_LIBRARY_PATH=\\"%esyStorePath%/i/%depid%/stublibs:%esyStorePath%/i/%depid%/lib/stublibs:$CAML_LD_LIBRARY_PATH\\"
-export OCAMLPATH=\\"%esyStorePath%/i/%depid%/lib:$OCAMLPATH\\"
-export MAN_PATH=\\"%esyStorePath%/i/%depid%/man:$MAN_PATH\\"
-export PATH=\\"%esyStorePath%/i/%depid%/bin:$PATH\\"
-
-#
 # Built-in
 #
-export OCAMLFIND_LDCONF=\\"ignore\\"
-export OCAMLFIND_DESTDIR=\\"%projectPath%/_esy/default/store/i/%id%/lib\\"
 export cur__etc=\\"%projectPath%/_esy/default/store/i/%id%/etc\\"
 export cur__share=\\"%projectPath%/_esy/default/store/i/%id%/share\\"
 export cur__toplevel=\\"%projectPath%/_esy/default/store/i/%id%/toplevel\\"
@@ -120,6 +110,20 @@ export cur__root=\\"%projectPath%\\"
 export cur__dev=\\"true\\"
 export cur__version=\\"1.0.0\\"
 export cur__name=\\"withDevDep\\"
+
+#
+# dep@path:dep@d41d8cd9
+#
+export CAML_LD_LIBRARY_PATH=\\"%esyStorePath%/i/%depid%/stublibs:%esyStorePath%/i/%depid%/lib/stublibs:$CAML_LD_LIBRARY_PATH\\"
+export OCAMLPATH=\\"%esyStorePath%/i/%depid%/lib:$OCAMLPATH\\"
+export MAN_PATH=\\"%esyStorePath%/i/%depid%/man:$MAN_PATH\\"
+export PATH=\\"%esyStorePath%/i/%depid%/bin:$PATH\\"
+
+#
+# Built-in
+#
+export OCAMLFIND_LDCONF=\\"ignore\\"
+export OCAMLFIND_DESTDIR=\\"%projectPath%/_esy/default/store/i/%id%/lib\\"
 export DUNE_BUILD_DIR=\\"%projectPath%/_esy/default/store/b/%id%\\"
 export SHELL=\\"env -i /bin/bash --norc --noprofile\\"
 export PATH=\\"$PATH:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\""

--- a/test-e2e/esy-build/__snapshots__/with-dev-dep.test.js.snap
+++ b/test-e2e/esy-build/__snapshots__/with-dev-dep.test.js.snap
@@ -48,14 +48,6 @@ exports[`devDep workflow macos || linux: build-env devDep snapshot 1`] = `
 
 
 #
-# depOfDevDep@path:depOfDevDep@d41d8cd9
-#
-export CAML_LD_LIBRARY_PATH=\\"%esyStorePath%/i/%depOfDevDepId%/stublibs:%esyStorePath%/i/%depOfDevDepId%/lib/stublibs:$CAML_LD_LIBRARY_PATH\\"
-export OCAMLPATH=\\"%esyStorePath%/i/%depOfDevDepId%/lib:$OCAMLPATH\\"
-export MAN_PATH=\\"%esyStorePath%/i/%depOfDevDepId%/man:$MAN_PATH\\"
-export PATH=\\"%esyStorePath%/i/%depOfDevDepId%/bin:$PATH\\"
-
-#
 # Built-in
 #
 export cur__etc=\\"%esyStorePath%/s/%id%/etc\\"
@@ -74,6 +66,18 @@ export cur__root=\\"%esyStorePath%/b/%id%\\"
 export cur__dev=\\"false\\"
 export cur__version=\\"1.0.0\\"
 export cur__name=\\"devDep\\"
+
+#
+# depOfDevDep@path:depOfDevDep@d41d8cd9
+#
+export CAML_LD_LIBRARY_PATH=\\"%esyStorePath%/i/%depOfDevDepId%/stublibs:%esyStorePath%/i/%depOfDevDepId%/lib/stublibs:$CAML_LD_LIBRARY_PATH\\"
+export OCAMLPATH=\\"%esyStorePath%/i/%depOfDevDepId%/lib:$OCAMLPATH\\"
+export MAN_PATH=\\"%esyStorePath%/i/%depOfDevDepId%/man:$MAN_PATH\\"
+export PATH=\\"%esyStorePath%/i/%depOfDevDepId%/bin:$PATH\\"
+
+#
+# Built-in
+#
 export OCAMLFIND_LDCONF=\\"ignore\\"
 export OCAMLFIND_DESTDIR=\\"%esyStorePath%/s/%id%/lib\\"
 export SHELL=\\"env -i /bin/bash --norc --noprofile\\"

--- a/test-e2e/esy-build/__snapshots__/with-linked-dep.test.js.snap
+++ b/test-e2e/esy-build/__snapshots__/with-linked-dep.test.js.snap
@@ -14,8 +14,6 @@ exports[`Build with a linked dep out of source build macos || linux: build-env d
 #
 # Built-in
 #
-export OCAMLFIND_LDCONF=\\"ignore\\"
-export OCAMLFIND_DESTDIR=\\"%projectPath%/_esy/default/store/i/%id%/lib\\"
 export cur__etc=\\"%projectPath%/_esy/default/store/i/%id%/etc\\"
 export cur__share=\\"%projectPath%/_esy/default/store/i/%id%/share\\"
 export cur__toplevel=\\"%projectPath%/_esy/default/store/i/%id%/toplevel\\"
@@ -32,6 +30,8 @@ export cur__root=\\"%projectPath%/dep\\"
 export cur__dev=\\"true\\"
 export cur__version=\\"1.0.0\\"
 export cur__name=\\"dep\\"
+export OCAMLFIND_LDCONF=\\"ignore\\"
+export OCAMLFIND_DESTDIR=\\"%projectPath%/_esy/default/store/i/%id%/lib\\"
 export DUNE_BUILD_DIR=\\"%projectPath%/_esy/default/store/b/%id%\\"
 export SHELL=\\"env -i /bin/bash --norc --noprofile\\"
 export PATH=\\"$PATH:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\""
@@ -49,18 +49,8 @@ exports[`Build with a linked dep out of source build macos || linux: build-env s
 
 
 #
-# dep@link:dep
-#
-export CAML_LD_LIBRARY_PATH=\\"%projectPath%/_esy/default/store/i/%depid%/stublibs:%projectPath%/_esy/default/store/i/%depid%/lib/stublibs:$CAML_LD_LIBRARY_PATH\\"
-export OCAMLPATH=\\"%projectPath%/_esy/default/store/i/%depid%/lib:$OCAMLPATH\\"
-export MAN_PATH=\\"%projectPath%/_esy/default/store/i/%depid%/man:$MAN_PATH\\"
-export PATH=\\"%projectPath%/_esy/default/store/i/%depid%/bin:$PATH\\"
-
-#
 # Built-in
 #
-export OCAMLFIND_LDCONF=\\"ignore\\"
-export OCAMLFIND_DESTDIR=\\"%projectPath%/_esy/default/store/i/%id%/lib\\"
 export cur__etc=\\"%projectPath%/_esy/default/store/i/%id%/etc\\"
 export cur__share=\\"%projectPath%/_esy/default/store/i/%id%/share\\"
 export cur__toplevel=\\"%projectPath%/_esy/default/store/i/%id%/toplevel\\"
@@ -77,6 +67,20 @@ export cur__root=\\"%projectPath%\\"
 export cur__dev=\\"true\\"
 export cur__version=\\"1.0.0\\"
 export cur__name=\\"with-linked-dep-_build\\"
+
+#
+# dep@link:dep
+#
+export CAML_LD_LIBRARY_PATH=\\"%projectPath%/_esy/default/store/i/%depid%/stublibs:%projectPath%/_esy/default/store/i/%depid%/lib/stublibs:$CAML_LD_LIBRARY_PATH\\"
+export OCAMLPATH=\\"%projectPath%/_esy/default/store/i/%depid%/lib:$OCAMLPATH\\"
+export MAN_PATH=\\"%projectPath%/_esy/default/store/i/%depid%/man:$MAN_PATH\\"
+export PATH=\\"%projectPath%/_esy/default/store/i/%depid%/bin:$PATH\\"
+
+#
+# Built-in
+#
+export OCAMLFIND_LDCONF=\\"ignore\\"
+export OCAMLFIND_DESTDIR=\\"%projectPath%/_esy/default/store/i/%id%/lib\\"
 export DUNE_BUILD_DIR=\\"%projectPath%/_esy/default/store/b/%id%\\"
 export SHELL=\\"env -i /bin/bash --norc --noprofile\\"
 export PATH=\\"$PATH:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\""

--- a/test-e2e/esy-build/opam-sandbox.test.js
+++ b/test-e2e/esy-build/opam-sandbox.test.js
@@ -399,6 +399,7 @@ describe('build opam sandbox', () => {
       ['dep:build-id', depPlan.id],
     ];
 
+    console.log(p.projectPath);
     for (let i = 0; i < expectBuild.length; i++) {
       expect(plan.build[i]).toEqual(expectBuild[i]);
     }

--- a/test-e2e/esy-build/with-dep.test.js
+++ b/test-e2e/esy-build/with-dep.test.js
@@ -39,7 +39,7 @@ function makeFixture(p, buildDep) {
     helpers.dir(
       'depOfDep',
       helpers.packageJson({
-        name: 'dep',
+        name: 'depOfDep',
         version: '1.0.0',
         esy: {
           build: 'true',
@@ -120,9 +120,7 @@ describe('Build with dep', () => {
           dep__local_dyn: 'dep__local_dyn:withDep',
           dep__global_dyn: 'dep__global_dyn:withDep',
           depOfDep__global: 'depOfDep__global',
-          // depOfDep__local: undefined,
           depOfDep__global_dyn: 'depOfDep__global_dyn:withDep',
-          // depOfDep__local_dyn: undefined,
           //built ins (cur)
           cur__version: '1.0.0',
           cur__toplevel: `${p.projectPath}/_esy/default/store/i/${id}/toplevel`,


### PR DESCRIPTION
Test coverage and few fixes:

- Emit auto variables `$cur__*` before deps.

  That way deps can export variables which reference `$cur__*`. We've
  regressed on this feature sometime ago. Now it's back. It's not often used
  but nice to have.

- Use package names. not build names when referring to deps.

  This is more correct as consumer now define namespaces rather than the package
  itself.