### PR TITLE
Enable buildDev access devDependencies for root package

### DIFF
--- a/.ci/build.yml
+++ b/.ci/build.yml
@@ -1,5 +1,5 @@
 steps:
-  - script: 'npm install -g esy@0.4.7 --unsafe-perm'
+  - script: 'npm install -g esy@0.4.9 --unsafe-perm'
     displayName: 'npm install -g esy'
 
   - script: 'esy install'

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -101,6 +101,15 @@ You can also use `esy b` shortcurt instead of `esy build`:
 % esy b dune build bin/hello.exe
 ```
 
+Note that the invocation `esy build CMD` also has to `"devDependencies"` and
+thus it might be used for development time builds:
+```bash
+% esy build refmterr dune build
+```
+
+where `refmterr` command comes from `refmterr` package which is defined in
+`"devDependencies"`.
+
 ### `esy x COMMAND`
 
 Execute command `COMMAND` in the test environment.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -48,23 +48,33 @@ declare build commands.
 ### `esy.buildDev`
 
 Describe how your package's default targets should be built when package is
-being developed.
+being developed. This is only used for the root package of an esy project.
 
-For example, for a [dune](https://dune.readthedocs.io/) based package you'd want to call `dune build`
-command.
+The main difference with `esy.build` is that commands declared in `esy.buildDev`
+have access to `"devDependencies"`.
+
+For example, for a [dune](https://dune.readthedocs.io/) based package you'd want
+to call `dune build` command.
 
 ```
 {
   "esy": {
     "buildDev": [
-      "dune build --root . --only-packages #{self.name}",
+      "refmterr dune build --root . --only-packages #{self.name}",
     ]
+  },
+  "dependencies": {
+    "refmterr": "*",
+    ...
   }
 }
 ```
 
-[esy variable substitution syntax](environment.md#variable-substitution-syntax) can be used to
-declare build commands.
+Note that we use `refmterr` command which is declared in `"devDependencies"`
+section.
+
+[esy variable substitution syntax](environment.md#variable-substitution-syntax)
+can be used to declare build commands.
 
 If no `esy.buildDev` is defined then `esy.build` is used instead.
 

--- a/esy/BuildId.ml
+++ b/esy/BuildId.ml
@@ -121,11 +121,11 @@ module Repr = struct
         buildEnv
       } = build in
       let buildCommands =
-        match mode, sourceType, buildDev with
-        | BuildSpec.Build, _, _
-        | BuildSpec.BuildDev, (SourceType.ImmutableWithTransientDependencies | Immutable), _
-        | BuildSpec.BuildDev, Transient, None -> build
-        | BuildSpec.BuildDev, SourceType.Transient, Some commands ->
+        match (mode : BuildSpec.mode), sourceType, buildDev with
+        | Build, _, _
+        | (BuildDev | BuildDevForce), (SourceType.ImmutableWithTransientDependencies | Immutable), _
+        | (BuildDev | BuildDevForce), Transient, None -> build
+        | (BuildDev | BuildDevForce), SourceType.Transient, Some commands ->
           BuildManifest.EsyCommands commands
       in
       {

--- a/esy/BuildSandbox.ml
+++ b/esy/BuildSandbox.ml
@@ -518,6 +518,7 @@ module Plan = struct
 
   type t = {
     buildspec : BuildSpec.t;
+    plan : BuildSpec.plan;
     tasks : Task.t option PackageId.Map.t;
   }
 
@@ -557,6 +558,8 @@ module Plan = struct
       | _ , None -> tasks
     in
     List.fold_left ~f ~init:[] (PackageId.Map.bindings plan.tasks)
+
+  let plan plan = plan.plan
 end
 
 let makePlan
@@ -669,7 +672,7 @@ let makePlan
     visit PackageId.Map.empty [root.id]
   in
 
-  return {Plan. tasks; buildspec;}
+  return {Plan. plan = mode; tasks; buildspec;}
 
 let task buildspec mode sandbox id =
   let open RunAsync.Syntax in

--- a/esy/BuildSandbox.ml
+++ b/esy/BuildSandbox.ml
@@ -265,6 +265,7 @@ let makeScope
   ?envspec
   ~forceImmutable
   buildspec
+  mode
   sandbox
   id
   =
@@ -302,19 +303,17 @@ let makeScope
       Hashtbl.replace cache id res;
       return res
 
-  and visit' envspec seen id build =
+  and visit' envspec seen id buildManifest =
     let module IdS = PackageId.Set in
     let pkg = Solution.getExn id sandbox.solution in
     let location = Installation.findExn id sandbox.installation in
 
-    let mode, matchedForBuild =
-      let {BuildSpec. mode; deps} =
-        BuildSpec.classify buildspec sandbox.solution pkg
-      in
-      let matched =
-        DepSpec.eval sandbox.solution pkg.Package.id deps
-      in
-      mode, matched
+    let build, _commands =
+      BuildSpec.classify buildspec mode sandbox.solution pkg buildManifest
+    in
+
+    let matchedForBuild =
+      DepSpec.eval sandbox.solution pkg.Package.id build.deps
     in
 
     let matchedForScope =
@@ -457,9 +456,9 @@ let makeScope
         ~packageId:pkg.id
         ~platform:sandbox.platform
         ~arch:sandbox.arch
-        ~build
+        ~build:buildManifest
         ~sourceType
-        ~mode
+        ~mode:build.mode
         ~dependencies
         ()
     in
@@ -482,9 +481,9 @@ let makeScope
         ~version
         ~sourceType
         ~sourcePath
-        ~mode
+        ~build
         pkg
-        build
+        buildManifest
     in
 
     let scope =
@@ -562,15 +561,16 @@ end
 
 let makePlan
   ?(forceImmutable=false)
-  sandbox
   buildspec
+  mode
+  sandbox
   =
   let open Run.Syntax in
 
   let cache = Hashtbl.create 100 in
 
   let makeTask pkg =
-    match%bind makeScope ~cache ~forceImmutable buildspec sandbox pkg.id with
+    match%bind makeScope ~cache ~forceImmutable buildspec mode sandbox pkg.id with
     | None -> return None
     | Some (scope, build, idrepr, dependencies) ->
 
@@ -585,34 +585,30 @@ let makePlan
 
       let%bind buildCommands =
 
-        let {BuildSpec. mode; deps = _;} = BuildSpec.classify buildspec sandbox.solution pkg in
-        match mode, Scope.sourceType scope, build.BuildManifest.buildDev with
-        | BuildSpec.Build, _, _
-        | BuildDev, (ImmutableWithTransientDependencies | Immutable), _
-        | BuildDev, Transient, None ->
-          Run.context
-            begin match build.BuildManifest.build with
-            | EsyCommands commands ->
-              let%bind commands = renderEsyCommands ~buildIsInProgress:true ~env scope commands in
-              let%bind applySubstsCommands = renderOpamSubstsAsCommands opamEnv build.substs in
-              let%bind applyPatchesCommands = renderOpamPatchesToCommands opamEnv build.patches in
-              return (applySubstsCommands @ applyPatchesCommands @ commands)
-            | OpamCommands commands ->
-              let%bind commands = renderOpamCommands opamEnv commands in
-              let%bind applySubstsCommands = renderOpamSubstsAsCommands opamEnv build.substs in
-              let%bind applyPatchesCommands = renderOpamPatchesToCommands opamEnv build.patches in
-              return (applySubstsCommands @ applyPatchesCommands @ commands)
-            | NoCommands ->
-              return []
-            end
-            "processing esy.build"
-        | BuildSpec.BuildDev, Transient, Some commands ->
-          Run.context (
+        let _, commands =
+          BuildSpec.classify
+            buildspec
+            mode
+            sandbox.solution
+            pkg
+            build
+        in
+        Run.context
+          begin match commands with
+          | BuildManifest.EsyCommands commands ->
             let%bind commands = renderEsyCommands ~buildIsInProgress:true ~env scope commands in
             let%bind applySubstsCommands = renderOpamSubstsAsCommands opamEnv build.substs in
             let%bind applyPatchesCommands = renderOpamPatchesToCommands opamEnv build.patches in
             return (applySubstsCommands @ applyPatchesCommands @ commands)
-          ) "processing esy.buildDev"
+          | OpamCommands commands ->
+            let%bind commands = renderOpamCommands opamEnv commands in
+            let%bind applySubstsCommands = renderOpamSubstsAsCommands opamEnv build.substs in
+            let%bind applyPatchesCommands = renderOpamPatchesToCommands opamEnv build.patches in
+            return (applySubstsCommands @ applyPatchesCommands @ commands)
+          | NoCommands ->
+            return []
+          end
+          "processing build commands"
       in
 
       let%bind installCommands =
@@ -675,16 +671,16 @@ let makePlan
 
   return {Plan. tasks; buildspec;}
 
-let task buildspec sandbox id =
+let task buildspec mode sandbox id =
   let open RunAsync.Syntax in
-  let%bind tasks = RunAsync.ofRun (makePlan sandbox buildspec) in
+  let%bind tasks = RunAsync.ofRun (makePlan buildspec mode sandbox) in
   match Plan.get tasks id with
   | None -> errorf "no build found for %a" PackageId.pp id
   | Some task -> return task
 
-let buildShell buildspec sandbox id =
+let buildShell buildspec mode sandbox id =
   let open RunAsync.Syntax in
-  let%bind task = task buildspec sandbox id in
+  let%bind task = task buildspec mode sandbox id in
   let plan = Task.plan task in
   EsyBuildPackageApi.buildShell ~cfg:sandbox.cfg plan
 
@@ -780,6 +776,7 @@ let configure
   ?(forceImmutable=false)
   envspec
   buildspec
+  mode
   sandbox
   id
   =
@@ -787,28 +784,39 @@ let configure
   let cache = Hashtbl.create 100 in
 
   let%bind scope =
-    match%bind makeScope ~cache ~forceImmutable ?envspec:envspec.augmentDeps buildspec sandbox id with
+    let scope =
+      makeScope
+        ~cache
+        ~forceImmutable
+        ?envspec:envspec.augmentDeps
+        buildspec
+        mode
+        sandbox
+        id
+    in
+    match%bind scope with
     | None -> errorf "no build found for %a" PackageId.pp id
     | Some (scope, _, _, _) -> return scope
   in
 
   augmentEnvWithOptions envspec sandbox scope
 
-let env ?forceImmutable envspec buildspec sandbox id =
+let env ?forceImmutable envspec buildspec mode sandbox id =
   let open Run.Syntax in
-  let%map env, _scope = configure ?forceImmutable envspec buildspec sandbox id in
+  let%map env, _scope = configure ?forceImmutable envspec buildspec mode sandbox id in
   env
 
 let exec
   envspec
   buildspec
+  mode
   sandbox
   id
   cmd =
   let open RunAsync.Syntax in
   let%bind env, scope = RunAsync.ofRun (
     let open Run.Syntax in
-    let%bind env, scope = configure envspec buildspec sandbox id in
+    let%bind env, scope = configure envspec buildspec mode sandbox id in
     let%bind env = Run.ofStringError (Scope.SandboxEnvironment.Bindings.eval env) in
     return (env, scope)
   ) in
@@ -828,7 +836,7 @@ let exec
 
   if envspec.EnvSpec.buildIsInProgress
   then
-    let%bind task = task buildspec sandbox id in
+    let%bind task = task buildspec mode sandbox id in
     let plan = Task.plan ~env task in
     EsyBuildPackageApi.buildExec ~cfg:sandbox.cfg plan cmd
   else

--- a/esy/BuildSandbox.mli
+++ b/esy/BuildSandbox.mli
@@ -21,6 +21,7 @@ val configure :
   ?forceImmutable:bool
   -> EnvSpec.t
   -> BuildSpec.t
+  -> BuildSpec.mode
   -> t
   -> PackageId.t
   -> (Scope.SandboxEnvironment.Bindings.t * Scope.t) Run.t
@@ -29,6 +30,7 @@ val env :
   ?forceImmutable:bool
   -> EnvSpec.t
   -> BuildSpec.t
+  -> BuildSpec.mode
   -> t
   -> PackageId.t
   -> Scope.SandboxEnvironment.Bindings.t Run.t
@@ -36,6 +38,7 @@ val env :
 val exec :
   EnvSpec.t
   -> BuildSpec.t
+  -> BuildSpec.mode
   -> t
   -> PackageId.t
   -> Cmd.t
@@ -74,12 +77,14 @@ end
 
 val makePlan :
   ?forceImmutable : bool
-  -> t
   -> BuildSpec.t
+  -> BuildSpec.mode
+  -> t
   -> Plan.t Run.t
 
 val buildShell :
   BuildSpec.t
+  -> BuildSpec.mode
   -> t
   -> PackageId.t
   -> Unix.process_status RunAsync.t

--- a/esy/BuildSandbox.mli
+++ b/esy/BuildSandbox.mli
@@ -21,7 +21,7 @@ val configure :
   ?forceImmutable:bool
   -> EnvSpec.t
   -> BuildSpec.t
-  -> BuildSpec.mode
+  -> BuildSpec.plan
   -> t
   -> PackageId.t
   -> (Scope.SandboxEnvironment.Bindings.t * Scope.t) Run.t
@@ -30,7 +30,7 @@ val env :
   ?forceImmutable:bool
   -> EnvSpec.t
   -> BuildSpec.t
-  -> BuildSpec.mode
+  -> BuildSpec.plan
   -> t
   -> PackageId.t
   -> Scope.SandboxEnvironment.Bindings.t Run.t
@@ -38,7 +38,7 @@ val env :
 val exec :
   EnvSpec.t
   -> BuildSpec.t
-  -> BuildSpec.mode
+  -> BuildSpec.plan
   -> t
   -> PackageId.t
   -> Cmd.t
@@ -78,13 +78,13 @@ end
 val makePlan :
   ?forceImmutable : bool
   -> BuildSpec.t
-  -> BuildSpec.mode
+  -> BuildSpec.plan
   -> t
   -> Plan.t Run.t
 
 val buildShell :
   BuildSpec.t
-  -> BuildSpec.mode
+  -> BuildSpec.plan
   -> t
   -> PackageId.t
   -> Unix.process_status RunAsync.t

--- a/esy/BuildSandbox.mli
+++ b/esy/BuildSandbox.mli
@@ -73,6 +73,7 @@ module Plan : sig
   val getByNameVersion : t -> string -> Version.t -> Task.t option
 
   val all : t -> Task.t list
+  val plan : t -> BuildSpec.plan
 end
 
 val makePlan :

--- a/esy/BuildSpec.ml
+++ b/esy/BuildSpec.ml
@@ -11,18 +11,22 @@ type t = {
 type mode =
   | Build
   | BuildDev
+  | BuildDevForce
 
 let pp_mode fmt = function
   | Build -> Fmt.string fmt "build"
   | BuildDev -> Fmt.string fmt "buildDev"
+  | BuildDevForce -> Fmt.string fmt "buildDevForce"
 
 let show_mode = function
   | Build -> "build"
   | BuildDev -> "buildDev"
+  | BuildDevForce -> "buildDevForce"
 
 let mode_to_yojson = function
   | Build -> `String "build"
   | BuildDev -> `String "buildDev"
+  | BuildDevForce -> `String "buildDevForce"
 
 let mode_of_yojson = function
   | `String "build" -> Ok Build
@@ -64,6 +68,8 @@ let classify spec plan solution pkg buildManifest =
     | Build, _ -> mode, commands
     | BuildDev, None -> Build, commands
     | BuildDev, Some commands -> BuildDev, BuildManifest.EsyCommands commands
+    | BuildDevForce, None -> mode, commands
+    | BuildDevForce, Some commands -> mode, BuildManifest.EsyCommands commands
   in
   let build =
     match kind with
@@ -75,7 +81,7 @@ let classify spec plan solution pkg buildManifest =
       end
     | `Root ->
       begin match mode with
