### PR TITLE
EnvSpec can be configured to export esy introspection env

### DIFF
--- a/esy/BuildSandbox.mli
+++ b/esy/BuildSandbox.mli
@@ -1,5 +1,9 @@
 open EsyPackageConfig
 
+module EsyIntrospectionEnv : sig
+  val rootPackageConfigPath : string
+end
+
 type t
 
 val make :

--- a/esy/BuildSandbox.mli
+++ b/esy/BuildSandbox.mli
@@ -15,6 +15,8 @@ val make :
 
 val renderExpression : t -> Scope.t -> string -> string Run.t
 
+val rootPackageConfigPath : t -> Fpath.t option
+
 val configure :
   ?forceImmutable:bool
   -> EnvSpec.t

--- a/esy/EnvSpec.ml
+++ b/esy/EnvSpec.ml
@@ -3,5 +3,6 @@ type t = {
   buildIsInProgress : bool;
   includeCurrentEnv : bool;
   includeBuildEnv : bool;
+  includeEsyIntrospectionEnv : bool;
   includeNpmBin : bool;
 }

--- a/esy/EnvSpec.mli
+++ b/esy/EnvSpec.mli
@@ -1,14 +1,29 @@
 (** This describes how to construct environment for command invocations. *)
 
 type t = {
+  (**
+    Defines what packages we should bring into the command env.
+    *)
   augmentDeps : DepSpec.t option;
-  (** Defines what packages we should bring into the command env. *)
+
+  (**
+    If we should init the build environment (enable sandboxing, do source
+    relloc).
+    *)
   buildIsInProgress : bool;
-  (** If we should init the build environment (enable sandboxing, do source relloc). *)
+
+  (**
+    If we should include current environment.
+    *)
   includeCurrentEnv : bool;
-  (** If we should include current environment. *)
+
+  (**
+    If we should include the package's build environment.
+    *)
   includeBuildEnv : bool;
-  (** If we should include the package's build environment. *)
+
+  (**
+    If we should include the project's npm bin in $PATH.
+    *)
   includeNpmBin : bool;
-  (** If we should include the project's npm bin in $PATH. *)
 }

--- a/esy/EnvSpec.mli
+++ b/esy/EnvSpec.mli
@@ -23,6 +23,12 @@ type t = {
   includeBuildEnv : bool;
 
   (**
+    If we should include additional environment variables for introspection so
+    that tools running can access info about the project.
+    *)
+  includeEsyIntrospectionEnv : bool;
+
+  (**
     If we should include the project's npm bin in $PATH.
     *)
   includeNpmBin : bool;

--- a/esy/bin/NpmReleaseCommand.ml
+++ b/esy/bin/NpmReleaseCommand.ml
@@ -283,6 +283,7 @@ let envspec = {
   includeCurrentEnv = false;
   includeBuildEnv = false;
   includeNpmBin = false;
+  includeEsyIntrospectionEnv = false;
   augmentDeps = Some DepSpec.(package self + dependencies self + devDependencies self);
 }
 let buildspec = {

--- a/esy/bin/Project.ml
+++ b/esy/bin/Project.ml
@@ -20,14 +20,16 @@ module TermPp = struct
       buildIsInProgress;
       includeCurrentEnv;
       includeBuildEnv;
+      includeEsyIntrospectionEnv;
       includeNpmBin;
     } = envspec in
     Fmt.pf fmt
-      "%a%a%a%a%a"
+      "%a%a%a%a%a%a"
       (ppOption "--envspec" (Fmt.quote ~mark:"'" DepSpec.pp)) augmentDeps
       (ppFlag "--build-context") buildIsInProgress
       (ppFlag "--include-current-env") includeCurrentEnv
       (ppFlag "--include-npm-bin") includeNpmBin
+      (ppFlag "--include-esy-introspection-env") includeEsyIntrospectionEnv
       (ppFlag "--include-build-env") includeBuildEnv
 
   let ppMode fmt mode =

--- a/esy/bin/Workflow.ml
+++ b/esy/bin/Workflow.ml
@@ -30,6 +30,7 @@ let default =
     buildIsInProgress = false;
     includeCurrentEnv = true;
     includeBuildEnv = false;
+    includeEsyIntrospectionEnv = true;
     includeNpmBin = true;
     (* Environment contains dependencies, devDependencies and package itself. *)
     augmentDeps = Some DepSpec.(package self + dependencies self + devDependencies self);
@@ -41,6 +42,7 @@ let default =
     buildIsInProgress = false;
     includeCurrentEnv = true;
     includeBuildEnv = true;
+    includeEsyIntrospectionEnv = true;
     includeNpmBin = true;
     (* Environment contains dependencies and devDependencies. *)
     augmentDeps = Some DepSpec.(dependencies self + devDependencies self);
@@ -52,6 +54,7 @@ let default =
     buildIsInProgress = true;
     includeCurrentEnv = false;
     includeBuildEnv = true;
+    includeEsyIntrospectionEnv = false;
     includeNpmBin = false;
     (* This means that environment is the same as in buildspec. *)
     augmentDeps = None;

--- a/esy/bin/esyCommand.ml
+++ b/esy/bin/esyCommand.ml
@@ -308,6 +308,7 @@ module Status = struct
     isProjectReadyForDev : bool;
     rootBuildPath : Path.t option;
     rootInstallPath : Path.t option;
+    rootPackageConfigPath : Path.t option;
   } [@@deriving to_yojson]
 
   let notAProject = {
@@ -317,6 +318,7 @@ module Status = struct
     isProjectReadyForDev = false;
     rootBuildPath = None;
     rootInstallPath = None;
+    rootPackageConfigPath = None;
   }
 
 end
@@ -377,6 +379,11 @@ let status
         let root = configured.Project.WithWorkflow.root in
         return (Some (BuildSandbox.Task.installPath proj.projcfg.ProjectConfig.cfg root))
       in
+      let%lwt rootPackageConfigPath =
+        let open RunAsync.Syntax in
+        let%bind fetched = Project.fetched proj in
+        return (BuildSandbox.rootPackageConfigPath fetched.Project.sandbox)
+      in
       return {
         isProject = true;
         isProjectSolved;
@@ -384,6 +391,7 @@ let status
         isProjectReadyForDev = Result.getOr false built;
         rootBuildPath = Result.getOr None rootBuildPath;
         rootInstallPath = Result.getOr None rootInstallPath;
+        rootPackageConfigPath = Result.getOr None rootPackageConfigPath;
       }
     in
     Format.fprintf

--- a/esy/bin/esyCommand.ml
+++ b/esy/bin/esyCommand.ml
@@ -1228,25 +1228,12 @@ let makeAlias ?(docs=aliasesSection) command alias =
   in
   term, info
 
-let makeCommands rootPackagePath =
+let makeCommands projectPath =
   let open Cmdliner in
 
-  let rootPackagePath =
-    match rootPackagePath with
-    | Some _ -> rootPackagePath
-    | None ->
-      let open Option.Syntax in
-      let%map v =
-        StringMap.find_opt
-          BuildSandbox.EsyIntrospectionEnv.rootPackageConfigPath
-          System.Environment.current
-      in
-      Path.v v
-  in
-
-  let projectConfig = ProjectConfig.term rootPackagePath in
-  let projectWithWorkflow = Project.WithWorkflow.term rootPackagePath in
-  let project = Project.WithoutWorkflow.term rootPackagePath in
+  let projectConfig = ProjectConfig.term projectPath in
+  let projectWithWorkflow = Project.WithWorkflow.term projectPath in
+  let project = Project.WithoutWorkflow.term projectPath in
 
   let makeProjectWithWorkflowCommand ?(header=`Standard) ?docs ?doc ~name cmd =
     let cmd =
@@ -1526,7 +1513,7 @@ let makeCommands rootPackagePath =
       ~docs:introspectionSection
       Term.(
         const status
-        $ Project.WithWorkflow.promiseTerm rootPackagePath
+        $ Project.WithWorkflow.promiseTerm projectPath
         $ Arg.(value & flag & info ["json"] ~doc:"Format output as JSON")
         $ Cli.setupLogTerm
       );

--- a/test-e2e/esy-status.test.js
+++ b/test-e2e/esy-status.test.js
@@ -1,5 +1,6 @@
 // @flow
 
+const path = require('path');
 const helpers = require('./test/helpers.js');
 
 describe(`'esy status' command`, function() {
@@ -16,6 +17,7 @@ describe(`'esy status' command`, function() {
       isProjectSolved: false,
       rootBuildPath: null,
       rootInstallPath: null,
+      rootPackageConfigPath: null,
     });
   });
 
@@ -26,6 +28,12 @@ describe(`'esy status' command`, function() {
         dep: 'path:./dep',
       },
     }),
+    helpers.file('dev.json', JSON.stringify({
+      name: 'dev',
+      dependencies: {
+        dep: 'path:./dep',
+      },
+    }, null, 2)),
     helpers.dir(
       'dep',
       helpers.packageJson({
@@ -48,6 +56,7 @@ describe(`'esy status' command`, function() {
       isProjectSolved: false,
       rootBuildPath: null,
       rootInstallPath: null,
+      rootPackageConfigPath: null,
     });
   });
 
@@ -65,6 +74,7 @@ describe(`'esy status' command`, function() {
       isProjectSolved: true,
       rootBuildPath: null,
       rootInstallPath: null,
+      rootPackageConfigPath: null,
     });
   });
 
@@ -80,6 +90,7 @@ describe(`'esy status' command`, function() {
       isProjectFetched: true,
       isProjectReadyForDev: false,
       isProjectSolved: true,
+      rootPackageConfigPath: path.join(p.projectPath, 'package.json')
     });
     expect(status.rootBuildPath).not.toBe(null);
     expect(status.rootInstallPath).not.toBe(null);
@@ -98,6 +109,26 @@ describe(`'esy status' command`, function() {
       isProjectFetched: true,
       isProjectReadyForDev: true,
       isProjectSolved: true,
+      rootPackageConfigPath: path.join(p.projectPath, 'package.json')
+    });
+    expect(status.rootBuildPath).not.toBe(null);
+    expect(status.rootInstallPath).not.toBe(null);
+  });
+
+  it('reports correct "rootPackageConfigPath" with named invocation', async function() {
+    const p = await helpers.createTestSandbox();
+    await p.fixture(...fixture);
+    await p.esy('@dev install');
+    await p.esy('@dev build');
+
+    const {stdout} = await p.esy('@dev status --json');
+    const status = JSON.parse(stdout);
+    expect(status).toMatchObject({
+      isProject: true,
+      isProjectFetched: true,
+      isProjectReadyForDev: true,
+      isProjectSolved: true,
+      rootPackageConfigPath: path.join(p.projectPath, 'dev.json')
     });
     expect(status.rootBuildPath).not.toBe(null);
     expect(status.rootInstallPath).not.toBe(null);


### PR DESCRIPTION
esy introspection env can be used by tools to learn about current esy project
configutation.

For now the only env variable present is `$ESY__ROOT_PACKAGE_CONFIG_PATH` which
points to the path of the root package config (usually `package.json` but it
reports the correct value for named projects too: `esy @dev bash -c '$ESY__ROOT_PACKAGE_CONFIG_PATH'`).

We also configure `esy` to autoconfigure itself with
`$ESY__ROOT_PACKAGE_CONFIG_PATH` so that nested esy invocations will see the
correct sandboxes:

    % esy @dev esy echo '#{self.name}'

will output the `"name"` field from `./dev.json`.

Then finally we add `"rootPackageConfigPath"` to `esy status` command output.

cc @anmonteiro: this might be useful for RLS to make it know how to build the
project.

cc @jordwalke this can help making `vim-reason` working with named esy
invocations:

    % esy @dev vim ...