-      | BuildDev ->
+      | BuildDev | BuildDevForce ->
         begin match spec.buildRootForDev, spec.buildRootForRelease, spec.buildLink with
         | Some build, _,          _     -> build
         | None,       Some build, _     -> build

--- a/esy/BuildSpec.mli
+++ b/esy/BuildSpec.mli
@@ -1,31 +1,34 @@
 (** This describes how a project should be built. *)
 
+open EsyPackageConfig
+
 type t = {
   (**
     Define how we build packages.
     *)
-  build : build;
+  build : DepSpec.t;
 
   (**
     Optionally define if we need to treat linked packages in a specific way.
 
     (this overrides buildLink and build)
     *)
-  buildLink : build option;
+  buildLink : DepSpec.t option;
 
   (**
     Optionally define if we need to treat the root package in a specific way.
 
     (this overrides buildLink and build)
     *)
-  buildRoot : build option;
+  buildRootForRelease : DepSpec.t option;
+  buildRootForDev : DepSpec.t option;
 }
 
 (**
   This is a pair of which build command to use ("build" or "buildDev") and
   a specification of what to bring into the build env.
  *)
-and build = {
+type build = {
   mode : mode;
   deps : DepSpec.t;
 }
@@ -39,4 +42,10 @@ val show_mode : mode -> string
 val mode_to_yojson : mode Json.encoder
 val mode_of_yojson : mode Json.decoder
 
-val classify : t -> EsyInstall.Solution.t -> EsyInstall.Package.t -> build
+val classify :
+  t
+  -> mode
+  -> EsyInstall.Solution.t
+  -> EsyInstall.Package.t
+  -> BuildManifest.t
+  -> build * BuildManifest.commands

--- a/esy/BuildSpec.mli
+++ b/esy/BuildSpec.mli
@@ -24,6 +24,16 @@ type t = {
   buildRootForDev : DepSpec.t option;
 }
 
+type mode =
+  | Build
+  | BuildDev
+
+val pp_mode : mode Fmt.t
+val show_mode : mode -> string
+
+val mode_to_yojson : mode Json.encoder
+val mode_of_yojson : mode Json.decoder
+
 (**
   This is a pair of which build command to use ("build" or "buildDev") and
   a specification of what to bring into the build env.
@@ -33,18 +43,18 @@ type build = {
   deps : DepSpec.t;
 }
 
-and mode =
-  | Build
-  | BuildDev
+type plan = {
+  all : mode;
+  link : mode;
+  root : mode;
+}
 
-val pp_mode : mode Fmt.t
-val show_mode : mode -> string
-val mode_to_yojson : mode Json.encoder
-val mode_of_yojson : mode Json.decoder
+val pp_plan : plan Fmt.t
+val show_plan : plan -> string
 
 val classify :
   t
-  -> mode
+  -> plan
   -> EsyInstall.Solution.t
   -> EsyInstall.Package.t
   -> BuildManifest.t

--- a/esy/BuildSpec.mli
+++ b/esy/BuildSpec.mli
@@ -1,32 +1,34 @@
 (** This describes how a project should be built. *)
 
 type t = {
+  (**
+    Define how we build packages.
+    *)
   build : build;
-  (** Define how we build packages. *)
 
+  (**
+    Optionally define if we need to treat linked packages in a specific way.
+
+    (this overrides buildLink and build)
+    *)
   buildLink : build option;
-  (**
-   * Optionally define if we need to treat linked packages in a specific way.
-   *
-   * (this overrides buildLink and build)
-   *)
 
-  buildRoot : build option;
   (**
-   * Optionally define if we need to treat the root packag in a specific way.
-   *
-   * (this overrides buildLink and build)
-   *)
+    Optionally define if we need to treat the root package in a specific way.
+
+    (this overrides buildLink and build)
+    *)
+  buildRoot : build option;
 }
 
+(**
+  This is a pair of which build command to use ("build" or "buildDev") and
+  a specification of what to bring into the build env.
+ *)
 and build = {
   mode : mode;
   deps : DepSpec.t;
 }
-(**
-  * This is a pair of which build command to use ("build" or "buildDev") and
-  * a specification of what to bring into the build env.
-  *)
 
 and mode =
   | Build

--- a/esy/BuildSpec.mli
+++ b/esy/BuildSpec.mli
@@ -27,6 +27,7 @@ type t = {
 type mode =
   | Build
   | BuildDev
+  | BuildDevForce
 
 val pp_mode : mode Fmt.t
 val show_mode : mode -> string

--- a/esy/Scope.ml
+++ b/esy/Scope.ml
@@ -283,7 +283,7 @@ end
 type t = {
   platform : System.Platform.t;
   pkg : Package.t;
-  mode : BuildSpec.mode;
+  build : BuildSpec.build;
 
   children : bool PackageId.Map.t;
 
@@ -301,11 +301,11 @@ let make
   ~id
   ~name
   ~version
-  ~mode
+  ~build
   ~sourceType
   ~sourcePath
   pkg
-  build =
+  buildManifest =
   let self =
     PackageScope.make
       ~id
@@ -313,7 +313,7 @@ let make
       ~version
       ~sourceType
       ~sourcePath
-      build
+      buildManifest
   in
   {
     platform;
@@ -322,7 +322,7 @@ let make
     dependencies = [];
     directDependencies = StringMap.empty;
     self;
-    mode;
+    build;
     pkg;
     finalEnv = (
       let defaultPath =
@@ -368,6 +368,7 @@ let add ~direct ~dep scope =
 let pkg scope = scope.pkg
 let id scope = PackageScope.id scope.self
 let name scope = PackageScope.name scope.self
+let build scope = scope.build
 let version scope = PackageScope.version scope.self
 let sourceType scope = PackageScope.sourceType scope.self
 let buildType scope = PackageScope.buildType scope.self
@@ -449,13 +450,13 @@ let makeEnvBindings ~buildIsInProgress ?origin bindings scope =
 
 let buildEnv ~buildIsInProgress scope =
   let open Run.Syntax in
-  let bindings = PackageScope.buildEnv ~buildIsInProgress scope.mode scope.self in
+  let bindings = PackageScope.buildEnv ~buildIsInProgress scope.build.mode scope.self in
   let%bind env = makeEnvBindings ~buildIsInProgress bindings scope in
   return env
 
 let buildEnvAuto ~buildIsInProgress scope =
   let open Run.Syntax in
-  let bindings = PackageScope.buildEnvAuto ~buildIsInProgress scope.mode scope.self in
+  let bindings = PackageScope.buildEnvAuto ~buildIsInProgress scope.build.mode scope.self in
   let%bind env = makeEnvBindings ~buildIsInProgress bindings scope in
   return env
 

--- a/esy/Scope.ml
+++ b/esy/Scope.ml
@@ -224,7 +224,7 @@ end = struct
     let p v = SandboxValue.show (SandboxPath.toValue v) in
     let dev =
       match mode, scope.sourceType with
-      | BuildSpec.BuildDev, Transient -> "true"
+      | (BuildSpec.BuildDev | BuildDevForce), Transient -> "true"
       | BuildSpec.Build, Transient -> "false"
       | _, Immutable
       | _, ImmutableWithTransientDependencies -> "false"

--- a/esy/Scope.mli
+++ b/esy/Scope.mli
@@ -12,7 +12,7 @@ val make :
   -> id:BuildId.t
   -> name:string
   -> version:Version.t
-  -> mode:BuildSpec.mode
+  -> build:BuildSpec.build
   -> sourceType:SourceType.t
   -> sourcePath:SandboxPath.t
   -> EsyInstall.Package.t
@@ -25,6 +25,7 @@ val add : direct:bool -> dep:t -> t -> t
 
 val pkg : t -> EsyInstall.Package.t
 val id : t -> BuildId.t
+val build : t -> BuildSpec.build
 val name : t -> string
 val version : t -> Version.t
 val sourceType : t -> SourceType.t

--- a/esy/bin/NpmReleaseCommand.ml
+++ b/esy/bin/NpmReleaseCommand.ml
@@ -327,7 +327,7 @@ let make
     BuildSandbox.makePlan
       ~forceImmutable:true
       buildspec
-      BuildSpec.Build
+      {all = Build; link = Build; root = Build;}
       sandbox
   ) in
   let tasks = BuildSandbox.Plan.all plan in
@@ -433,7 +433,7 @@ let make
           ~forceImmutable:true
           envspec
           buildspec
-          BuildSpec.Build
+          {all = Build; link = Build; root = Build;}
           sandbox
           root.Package.id
       ) in

--- a/esy/bin/NpmReleaseCommand.ml
+++ b/esy/bin/NpmReleaseCommand.ml
@@ -607,7 +607,7 @@ let run (proj : Project.WithWorkflow.t) =
         ~buildLinked:true
         ~buildDevDependencies:true
         proj
-        configured.Project.WithWorkflow.plan
+        configured.Project.WithWorkflow.planForDev
         configured.Project.WithWorkflow.root.pkg
     in
     let%bind p = Project.WithWorkflow.ocaml proj in

--- a/esy/bin/NpmReleaseCommand.ml
+++ b/esy/bin/NpmReleaseCommand.ml
@@ -288,9 +288,10 @@ let envspec = {
 }
 let buildspec = {
   BuildSpec.
-  build = {mode = Build; deps = DepSpec.(dependencies self);};
-  buildLink = Some {mode = Build; deps = DepSpec.(dependencies self);};
-  buildRoot = Some {mode = Build; deps = DepSpec.(dependencies self);};
+  build = DepSpec.(dependencies self);
+  buildLink = Some DepSpec.(dependencies self);
+  buildRootForDev = Some DepSpec.(dependencies self);
+  buildRootForRelease = Some DepSpec.(dependencies self);
 }
 
 let cleanupLinksFromGlobalStore cfg tasks =
@@ -325,8 +326,9 @@ let make
   let%bind plan = RunAsync.ofRun (
     BuildSandbox.makePlan
       ~forceImmutable:true
-      sandbox
       buildspec
+      BuildSpec.Build
+      sandbox
   ) in
   let tasks = BuildSandbox.Plan.all plan in
 
@@ -431,6 +433,7 @@ let make
           ~forceImmutable:true
           envspec
           buildspec
+          BuildSpec.Build
           sandbox
           root.Package.id
       ) in

--- a/esy/bin/Project.ml
+++ b/esy/bin/Project.ml
@@ -294,7 +294,7 @@ module WithWorkflow = struct
       let%bind plan =
         BuildSandbox.makePlan
           workflow.buildspec
-          BuildSpec.BuildDev
+          Workflow.defaultPlan
           sandbox
       in
       let pkg = EsyInstall.Solution.root solution in
@@ -345,7 +345,7 @@ module WithWorkflow = struct
           BuildSandbox.env
             configured.workflow.commandenvspec
             configured.workflow.buildspec
-            BuildSpec.BuildDev
+            Workflow.defaultPlan
             fetched.sandbox
             root.Package.id
         in
@@ -503,7 +503,7 @@ let printEnv
   (proj : _ project)
   envspec
   buildspec
-  mode
+  plan
   asJson
   pkgarg
   ()
@@ -530,7 +530,7 @@ let printEnv
         BuildSandbox.configure
           envspec
           buildspec
-          mode
+          plan
           fetched.sandbox
           pkg.id
       in
@@ -548,7 +548,7 @@ let printEnv
           Format.asprintf {|# %s
 # package:            %a
 # depspec:            %a
-# mode:               %a
+# plan:               %a
 # envspec:            %a
 # buildIsInProgress:  %b
 # includeBuildEnv:    %b
@@ -558,7 +558,7 @@ let printEnv
             name
             Package.pp pkg
             DepSpec.pp build.BuildSpec.deps
-            BuildSpec.pp_mode mode
+            BuildSpec.pp_plan plan
             (Fmt.option DepSpec.pp)
             envspec.EnvSpec.augmentDeps
             envspec.buildIsInProgress

--- a/esy/bin/Project.ml
+++ b/esy/bin/Project.ml
@@ -285,7 +285,7 @@ module WithWorkflow = struct
   type configured = {
     workflow : Workflow.t;
     scripts : Scripts.t;
-    plan : BuildSandbox.Plan.t;
+    planForDev : BuildSandbox.Plan.t;
     root : BuildSandbox.Task.t;
   }
 
@@ -297,12 +297,12 @@ module WithWorkflow = struct
 
     let%bind scripts = Scripts.ofSandbox projcfg.ProjectConfig.spec in
 
-    let%bind root, plan = RunAsync.ofRun (
+    let%bind root, planForDev = RunAsync.ofRun (
       let open Run.Syntax in
       let%bind plan =
         BuildSandbox.makePlan
           sandbox
-          workflow.buildspec
+          workflow.buildspecForDev
       in
       let pkg = EsyInstall.Solution.root solution in
       let root =
@@ -315,7 +315,7 @@ module WithWorkflow = struct
 
     return {
       workflow;
-      plan;
+      planForDev;
       root;
       scripts;
     }
@@ -350,7 +350,7 @@ module WithWorkflow = struct
         let header = "# Command environment" in
         let%bind commandEnv = BuildSandbox.env
           configured.workflow.commandenvspec
-          configured.workflow.buildspec
+          configured.workflow.buildspecForDev
           fetched.sandbox
           root.Package.id
         in
@@ -386,7 +386,7 @@ module WithWorkflow = struct
         let open Run.Syntax in
         let task =
           let open Option.Syntax in
-          let%bind task = BuildSandbox.Plan.getByName configured.plan name in
+          let%bind task = BuildSandbox.Plan.getByName configured.planForDev name in
           return task
         in
         return (task, fetched.sandbox)

--- a/esy/bin/Project.ml
+++ b/esy/bin/Project.ml
@@ -294,7 +294,7 @@ module WithWorkflow = struct
       let%bind plan =
         BuildSandbox.makePlan
           workflow.buildspec
-          Workflow.defaultPlan
+          Workflow.defaultPlanForDev
           sandbox
       in
       let pkg = EsyInstall.Solution.root solution in
@@ -345,7 +345,7 @@ module WithWorkflow = struct
           BuildSandbox.env
             configured.workflow.commandenvspec
             configured.workflow.buildspec
-            Workflow.defaultPlan
+            Workflow.defaultPlanForDev
             fetched.sandbox
             root.Package.id
         in

--- a/esy/bin/Project.mli
+++ b/esy/bin/Project.mli
@@ -101,6 +101,7 @@ val execCommand :
   -> _ fetched solved project
   -> EnvSpec.t
   -> BuildSpec.t
+  -> BuildSpec.mode
   -> PkgArg.t
   -> Cmd.t
   -> unit
@@ -111,6 +112,7 @@ val printEnv :
   -> _ fetched solved project
   -> EnvSpec.t
   -> BuildSpec.t
+  -> BuildSpec.mode
   -> bool
   -> PkgArg.t
   -> unit

--- a/esy/bin/Project.mli
+++ b/esy/bin/Project.mli
@@ -101,7 +101,7 @@ val execCommand :
   -> _ fetched solved project
   -> EnvSpec.t
   -> BuildSpec.t
-  -> BuildSpec.mode
+  -> BuildSpec.plan
   -> PkgArg.t
   -> Cmd.t
   -> unit
@@ -112,7 +112,7 @@ val printEnv :
   -> _ fetched solved project
   -> EnvSpec.t
   -> BuildSpec.t
-  -> BuildSpec.mode
+  -> BuildSpec.plan
   -> bool
   -> PkgArg.t
   -> unit

--- a/esy/bin/Project.mli
+++ b/esy/bin/Project.mli
@@ -54,7 +54,7 @@ module WithWorkflow : sig
   and configured = {
     workflow : Workflow.t;
     scripts : Scripts.t;
-    plan : BuildSandbox.Plan.t;
+    planForDev : BuildSandbox.Plan.t;
     root : BuildSandbox.Task.t;
   }
 

--- a/esy/bin/Workflow.ml
+++ b/esy/bin/Workflow.ml
@@ -12,6 +12,13 @@ let defaultDepspecForLink = DepSpec.(dependencies self)
 let defaultDepspecForRootForRelease = DepSpec.(dependencies self)
 let defaultDepspecForRootForDev = DepSpec.(dependencies self + devDependencies self)
 
+let defaultPlanForRelease = {
+  BuildSpec.
+  all = Build;
+  link = Build;
+  root = Build;
+}
+
 let defaultPlanForDev = {
   BuildSpec.
   all = Build;
@@ -19,11 +26,11 @@ let defaultPlanForDev = {
   root = BuildDev;
 }
 
-let defaultPlanForRelease = {
+let defaultPlanForDevForce = {
   BuildSpec.
   all = Build;
   link = Build;
-  root = Build;
+  root = BuildDevForce;
 }
 
 let default =

--- a/esy/bin/Workflow.ml
+++ b/esy/bin/Workflow.ml
@@ -12,11 +12,18 @@ let defaultDepspecForLink = DepSpec.(dependencies self)
 let defaultDepspecForRootForRelease = DepSpec.(dependencies self)
 let defaultDepspecForRootForDev = DepSpec.(dependencies self + devDependencies self)
 
-let defaultPlan = {
+let defaultPlanForDev = {
   BuildSpec.
   all = Build;
   link = Build;
   root = BuildDev;
+}
+
+let defaultPlanForRelease = {
+  BuildSpec.
+  all = Build;
+  link = Build;
+  root = Build;
 }
 
 let default =

--- a/esy/bin/Workflow.ml
+++ b/esy/bin/Workflow.ml
@@ -12,6 +12,13 @@ let defaultDepspecForLink = DepSpec.(dependencies self)
 let defaultDepspecForRootForRelease = DepSpec.(dependencies self)
 let defaultDepspecForRootForDev = DepSpec.(dependencies self + devDependencies self)
 
+let defaultPlan = {
+  BuildSpec.
+  all = Build;
+  link = Build;
+  root = BuildDev;
+}
+
 let default =
 
   (* This defines how project is built. *)

--- a/esy/bin/Workflow.ml
+++ b/esy/bin/Workflow.ml
@@ -1,7 +1,8 @@
 open Esy
 
 type t = {
-  buildspec : BuildSpec.t;
+  buildspecForDev : BuildSpec.t;
+  buildspecForRelease : BuildSpec.t;
   execenvspec : EnvSpec.t;
   commandenvspec : EnvSpec.t;
   buildenvspec : EnvSpec.t;
@@ -14,7 +15,7 @@ let defaultDepspecForRoot = DepSpec.(dependencies self)
 let default =
 
   (* This defines how project is built. *)
-  let buildspec = {
+  let buildspecForDev = {
     BuildSpec.
     (* build all other packages using "build" command with dependencies in the env *)
     build = {mode = Build; deps = defaultDepspec};
@@ -23,6 +24,16 @@ let default =
     (* build linked packages using "buildDev" command with dependencies in the env *)
     buildRoot = Some {mode = BuildDev; deps = defaultDepspecForRoot};
   } in
+
+  let buildspecForRelease =
+    let build = {BuildSpec.mode = Build; deps = defaultDepspec} in
+    {
+      BuildSpec.
+      build = build;
+      buildLink = Some build;
+      buildRoot = Some build;
+    }
+  in
 
   (* This defines environment for "esy x CMD" invocation. *)
   let execenvspec = {
@@ -60,4 +71,4 @@ let default =
     augmentDeps = None;
   } in
 
-  {buildspec; execenvspec; commandenvspec; buildenvspec;}
+  {buildspecForDev; buildspecForRelease; execenvspec; commandenvspec; buildenvspec;}

--- a/esy/bin/Workflow.ml
+++ b/esy/bin/Workflow.ml
@@ -1,8 +1,7 @@
 open Esy
 
 type t = {
-  buildspecForDev : BuildSpec.t;
-  buildspecForRelease : BuildSpec.t;
+  buildspec : BuildSpec.t;
   execenvspec : EnvSpec.t;
   commandenvspec : EnvSpec.t;
   buildenvspec : EnvSpec.t;
@@ -10,30 +9,22 @@ type t = {
 
 let defaultDepspec = DepSpec.(dependencies self)
 let defaultDepspecForLink = DepSpec.(dependencies self)
-let defaultDepspecForRoot = DepSpec.(dependencies self)
+let defaultDepspecForRootForRelease = DepSpec.(dependencies self)
+let defaultDepspecForRootForDev = DepSpec.(dependencies self + devDependencies self)
 
 let default =
 
   (* This defines how project is built. *)
-  let buildspecForDev = {
+  let buildspec = {
     BuildSpec.
     (* build all other packages using "build" command with dependencies in the env *)
-    build = {mode = Build; deps = defaultDepspec};
-    (* build linked packages using "buildDev" command with dependencies in the env *)
-    buildLink = Some {mode = BuildDev; deps = defaultDepspecForLink};
-    (* build linked packages using "buildDev" command with dependencies in the env *)
-    buildRoot = Some {mode = BuildDev; deps = defaultDepspecForRoot};
-  } in
+    build = defaultDepspec;
+    (* build linked packages using "build" command with dependencies in the env *)
+    buildLink = Some defaultDepspecForLink;
 
-  let buildspecForRelease =
-    let build = {BuildSpec.mode = Build; deps = defaultDepspec} in
-    {
-      BuildSpec.
-      build = build;
-      buildLink = Some build;
-      buildRoot = Some build;
-    }
-  in
+    buildRootForRelease = Some defaultDepspecForRootForRelease;
+    buildRootForDev = Some defaultDepspecForRootForDev;
+  } in
 
   (* This defines environment for "esy x CMD" invocation. *)
   let execenvspec = {
@@ -71,4 +62,4 @@ let default =
     augmentDeps = None;
   } in
 
-  {buildspecForDev; buildspecForRelease; execenvspec; commandenvspec; buildenvspec;}
+  {buildspec; execenvspec; commandenvspec; buildenvspec;}

--- a/esy/bin/Workflow.mli
+++ b/esy/bin/Workflow.mli
@@ -1,7 +1,8 @@
 open Esy
 
 type t = {
-  buildspec : BuildSpec.t;
+  buildspecForDev : BuildSpec.t;
+  buildspecForRelease : BuildSpec.t;
   execenvspec : EnvSpec.t;
   commandenvspec : EnvSpec.t;
   buildenvspec : EnvSpec.t;

--- a/esy/bin/Workflow.mli
+++ b/esy/bin/Workflow.mli
@@ -12,6 +12,8 @@ val defaultDepspecForLink : DepSpec.t
 val defaultDepspecForRootForDev : DepSpec.t
 val defaultDepspecForRootForRelease : DepSpec.t
 
-val defaultPlanForDev : BuildSpec.plan
 val defaultPlanForRelease : BuildSpec.plan
+val defaultPlanForDev : BuildSpec.plan
+val defaultPlanForDevForce : BuildSpec.plan
+
 val default : t

--- a/esy/bin/Workflow.mli
+++ b/esy/bin/Workflow.mli
@@ -1,8 +1,7 @@
 open Esy
 
 type t = {
-  buildspecForDev : BuildSpec.t;
-  buildspecForRelease : BuildSpec.t;
+  buildspec : BuildSpec.t;
   execenvspec : EnvSpec.t;
   commandenvspec : EnvSpec.t;
   buildenvspec : EnvSpec.t;
@@ -10,6 +9,7 @@ type t = {
 
 val defaultDepspec : DepSpec.t
 val defaultDepspecForLink : DepSpec.t
-val defaultDepspecForRoot : DepSpec.t
+val defaultDepspecForRootForDev : DepSpec.t
+val defaultDepspecForRootForRelease : DepSpec.t
 
 val default : t

--- a/esy/bin/Workflow.mli
+++ b/esy/bin/Workflow.mli
@@ -12,4 +12,5 @@ val defaultDepspecForLink : DepSpec.t
 val defaultDepspecForRootForDev : DepSpec.t
 val defaultDepspecForRootForRelease : DepSpec.t
 
+val defaultPlan : BuildSpec.plan
 val default : t

--- a/esy/bin/Workflow.mli
+++ b/esy/bin/Workflow.mli
@@ -12,5 +12,6 @@ val defaultDepspecForLink : DepSpec.t
 val defaultDepspecForRootForDev : DepSpec.t
 val defaultDepspecForRootForRelease : DepSpec.t
 
-val defaultPlan : BuildSpec.plan
+val defaultPlanForDev : BuildSpec.plan
+val defaultPlanForRelease : BuildSpec.plan
 val default : t

--- a/esy/bin/esyCommand.ml
+++ b/esy/bin/esyCommand.ml
@@ -38,6 +38,7 @@ let modeConv =
     match v with
     | BuildSpec.Build -> Fmt.unit "release" fmt ()
     | BuildSpec.BuildDev -> Fmt.unit "dev" fmt ()
+    | BuildSpec.BuildDevForce -> Fmt.unit "force-dev" fmt ()
   in
   let parse v =
     match v with
@@ -501,7 +502,7 @@ let build ?(buildOnly=true) ?(release=false) (proj : Project.WithWorkflow.t) cmd
         BuildSandbox.makePlan
           Workflow.default.buildspec
           Workflow.defaultPlanForRelease
-          fetched.sandbox
+          fetched.Project.sandbox
       else
         return configured.Project.WithWorkflow.planForDev
     )
@@ -540,7 +541,9 @@ let build ?(buildOnly=true) ?(release=false) (proj : Project.WithWorkflow.t) cmd
       proj
       configured.workflow.buildenvspec
       configured.workflow.buildspec
-      (BuildSandbox.Plan.plan plan)
+      (if release
+      then BuildSandbox.Plan.plan plan
+      else Workflow.defaultPlanForDevForce)
       PkgArg.root
       cmd
       ()

--- a/test-e2e/complete/monorepo-workflow.test.js
+++ b/test-e2e/complete/monorepo-workflow.test.js
@@ -147,11 +147,11 @@ describe('Monorepo workflow using low level commands', function() {
     // release build should work as-is as we are building using `"esy.build"`
     // commands.
     const p = await createTestSandbox();
-    await p.esy('build-dependencies --all --release');
+    await p.esy('build-dependencies --all --link-mode release');
 
     for (const pkg of ['pkga', 'pkgb', 'pkgc']) {
       const {stdout} = await p.esy(
-        `exec-command --release --include-current-env root -- ${pkg}.cmd`,
+        `exec-command --link-mode release --include-current-env root -- ${pkg}.cmd`,
       );
       expect(stdout.trim()).toBe(`__${pkg}__`);
     }

--- a/test-e2e/esy-build-CMD.test.js
+++ b/test-e2e/esy-build-CMD.test.js
@@ -8,32 +8,32 @@ const {packageJson, dir, file, dummyExecutable, buildCommand} = helpers;
 
 helpers.skipSuiteOnWindows();
 
-describe(`'esy build CMD' invocation`, () => {
-  function createPackage(p, {name, dependencies}: {name: string, dependencies?: Object}) {
-    return dir(
+function createPackage(p, {name, dependencies}: {name: string, dependencies?: Object}) {
+  return dir(
+    name,
+    packageJson({
       name,
-      packageJson({
-        name,
-        version: '1.0.0',
-        dependencies,
-        esy: {
-          install: [
-            'cp #{self.root / self.name}.js #{self.bin / self.name}.js',
-            buildCommand(p, '#{self.bin / self.name}.js'),
-          ],
-          buildEnv: {
-            [`${name}__buildvar`]: `${name}__buildvar__value`,
-          },
-          exportedEnv: {
-            [`${name}__local`]: {val: `${name}__local__value`},
-            [`${name}__global`]: {val: `${name}__global__value`, scope: 'global'},
-          },
+      version: '1.0.0',
+      dependencies,
+      esy: {
+        install: [
+          'cp #{self.root / self.name}.js #{self.bin / self.name}.js',
+          buildCommand(p, '#{self.bin / self.name}.js'),
+        ],
+        buildEnv: {
+          [`${name}__buildvar`]: `${name}__buildvar__value`,
         },
-      }),
+        exportedEnv: {
+          [`${name}__local`]: {val: `${name}__local__value`},
+          [`${name}__global`]: {val: `${name}__global__value`, scope: 'global'},
+        },
+      },
+    }),
+    dummyExecutable(name),
+  );
+}
 
-      dummyExecutable(name),
-    );
-  }
+describe(`'esy build CMD' invocation`, () => {
 
   async function createTestSandbox() {
     const p = await helpers.createTestSandbox();
@@ -43,6 +43,14 @@ describe(`'esy build CMD' invocation`, () => {
         name,
         version: '1.0.0',
         esy: {
+          build: [
+            ['cp', '#{self.name}.js', '#{self.target_dir / self.name}.js'],
+            helpers.buildCommand(p, '#{self.target_dir / self.name}.js'),
+          ],
+          install: [
+            `cp #{self.target_dir / self.name}.cmd #{self.bin / self.name}.cmd`,
+            `cp #{self.target_dir / self.name}.js #{self.bin / self.name}.js`,
+          ],
           buildEnv: {
             [`${name}__buildvar`]: `${name}__buildvar__value`,
           },
@@ -62,6 +70,7 @@ describe(`'esy build CMD' invocation`, () => {
           linkedDep: 'link:./linkedDep',
         },
       }),
+      dummyExecutable(name),
       createPackage(p, {name: 'dep', dependencies: {depOfDep: 'path:../depOfDep'}}),
       createPackage(p, {name: 'depOfDep'}),
       createPackage(p, {name: 'linkedDep'}),
@@ -140,4 +149,100 @@ describe(`'esy build CMD' invocation`, () => {
       expect.objectContaining({code: 7}),
     );
   });
+});
+
+describe(`'esy build CMD' invocation ("buildDev" config at the root)`, () => {
+
+  async function createTestSandbox() {
+    const p = await helpers.createTestSandbox();
+    const name = 'root';
+    await p.fixture(
+      packageJson({
+        name,
+        version: '1.0.0',
+        esy: {
+          build: [
+            ['cp', '#{self.name}.js', '#{self.target_dir / self.name}.js'],
+            helpers.buildCommand(p, '#{self.target_dir / self.name}.js'),
+          ],
+          buildDev: [
+            ['cp', '#{self.name}-dev.js', '#{self.target_dir / self.name}.js'],
+            helpers.buildCommand(p, '#{self.target_dir / self.name}.js'),
+          ],
+          install: [
+            `cp #{self.target_dir / self.name}.cmd #{self.bin / self.name}.cmd`,
+            `cp #{self.target_dir / self.name}.js #{self.bin / self.name}.js`,
+          ],
+          buildEnv: {
+            [`${name}__buildvar`]: `${name}__buildvar__value`,
+          },
+          exportedEnv: {
+            [`${name}__local`]: {val: `${name}__local__value`},
+            [`${name}__global`]: {val: `${name}__global__value`, scope: 'global'},
+          },
+        },
+        dependencies: {
+          dep: 'path:./dep',
+          linkedDep: '*',
+        },
+        devDependencies: {
+          devDep: 'path:./devDep',
+        },
+        resolutions: {
+          linkedDep: 'link:./linkedDep',
+        },
+      }),
+      dummyExecutable(name),
+      dummyExecutable(name + '-dev'),
+      createPackage(p, {name: 'dep', dependencies: {depOfDep: 'path:../depOfDep'}}),
+      createPackage(p, {name: 'depOfDep'}),
+      createPackage(p, {name: 'linkedDep'}),
+      createPackage(p, {name: 'devDep'}),
+    );
+    return p;
+  }
+
+  it(`can access dependencies`, async () => {
+    const p = await createTestSandbox();
+    await p.esy('install');
+    await p.esy('build');
+
+    await expect(p.esy('build dep.cmd')).resolves.toEqual({
+      stdout: '__dep__' + os.EOL,
+      stderr: '',
+    });
+  });
+
+  it(`can access dependencies if --release is passed`, async () => {
+    const p = await createTestSandbox();
+    await p.esy('install');
+    await p.esy('build');
+
+    await expect(p.esy('build dep.cmd')).resolves.toEqual({
+      stdout: '__dep__' + os.EOL,
+      stderr: '',
+    });
+  });
+
+  it(`can access devDependencies`, async () => {
+    const p = await createTestSandbox();
+    await p.esy('install');
+    await p.esy('build');
+
+    await expect(p.esy('build devDep.cmd')).resolves.toEqual({
+      stdout: '__devDep__' + os.EOL,
+      stderr: '',
+    });
+  });
+
+  it(`cannot access devDependencies if --release is passed`, async () => {
+    const p = await createTestSandbox();
+    await p.esy('install');
+    await p.esy('build');
+
+    await expect(p.esy('build --release devDep.cmd')).rejects.toMatchObject({
+      message: expect.stringMatching('unable to resolve command: devDep.cmd')
+    });
+  });
+
 });

--- a/test-e2e/esy-build-CMD.test.js
+++ b/test-e2e/esy-build-CMD.test.js
@@ -95,8 +95,9 @@ describe(`'esy build CMD' invocation`, () => {
     await p.esy('install');
     await p.esy('build');
 
-    await expect(p.esy('build devDep.cmd')).rejects.toMatchObject({
-      code: 1,
+    await expect(p.esy('build devDep.cmd')).resolves.toMatchObject({
+      stdout: '__devDep__' + os.EOL,
+      stderr: '',
     });
   });
 

--- a/test-e2e/esy-build-CMD.test.js
+++ b/test-e2e/esy-build-CMD.test.js
@@ -90,7 +90,7 @@ describe(`'esy build CMD' invocation`, () => {
     });
   });
 
-  it(`cannot invoke commands defined in devDependencies`, async () => {
+  it(`can invoke commands defined in devDependencies`, async () => {
     const p = await createTestSandbox();
     await p.esy('install');
     await p.esy('build');
@@ -98,6 +98,17 @@ describe(`'esy build CMD' invocation`, () => {
     await expect(p.esy('build devDep.cmd')).resolves.toMatchObject({
       stdout: '__devDep__' + os.EOL,
       stderr: '',
+    });
+  });
+
+  it(`cannot invoke commands defined in devDependencies if --release is passed`, async () => {
+    const p = await createTestSandbox();
+    await p.esy('install');
+    await p.esy('build');
+
+    await expect(p.esy('build --release devDep.cmd')).rejects.toMatchObject({
+      stdout: '',
+      stderr: expect.stringMatching('unable to resolve command: devDep.cmd'),
     });
   });
 

--- a/test-e2e/esy-build-env.test.js
+++ b/test-e2e/esy-build-env.test.js
@@ -101,7 +101,7 @@ describe(`'esy build-env' command`, () => {
 
     expect(env.cur__name).toBe('simple-project');
     expect(env.cur__version).toBe('1.0.0');
-    expect(env.cur__dev).toBe('true');
+    expect(env.cur__dev).toBe('false');
     expect(env.cur__toplevel).toBeTruthy();
     expect(env.cur__target_dir).toBeTruthy();
     expect(env.cur__stublibs).toBeTruthy();
@@ -166,7 +166,7 @@ describe(`'esy build-env' command`, () => {
 
     const env = JSON.parse((await p.esy('build-env --json linkedDep')).stdout);
     expect(env.cur__name).toBe('linkedDep');
-    expect(env.cur__dev).toBe('true');
+    expect(env.cur__dev).toBe('false');
   });
 
   it('allows to query build env for a dep (by name, version)', async () => {

--- a/test-e2e/esy-build/__snapshots__/no-deps.test.js.snap
+++ b/test-e2e/esy-build/__snapshots__/no-deps.test.js.snap
@@ -4,7 +4,7 @@ exports[`'esy build': simple executable with no deps out of source build macos |
 "# Build environment
 # package:            no-deps@link:./package.json
 # depspec:            dependencies(self)
-# mode:               buildDev
+# plan:               root=buildDev link=build all=build
 # envspec:            
 # buildIsInProgress:  true
 # includeBuildEnv:    true

--- a/test-e2e/esy-build/__snapshots__/no-deps.test.js.snap
+++ b/test-e2e/esy-build/__snapshots__/no-deps.test.js.snap
@@ -4,6 +4,7 @@ exports[`'esy build': simple executable with no deps out of source build macos |
 "# Build environment
 # package:            no-deps@link:./package.json
 # depspec:            dependencies(self)
+# mode:               buildDev
 # envspec:            
 # buildIsInProgress:  true
 # includeBuildEnv:    true
@@ -27,7 +28,7 @@ export cur__install=\\"%projectPath%/_esy/default/store/i/%id%\\"
 export cur__target_dir=\\"%projectPath%/_esy/default/store/b/%id%\\"
 export cur__original_root=\\"%projectPath%\\"
 export cur__root=\\"%projectPath%\\"
-export cur__dev=\\"true\\"
+export cur__dev=\\"false\\"
 export cur__version=\\"1.0.0\\"
 export cur__name=\\"no-deps\\"
 export OCAMLFIND_LDCONF=\\"ignore\\"

--- a/test-e2e/esy-build/__snapshots__/optDependencies.test.js.snap
+++ b/test-e2e/esy-build/__snapshots__/optDependencies.test.js.snap
@@ -4,7 +4,7 @@ exports[`Build with optDependencies builds w/ opt dependency installed snapshot 
 "# Build environment
 # package:            root@link:./package.json
 # depspec:            dependencies(self)
-# mode:               buildDev
+# plan:               root=buildDev link=build all=build
 # envspec:            
 # buildIsInProgress:  true
 # includeBuildEnv:    true
@@ -62,7 +62,7 @@ exports[`Build with optDependencies builds w/ opt dependency installed snapshot 
 "# Build environment
 # package:            dep@path:dep
 # depspec:            dependencies(self)
-# mode:               buildDev
+# plan:               root=buildDev link=build all=build
 # envspec:            
 # buildIsInProgress:  true
 # includeBuildEnv:    true
@@ -112,7 +112,7 @@ exports[`Build with optDependencies builds w/o opt dependency installed snapshot
 "# Build environment
 # package:            root@link:./package.json
 # depspec:            dependencies(self)
-# mode:               buildDev
+# plan:               root=buildDev link=build all=build
 # envspec:            
 # buildIsInProgress:  true
 # includeBuildEnv:    true
@@ -162,7 +162,7 @@ exports[`Build with optDependencies builds w/o opt dependency installed snapshot
 "# Build environment
 # package:            dep@path:dep
 # depspec:            dependencies(self)
-# mode:               buildDev
+# plan:               root=buildDev link=build all=build
 # envspec:            
 # buildIsInProgress:  true
 # includeBuildEnv:    true

--- a/test-e2e/esy-build/__snapshots__/optDependencies.test.js.snap
+++ b/test-e2e/esy-build/__snapshots__/optDependencies.test.js.snap
@@ -4,6 +4,7 @@ exports[`Build with optDependencies builds w/ opt dependency installed snapshot 
 "# Build environment
 # package:            root@link:./package.json
 # depspec:            dependencies(self)
+# mode:               buildDev
 # envspec:            
 # buildIsInProgress:  true
 # includeBuildEnv:    true
@@ -27,7 +28,7 @@ export cur__install=\\"%projectPath%/_esy/default/store/i/%id%\\"
 export cur__target_dir=\\"%projectPath%/_esy/default/store/b/%id%\\"
 export cur__original_root=\\"%projectPath%\\"
 export cur__root=\\"%projectPath%\\"
-export cur__dev=\\"true\\"
+export cur__dev=\\"false\\"
 export cur__version=\\"1.0.0\\"
 export cur__name=\\"root\\"
 
@@ -61,6 +62,7 @@ exports[`Build with optDependencies builds w/ opt dependency installed snapshot 
 "# Build environment
 # package:            dep@path:dep
 # depspec:            dependencies(self)
+# mode:               buildDev
 # envspec:            
 # buildIsInProgress:  true
 # includeBuildEnv:    true
@@ -110,6 +112,7 @@ exports[`Build with optDependencies builds w/o opt dependency installed snapshot
 "# Build environment
 # package:            root@link:./package.json
 # depspec:            dependencies(self)
+# mode:               buildDev
 # envspec:            
 # buildIsInProgress:  true
 # includeBuildEnv:    true
@@ -133,7 +136,7 @@ export cur__install=\\"%projectPath%/_esy/default/store/i/%id%\\"
 export cur__target_dir=\\"%projectPath%/_esy/default/store/b/%id%\\"
 export cur__original_root=\\"%projectPath%\\"
 export cur__root=\\"%projectPath%\\"
-export cur__dev=\\"true\\"
+export cur__dev=\\"false\\"
 export cur__version=\\"1.0.0\\"
 export cur__name=\\"root\\"
 
@@ -159,6 +162,7 @@ exports[`Build with optDependencies builds w/o opt dependency installed snapshot
 "# Build environment
 # package:            dep@path:dep
 # depspec:            dependencies(self)
+# mode:               buildDev
 # envspec:            
 # buildIsInProgress:  true
 # includeBuildEnv:    true

--- a/test-e2e/esy-build/__snapshots__/with-dep.test.js.snap
+++ b/test-e2e/esy-build/__snapshots__/with-dep.test.js.snap
@@ -4,6 +4,7 @@ exports[`Build with dep out of source build macos || linux: build-env dep snapsh
 "# Build environment
 # package:            dep@path:dep
 # depspec:            dependencies(self)
+# mode:               buildDev
 # envspec:            
 # buildIsInProgress:  true
 # includeBuildEnv:    true
@@ -57,6 +58,7 @@ exports[`Build with dep out of source build macos || linux: build-env snapshot 1
 "# Build environment
 # package:            withDep@link:./package.json
 # depspec:            dependencies(self)
+# mode:               buildDev
 # envspec:            
 # buildIsInProgress:  true
 # includeBuildEnv:    true
@@ -80,7 +82,7 @@ export cur__install=\\"%projectPath%/_esy/default/store/i/%id%\\"
 export cur__target_dir=\\"%projectPath%/_esy/default/store/b/%id%\\"
 export cur__original_root=\\"%projectPath%\\"
 export cur__root=\\"%projectPath%\\"
-export cur__dev=\\"true\\"
+export cur__dev=\\"false\\"
 export cur__version=\\"1.0.0\\"
 export cur__name=\\"withDep\\"
 

--- a/test-e2e/esy-build/__snapshots__/with-dep.test.js.snap
+++ b/test-e2e/esy-build/__snapshots__/with-dep.test.js.snap
@@ -4,7 +4,7 @@ exports[`Build with dep out of source build macos || linux: build-env dep snapsh
 "# Build environment
 # package:            dep@path:dep
 # depspec:            dependencies(self)
-# mode:               buildDev
+# plan:               root=buildDev link=build all=build
 # envspec:            
 # buildIsInProgress:  true
 # includeBuildEnv:    true
@@ -58,7 +58,7 @@ exports[`Build with dep out of source build macos || linux: build-env snapshot 1
 "# Build environment
 # package:            withDep@link:./package.json
 # depspec:            dependencies(self)
-# mode:               buildDev
+# plan:               root=buildDev link=build all=build
 # envspec:            
 # buildIsInProgress:  true
 # includeBuildEnv:    true

--- a/test-e2e/esy-build/__snapshots__/with-dev-dep.test.js.snap
+++ b/test-e2e/esy-build/__snapshots__/with-dev-dep.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`devDep workflow macos || linux: build-env dep snapshot 1`] = `
+exports[`Project with "devDependencies" macos || linux: build-env dep snapshot 1`] = `
 "# Build environment
 # package:            dep@path:dep
 # depspec:            dependencies(self)
@@ -37,7 +37,7 @@ export SHELL=\\"env -i /bin/bash --norc --noprofile\\"
 export PATH=\\"$PATH:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\""
 `;
 
-exports[`devDep workflow macos || linux: build-env devDep snapshot 1`] = `
+exports[`Project with "devDependencies" macos || linux: build-env devDep snapshot 1`] = `
 "# Build environment
 # package:            devDep@path:devDep
 # depspec:            dependencies(self)
@@ -86,7 +86,7 @@ export SHELL=\\"env -i /bin/bash --norc --noprofile\\"
 export PATH=\\"$PATH:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\""
 `;
 
-exports[`devDep workflow macos || linux: build-env snapshot 1`] = `
+exports[`Project with "devDependencies" macos || linux: build-env snapshot 1`] = `
 "# Build environment
 # package:            withDevDep@link:./package.json
 # depspec:            dependencies(self)

--- a/test-e2e/esy-build/__snapshots__/with-dev-dep.test.js.snap
+++ b/test-e2e/esy-build/__snapshots__/with-dev-dep.test.js.snap
@@ -4,7 +4,7 @@ exports[`devDep workflow macos || linux: build-env dep snapshot 1`] = `
 "# Build environment
 # package:            dep@path:dep
 # depspec:            dependencies(self)
-# mode:               buildDev
+# plan:               root=buildDev link=build all=build
 # envspec:            
 # buildIsInProgress:  true
 # includeBuildEnv:    true
@@ -41,7 +41,7 @@ exports[`devDep workflow macos || linux: build-env devDep snapshot 1`] = `
 "# Build environment
 # package:            devDep@path:devDep
 # depspec:            dependencies(self)
-# mode:               buildDev
+# plan:               root=buildDev link=build all=build
 # envspec:            
 # buildIsInProgress:  true
 # includeBuildEnv:    true
@@ -90,7 +90,7 @@ exports[`devDep workflow macos || linux: build-env snapshot 1`] = `
 "# Build environment
 # package:            withDevDep@link:./package.json
 # depspec:            dependencies(self)
-# mode:               buildDev
+# plan:               root=buildDev link=build all=build
 # envspec:            
 # buildIsInProgress:  true
 # includeBuildEnv:    true

--- a/test-e2e/esy-build/__snapshots__/with-dev-dep.test.js.snap
+++ b/test-e2e/esy-build/__snapshots__/with-dev-dep.test.js.snap
@@ -4,6 +4,7 @@ exports[`devDep workflow macos || linux: build-env dep snapshot 1`] = `
 "# Build environment
 # package:            dep@path:dep
 # depspec:            dependencies(self)
+# mode:               buildDev
 # envspec:            
 # buildIsInProgress:  true
 # includeBuildEnv:    true
@@ -40,6 +41,7 @@ exports[`devDep workflow macos || linux: build-env devDep snapshot 1`] = `
 "# Build environment
 # package:            devDep@path:devDep
 # depspec:            dependencies(self)
+# mode:               buildDev
 # envspec:            
 # buildIsInProgress:  true
 # includeBuildEnv:    true
@@ -88,6 +90,7 @@ exports[`devDep workflow macos || linux: build-env snapshot 1`] = `
 "# Build environment
 # package:            withDevDep@link:./package.json
 # depspec:            dependencies(self)
+# mode:               buildDev
 # envspec:            
 # buildIsInProgress:  true
 # includeBuildEnv:    true
@@ -111,7 +114,7 @@ export cur__install=\\"%projectPath%/_esy/default/store/i/%id%\\"
 export cur__target_dir=\\"%projectPath%/_esy/default/store/b/%id%\\"
 export cur__original_root=\\"%projectPath%\\"
 export cur__root=\\"%projectPath%\\"
-export cur__dev=\\"true\\"
+export cur__dev=\\"false\\"
 export cur__version=\\"1.0.0\\"
 export cur__name=\\"withDevDep\\"
 

--- a/test-e2e/esy-build/__snapshots__/with-linked-dep.test.js.snap
+++ b/test-e2e/esy-build/__snapshots__/with-linked-dep.test.js.snap
@@ -4,7 +4,7 @@ exports[`Build with a linked dep out of source build macos || linux: build-env d
 "# Build environment
 # package:            dep@link:dep
 # depspec:            dependencies(self)
-# mode:               buildDev
+# plan:               root=buildDev link=build all=build
 # envspec:            
 # buildIsInProgress:  true
 # includeBuildEnv:    true
@@ -42,7 +42,7 @@ exports[`Build with a linked dep out of source build macos || linux: build-env s
 "# Build environment
 # package:            with-linked-dep-_build@link:./package.json
 # depspec:            dependencies(self)
-# mode:               buildDev
+# plan:               root=buildDev link=build all=build
 # envspec:            
 # buildIsInProgress:  true
 # includeBuildEnv:    true

--- a/test-e2e/esy-build/__snapshots__/with-linked-dep.test.js.snap
+++ b/test-e2e/esy-build/__snapshots__/with-linked-dep.test.js.snap
@@ -4,6 +4,7 @@ exports[`Build with a linked dep out of source build macos || linux: build-env d
 "# Build environment
 # package:            dep@link:dep
 # depspec:            dependencies(self)
+# mode:               buildDev
 # envspec:            
 # buildIsInProgress:  true
 # includeBuildEnv:    true
@@ -27,7 +28,7 @@ export cur__install=\\"%projectPath%/_esy/default/store/i/%id%\\"
 export cur__target_dir=\\"%projectPath%/_esy/default/store/b/%id%\\"
 export cur__original_root=\\"%projectPath%/dep\\"
 export cur__root=\\"%projectPath%/dep\\"
-export cur__dev=\\"true\\"
+export cur__dev=\\"false\\"
 export cur__version=\\"1.0.0\\"
 export cur__name=\\"dep\\"
 export OCAMLFIND_LDCONF=\\"ignore\\"
@@ -41,6 +42,7 @@ exports[`Build with a linked dep out of source build macos || linux: build-env s
 "# Build environment
 # package:            with-linked-dep-_build@link:./package.json
 # depspec:            dependencies(self)
+# mode:               buildDev
 # envspec:            
 # buildIsInProgress:  true
 # includeBuildEnv:    true
@@ -64,7 +66,7 @@ export cur__install=\\"%projectPath%/_esy/default/store/i/%id%\\"
 export cur__target_dir=\\"%projectPath%/_esy/default/store/b/%id%\\"
 export cur__original_root=\\"%projectPath%\\"
 export cur__root=\\"%projectPath%\\"
-export cur__dev=\\"true\\"
+export cur__dev=\\"false\\"
 export cur__version=\\"1.0.0\\"
 export cur__name=\\"with-linked-dep-_build\\"
 

--- a/test-e2e/esy-build/with-dep.test.js
+++ b/test-e2e/esy-build/with-dep.test.js
@@ -63,23 +63,6 @@ describe('Build with dep', () => {
   let winsysDir =
     process.platform === 'win32' ? [helpers.getWindowsSystemDirectory()] : [];
 
-  async function checkDepIsInEnv(p) {
-    {
-      const {stdout} = await p.esy('dep.cmd');
-      expect(stdout.trim()).toEqual('__dep__');
-    }
-
-    {
-      const {stdout} = await p.esy('b dep.cmd');
-      expect(stdout.trim()).toEqual('__dep__');
-    }
-
-    {
-      const {stdout} = await p.esy('x dep.cmd');
-      expect(stdout.trim()).toEqual('__dep__');
-    }
-  }
-
   describe('out of source build', () => {
     function withProject(assertions) {
       return async () => {
@@ -102,7 +85,22 @@ describe('Build with dep', () => {
       };
     }
 
-    it('makes dep available in envs', withProject(checkDepIsInEnv));
+    it('makes dep available in envs', withProject(async p => {
+      {
+        const {stdout} = await p.esy('dep.cmd');
+        expect(stdout.trim()).toEqual('__dep__');
+      }
+
+      {
+        const {stdout} = await p.esy('b dep.cmd');
+        expect(stdout.trim()).toEqual('__dep__');
+      }
+
+      {
+        const {stdout} = await p.esy('x dep.cmd');
+        expect(stdout.trim()).toEqual('__dep__');
+      }
+    }));
 
     test(
       'build-env',
@@ -288,7 +286,22 @@ describe('Build with dep', () => {
       };
     }
 
-    it('makes dep available in envs', withProject(checkDepIsInEnv));
+    it('makes dep available in envs', withProject(async p => {
+      {
+        const {stdout} = await p.esy('dep.cmd');
+        expect(stdout.trim()).toEqual('__dep__');
+      }
+
+      {
+        const {stdout} = await p.esy('b dep.cmd');
+        expect(stdout.trim()).toEqual('__dep__');
+      }
+
+      {
+        const {stdout} = await p.esy('x dep.cmd');
+        expect(stdout.trim()).toEqual('__dep__');
+      }
+    }));
   });
 
   describe('_build build', () => {
@@ -314,6 +327,65 @@ describe('Build with dep', () => {
         await assertions(p);
       };
     }
-    it('makes dep available in envs', withProject(checkDepIsInEnv));
+    it('makes dep available in envs', withProject(async p => {
+      {
+        const {stdout} = await p.esy('dep.cmd');
+        expect(stdout.trim()).toEqual('__dep__');
+      }
+
+      {
+        const {stdout} = await p.esy('b dep.cmd');
+        expect(stdout.trim()).toEqual('__dep__');
+      }
+
+      {
+        const {stdout} = await p.esy('x dep.cmd');
+        expect(stdout.trim()).toEqual('__dep__');
+      }
+    }));
   });
+
+  describe('out of source build with buildDev in deps', () => {
+    function withProject(assertions) {
+      return async () => {
+        const p = await helpers.createTestSandbox();
+        await p.fixture(
+          ...makeFixture(p, {
+            build: [
+              'cp #{self.root / self.name}.js #{self.target_dir / self.name}.js',
+              helpers.buildCommand(p, '#{self.target_dir / self.name}.js'),
+            ],
+            // set buildDev to false to make sure we fail if it's going to be
+            // executed
+            buildDev: 'false',
+            install: [
+              `cp #{self.target_dir / self.name}.cmd #{self.bin / self.name}.cmd`,
+              `cp #{self.target_dir / self.name}.js #{self.bin / self.name}.js`,
+            ],
+          }),
+        );
+        await p.esy('install');
+        await p.esy('build');
+        await assertions(p);
+      };
+    }
+
+    it('makes dep available in envs', withProject(async p => {
+      {
+        const {stdout} = await p.esy('dep.cmd');
+        expect(stdout.trim()).toEqual('__dep__');
+      }
+
+      {
+        const {stdout} = await p.esy('b dep.cmd');
+        expect(stdout.trim()).toEqual('__dep__');
+      }
+
+      {
+        const {stdout} = await p.esy('x dep.cmd');
+        expect(stdout.trim()).toEqual('__dep__');
+      }
+    }));
+  });
+
 });

--- a/test-e2e/esy-build/with-dev-dep.test.js
+++ b/test-e2e/esy-build/with-dev-dep.test.js
@@ -99,7 +99,7 @@ describe(`Project with "devDependencies"`, () => {
     }
   });
 
-  it('package "dev-dep" should be visible only in command env', async () => {
+  it(`package "dev-dep" is visible in command env / test env and via 'esy b CMD'`, async () => {
     const p = await createTestSandbox();
 
     {
@@ -112,7 +112,10 @@ describe(`Project with "devDependencies"`, () => {
       expect(stdout.trim()).toEqual('__devDep__');
     }
 
-    return expect(p.esy('b devDep.cmd')).rejects.toThrow();
+    {
+      const {stdout} = await p.esy('b devDep.cmd');
+      expect(stdout.trim()).toEqual('__devDep__');
+    }
   });
 
   test('build-env', async function() {

--- a/test-e2e/esy-build/with-dev-dep.test.js
+++ b/test-e2e/esy-build/with-dev-dep.test.js
@@ -1,5 +1,6 @@
 // @flow
 
+const os = require('os');
 const path = require('path');
 const helpers = require('../test/helpers');
 const {test, isWindows, isMacos, isLinux} = helpers;
@@ -41,41 +42,38 @@ function makePackage(
   );
 }
 
-function makeFixture(p) {
-  return [
-    helpers.packageJson({
-      name: 'withDevDep',
-      version: '1.0.0',
-      esy: {
-        build: 'true',
-      },
-      dependencies: {
-        dep: 'path:./dep',
-      },
-      devDependencies: {
-        devDep: 'path:./devDep',
-      },
-    }),
-    makePackage(p, {
-      name: 'dep',
-      devDependencies: {devDepOfDep: '*'},
-    }),
-    makePackage(p, {
-      name: 'devDep',
-      dependencies: {
-        depOfDevDep: 'path:../depOfDevDep',
-      },
-    }),
-    makePackage(p, {
-      name: 'depOfDevDep',
-    }),
-  ];
-}
+describe(`Project with "devDependencies"`, () => {
 
-describe('devDep workflow', () => {
   async function createTestSandbox() {
     const p = await helpers.createTestSandbox();
-    await p.fixture(...makeFixture(p));
+    await p.fixture(
+      helpers.packageJson({
+        name: 'withDevDep',
+        version: '1.0.0',
+        esy: {
+          build: 'true',
+        },
+        dependencies: {
+          dep: 'path:./dep',
+        },
+        devDependencies: {
+          devDep: 'path:./devDep',
+        },
+      }),
+      makePackage(p, {
+        name: 'dep',
+        devDependencies: {devDepOfDep: '*'},
+      }),
+      makePackage(p, {
+        name: 'devDep',
+        dependencies: {
+          depOfDevDep: 'path:../depOfDevDep',
+        },
+      }),
+      makePackage(p, {
+        name: 'depOfDevDep',
+      }),
+    )
     await p.esy('install');
     await p.esy('build');
     return p;
@@ -335,5 +333,86 @@ describe('devDep workflow', () => {
     const envpath = env.PATH.split(path.delimiter);
     expect(envpath.includes(`${p.esyStorePath}/i/${depId}/bin`)).toBeTruthy();
     expect(envpath.includes(`${p.esyStorePath}/i/${devDepId}/bin`)).toBeTruthy();
+  });
+});
+
+describe('Project with "devDependencies" (with "buildDev" config at the root)', () => {
+
+  async function createTestSandbox() {
+    const p = await helpers.createTestSandbox();
+    const name = 'withDevDep';
+    await p.fixture(
+      helpers.packageJson({
+        name: name,
+        version: '1.0.0',
+        esy: {
+          build: [
+            'cp #{self.name}.js #{self.target_dir / self.name}.js',
+            helpers.buildCommand(p, '#{self.target_dir / self.name}.js')
+          ],
+          // run commands from "devDependencies" here
+          buildDev: [
+            'devDep.cmd',
+            'cp #{self.name}-dev.js #{self.target_dir / self.name}.js',
+            helpers.buildCommand(p, '#{self.target_dir / self.name}.js')
+          ],
+          install: [
+            `cp #{self.target_dir / self.name}.cmd #{self.bin / self.name}.cmd`,
+            `cp #{self.target_dir / self.name}.js #{self.bin / self.name}.js`,
+          ],
+        },
+        dependencies: {
+          dep: 'path:./dep',
+        },
+        devDependencies: {
+          devDep: 'path:./devDep',
+        },
+      }),
+      helpers.dummyExecutable(name),
+      helpers.dummyExecutable(`${name}-dev`),
+      makePackage(p, {
+        name: 'dep',
+        devDependencies: {devDepOfDep: '*'},
+      }),
+      makePackage(p, {
+        name: 'devDep',
+        dependencies: {
+          depOfDevDep: 'path:../depOfDevDep',
+        },
+      }),
+      makePackage(p, {
+        name: 'depOfDevDep',
+      }),
+    )
+    await p.esy('install');
+    return p;
+  }
+
+  it(`can be built with 'esy build'`, async () => {
+    const p = await createTestSandbox();
+
+    {
+      const {stdout} = await p.esy('build');
+      expect(stdout).toBe(`__devDep__${os.EOL}`);
+    }
+
+    {
+      const {stdout} = await p.esy('x withDevDep.cmd');
+      expect(stdout).toBe(`__devDep__${os.EOL}__withDevDep-dev__${os.EOL}`);
+    }
+  });
+
+  it(`can be built with 'esy build --release'`, async () => {
+    const p = await createTestSandbox();
+
+    {
+      const {stdout} = await p.esy('build --release');
+      expect(stdout).toBe(``);
+    }
+
+    {
+      const {stdout} = await p.esy('x --release withDevDep.cmd');
+      expect(stdout).toBe(`__withDevDep__${os.EOL}`);
+    }
   });
 });

--- a/test-e2e/esy-build/with-linked-dep.test.js
+++ b/test-e2e/esy-build/with-linked-dep.test.js
@@ -37,23 +37,6 @@ function makeFixture(p, buildDep) {
 }
 
 describe('Build with a linked dep', () => {
-  async function checkDepIsInEnv(p) {
-    {
-      const {stdout} = await p.esy('dep.cmd');
-      expect(stdout.trim()).toEqual('__dep__');
-    }
-
-    {
-      const {stdout} = await p.esy('b dep.cmd');
-      expect(stdout.trim()).toEqual('__dep__');
-    }
-
-    {
-      const {stdout} = await p.esy('x dep.cmd');
-      expect(stdout.trim()).toEqual('__dep__');
-    }
-  }
-
   describe('out of source build', () => {
     function withProject(assertions) {
       return async () => {
@@ -76,7 +59,22 @@ describe('Build with a linked dep', () => {
       };
     }
 
-    it('package "dep" should be visible in all envs', withProject(checkDepIsInEnv));
+    it('package "dep" should be visible in all envs', withProject(async p => {
+      {
+        const {stdout} = await p.esy('dep.cmd');
+        expect(stdout.trim()).toEqual('__dep__');
+      }
+
+      {
+        const {stdout} = await p.esy('b dep.cmd');
+        expect(stdout.trim()).toEqual('__dep__');
+      }
+
+      {
+        const {stdout} = await p.esy('x dep.cmd');
+        expect(stdout.trim()).toEqual('__dep__');
+      }
+    }));
 
     test.enableIf(isMacos || isLinux)(
       'macos || linux: build-env snapshot',
@@ -118,7 +116,22 @@ describe('Build with a linked dep', () => {
       };
     }
 
-    it('package "dep" should be visible in all envs', withProject(checkDepIsInEnv));
+    it('package "dep" should be visible in all envs', withProject(async p => {
+      {
+        const {stdout} = await p.esy('dep.cmd');
+        expect(stdout.trim()).toEqual('__dep__');
+      }
+
+      {
+        const {stdout} = await p.esy('b dep.cmd');
+        expect(stdout.trim()).toEqual('__dep__');
+      }
+
+      {
+        const {stdout} = await p.esy('x dep.cmd');
+        expect(stdout.trim()).toEqual('__dep__');
+      }
+    }));
   });
 
   describe('_build build', () => {
@@ -145,6 +158,64 @@ describe('Build with a linked dep', () => {
       };
     }
 
-    it('package "dep" should be visible in all envs', withProject(checkDepIsInEnv));
+    it('package "dep" should be visible in all envs', withProject(async p => {
+      {
+        const {stdout} = await p.esy('dep.cmd');
+        expect(stdout.trim()).toEqual('__dep__');
+      }
+
+      {
+        const {stdout} = await p.esy('b dep.cmd');
+        expect(stdout.trim()).toEqual('__dep__');
+      }
+
+      {
+        const {stdout} = await p.esy('x dep.cmd');
+        expect(stdout.trim()).toEqual('__dep__');
+      }
+    }));
   });
+
+  describe('out of source build with "buildDev" in dep', () => {
+    function withProject(assertions) {
+      return async () => {
+        const p = await helpers.createTestSandbox();
+        await p.fixture(
+          ...makeFixture(p, {
+            build: [
+              'cp #{self.root / self.name}.js #{self.target_dir / self.name}.js',
+              helpers.buildCommand(p, '#{self.target_dir / self.name}.js'),
+            ],
+            // set it to false so we fail if it's executed
+            buildDev: 'false',
+            install: [
+              `cp #{self.target_dir / self.name}.cmd #{self.bin / self.name}.cmd`,
+              `cp #{self.target_dir / self.name}.js #{self.bin / self.name}.js`,
+            ],
+          }),
+        );
+        await p.esy('install');
+        await p.esy('build');
+        await assertions(p);
+      };
+    }
+
+    it('package "dep" should be visible in all envs', withProject(async p => {
+      {
+        const {stdout} = await p.esy('dep.cmd');
+        expect(stdout.trim()).toEqual('__dep__');
+      }
+
+      {
+        const {stdout} = await p.esy('b dep.cmd');
+        expect(stdout.trim()).toEqual('__dep__');
+      }
+
+      {
+        const {stdout} = await p.esy('x dep.cmd');
+        expect(stdout.trim()).toEqual('__dep__');
+      }
+    }));
+  });
+
 });


### PR DESCRIPTION
- Now one can specify `"esy.buildDev"` in `package.json`

  What you'd want to put there for Reason project:

  ```
  {
    "esy": {
      "build": "dune build -p #{self.name}",
      "buildDev": "refmterr dune build --only-packages #{self.name} --root .",
    }
  }
  ```

  We are going to provide `esydune` executable which would construct such
  complex invocations automatically (soon):

  ```
  {
    "esy": {
      "build": "esydune",
      "buildDev": "esydune",
    }
  }
  ```

- `"esy.buildDev"` have access to `"devDependencies"`. That means `refmterr` can
  be a devDependency rather than regular one.

  `"esy.build"` never has access to `"devDependencies"`.

- `"esy.buildDev"` is only used when building the root package (this is what
  used when you run `esy build` now instead of `"esy.buiild"`).

  If depend (or link-depend) on a package with `"esy.buildDev"` it's not going
  to be used (because package's devDependencies are not installed).

- To produce build with `"esy.build"` command one does:

  ```
  % esy build --release
  ```

- By default `esy build CMD` has access to `"devDependencies"`, this means you
  can do dev time builds like this:

  ```
  % esy build refmterr dune build
  ```

  pass `--release` if you want to build like it's for release (no dev deps):

  ```
  % esy build --release dune build
  ```

- `esy x` also accept `--release` flag which makes it build & install in release
  mode:

  ```
  % esy x --release MyApp.exe
  ```
