### PR TITLE
Configure solver with DEPSPEC

### DIFF
--- a/esy-install/DepSpec.ml
+++ b/esy-install/DepSpec.ml
@@ -48,10 +48,7 @@ module Make (Id : ID) : DEPSPEC with type id = Id.t = struct
   let dependencies src = Dependencies src
   let devDependencies src = DevDependencies src
 
-  let union a b =
-    if compare a b > 0
-    then Union (a, b)
-    else Union (b, a)
+  let union a b = Union (a, b)
 
   let (+) = union
 

--- a/esy-install/SolutionLock.mli
+++ b/esy-install/SolutionLock.mli
@@ -1,17 +1,17 @@
 val toPath :
-  checksum:string
-  -> sandbox:Sandbox.t
-  -> solution:Solution.t
+  digest:Digestv.t
+  -> Sandbox.t
+  -> Solution.t
   -> Fpath.t
   -> unit RunAsync.t
 
 val ofPath :
-  checksum:string
-  -> sandbox:Sandbox.t
+  ?digest:Digestv.t
+  -> Sandbox.t
   -> Fpath.t
   -> Solution.t option RunAsync.t
 
 val unsafeUpdateChecksum :
-  checksum:string
+  digest:Digestv.t
   -> Fpath.t
   -> unit RunAsync.t

--- a/esy-package-config/Resolution.ml
+++ b/esy-package-config/Resolution.ml
@@ -10,6 +10,12 @@ and resolution =
   | SourceOverride of {source : Source.t; override : Json.t}
 [@@@ocaml.warning "+32"]
 
+let source r =
+  match r.resolution with
+  | Version (Version.Source source) -> Some source
+  | Version _ -> None
+  | SourceOverride {source; _} -> Some source
+
 let resolution_to_yojson resolution =
   match resolution with
   | Version v -> `String (Version.show v)

--- a/esy-package-config/Resolution.mli
+++ b/esy-package-config/Resolution.mli
@@ -11,6 +11,7 @@ val resolution_of_yojson : resolution Json.decoder
 val resolution_to_yojson : resolution Json.encoder
 
 val digest : t -> Digestv.t
+val source : t -> Source.t option
 
 include S.COMPARABLE with type t := t
 include S.PRINTABLE with type t := t

--- a/esy-solve/DepSpec.ml
+++ b/esy-solve/DepSpec.ml
@@ -1,0 +1,37 @@
+open EsyPackageConfig
+
+
+module Id = struct
+  type t =
+    | Self
+    [@@deriving ord]
+
+  let pp fmt = function
+    | Self -> Fmt.unit "self" fmt ()
+end
+
+include EsyInstall.DepSpec.Make(Id)
+
+let self = Id.Self
+
+let rec eval (manifest : InstallManifest.t) (spec : t) =
+  let module D = InstallManifest.Dependencies in
+  let open Run.Syntax in
+  match spec with
+  | Package Self -> return (D.NpmFormula NpmFormula.empty)
+  | Dependencies Self -> return manifest.dependencies
+  | DevDependencies Self -> return manifest.devDependencies
+  | Union (a, b) ->
+    let%bind adeps = eval manifest a in
+    let%bind bdeps = eval manifest b in
+    begin match adeps, bdeps with
+    | D.NpmFormula a, D.NpmFormula b ->
+      let reqs = NpmFormula.override a b in
+      return (D.NpmFormula reqs)
+    | D.OpamFormula a, D.OpamFormula b ->
+      return (D.OpamFormula (a @ b))
+    | _, _ ->
+      errorf
+        "incompatible dependency formulas found at %a: %a and %a"
+        InstallManifest.pp manifest pp a pp b
+    end

--- a/esy-solve/Sandbox.mli
+++ b/esy-solve/Sandbox.mli
@@ -11,19 +11,8 @@ type t = {
   (** Root package. *)
   root : InstallManifest.t;
 
-  (**
-   * A set of dependencies to be installed for the sandbox.
-   *
-   * Such dependencies are different than of root.dependencies as sandbox
-   * aggregates both regular dependencies and devDependencies.
-   *)
-  dependencies : InstallManifest.Dependencies.t;
-
   (** A set of resolutions. *)
   resolutions : Resolutions.t;
-
-  (** OCaml version request defined for the sandbox. *)
-  ocamlReq : Req.t option;
 
   (** Resolver associated with a sandbox. *)
   resolver : Resolver.t;

--- a/esy-solve/Sandbox.mli
+++ b/esy-solve/Sandbox.mli
@@ -19,3 +19,4 @@ type t = {
 }
 
 val make : cfg:Config.t -> EsyInstall.SandboxSpec.t -> t RunAsync.t
+val digest : SolveSpec.t -> t -> Digestv.t RunAsync.t

--- a/esy-solve/SolveSpec.ml
+++ b/esy-solve/SolveSpec.ml
@@ -4,7 +4,7 @@ type t = {
   solveRoot : DepSpec.t;
   solveLink : DepSpec.t;
   solveAll : DepSpec.t;
-}
+} [@@deriving ord]
 
 let eval spec root manifest =
   let depspec =

--- a/esy-solve/SolveSpec.ml
+++ b/esy-solve/SolveSpec.ml
@@ -1,0 +1,20 @@
+open EsyPackageConfig
+
+type t = {
+  solveRoot : DepSpec.t;
+  solveLink : DepSpec.t;
+  solveAll : DepSpec.t;
+}
+
+let eval spec root manifest =
+  let depspec =
+    let isRoot = InstallManifest.compare root manifest = 0 in
+    if isRoot
+    then spec.solveRoot
+    else
+      match manifest.InstallManifest.source with
+      | PackageSource.Link _ -> spec.solveLink
+      | _ -> spec.solveAll
+  in
+  DepSpec.eval manifest depspec
+

--- a/esy-solve/SolveSpec.mli
+++ b/esy-solve/SolveSpec.mli
@@ -7,3 +7,4 @@ type t = {
 }
 
 val eval : t -> InstallManifest.t -> InstallManifest.t -> InstallManifest.Dependencies.t Run.t
+val compare : t -> t -> int

--- a/esy-solve/SolveSpec.mli
+++ b/esy-solve/SolveSpec.mli
@@ -1,0 +1,9 @@
+open EsyPackageConfig
+
+type t = {
+  solveRoot : DepSpec.t;
+  solveLink : DepSpec.t;
+  solveAll : DepSpec.t;
+}
+
+val eval : t -> InstallManifest.t -> InstallManifest.t -> InstallManifest.Dependencies.t Run.t

--- a/esy-solve/Solver.ml
+++ b/esy-solve/Solver.ml
@@ -51,10 +51,9 @@ module Strategy = struct
 end
 
 type t = {
-  cfg : Config.t;
-  resolver : Resolver.t;
   universe : Universe.t;
-  resolutions : Resolutions.t;
+  solvespec : SolveSpec.t;
+  sandbox : Sandbox.t;
 }
 
 module Reason : sig
@@ -129,7 +128,7 @@ module Explanation = struct
 
   type t = Reason.t list
 
-  let empty = []
+  let empty : t = []
 
   let pp fmt reasons =
     let ppReasons fmt reasons =
@@ -372,10 +371,14 @@ let lockPackage
     devDependencies;
   }
 
-let make ~cfg ~resolver ~resolutions () =
+let make solvespec (sandbox : Sandbox.t) =
   let open RunAsync.Syntax in
-  let universe = ref (Universe.empty resolver) in
-  return {cfg; resolver; universe = !universe; resolutions}
+  let universe = ref (Universe.empty sandbox.resolver) in
+  return {
+    solvespec;
+    universe = !universe;
+    sandbox;
+  }
 
 let add ~(dependencies : Dependencies.t) solver =
   let open RunAsync.Syntax in
@@ -383,18 +386,21 @@ let add ~(dependencies : Dependencies.t) solver =
   let universe = ref solver.universe in
   let report, finish = Cli.createProgressReporter ~name:"resolving esy packages" () in
 
-  let rec addPackage (pkg : InstallManifest.t) =
-    if not (Universe.mem ~pkg !universe)
+  let rec addPackage (manifest : InstallManifest.t) =
+    if not (Universe.mem ~pkg:manifest !universe)
     then
-      match pkg.kind with
+      match manifest.kind with
       | InstallManifest.Esy ->
-        universe := Universe.add ~pkg !universe;
+        universe := Universe.add ~pkg:manifest !universe;
+        let%bind dependencies = RunAsync.ofRun (
+          SolveSpec.eval solver.solvespec solver.sandbox.root manifest
+        ) in
         let%bind () =
           RunAsync.contextf
-            (addDependencies pkg.dependencies)
-            "resolving %a" InstallManifest.pp pkg
+            (addDependencies dependencies)
+            "resolving %a" InstallManifest.pp manifest
         in
-        universe := Universe.add ~pkg !universe;
+        universe := Universe.add ~pkg:manifest !universe;
         return ()
       | InstallManifest.Npm -> return ()
     else return ()
@@ -414,7 +420,7 @@ let add ~(dependencies : Dependencies.t) solver =
     report "%s" req.name;%lwt
     let%bind resolutions =
       RunAsync.contextf (
-        Resolver.resolve ~fullMetadata:true ~name:req.name ~spec:req.spec solver.resolver
+        Resolver.resolve ~fullMetadata:true ~name:req.name ~spec:req.spec solver.sandbox.resolver
       ) "resolving %a" Req.pp req
     in
 
@@ -422,7 +428,7 @@ let add ~(dependencies : Dependencies.t) solver =
       let fetchPackage resolution =
         let%bind pkg =
           RunAsync.contextf
-            (Resolver.package ~resolution solver.resolver)
+            (Resolver.package ~resolution solver.sandbox.resolver)
             "resolving metadata %a" Resolution.pp resolution
         in
         match pkg with
@@ -438,9 +444,9 @@ let add ~(dependencies : Dependencies.t) solver =
     in
 
     let%bind () =
-      let f tasks pkg =
-        match pkg with
-        | Some pkg -> (addPackage pkg)::tasks
+      let f tasks manifest =
+        match manifest with
+        | Some manifest -> (addPackage manifest)::tasks
         | None -> tasks
       in
       packages
@@ -475,9 +481,9 @@ let solveDependencies ~root ~installed ~strategy dependencies solver =
 
   let runSolver filenameIn filenameOut =
     let cmd = Cmd.(
-      solver.cfg.Config.esySolveCmd
+      solver.sandbox.cfg.Config.esySolveCmd
       % ("--strategy=" ^ strategy)
-      % ("--timeout=" ^ string_of_float(solver.cfg.solveTimeout))
+      % ("--timeout=" ^ string_of_float(solver.sandbox.cfg.solveTimeout))
       % p filenameIn
       % p filenameOut
     ) in
@@ -585,7 +591,7 @@ let solveDependencies ~root ~installed ~strategy dependencies solver =
     let cudf = preamble, cudfUniverse, request in
     begin match%bind
       Explanation.explain
-        ~resolver:solver.resolver
+        ~resolver:solver.sandbox.resolver
         ~cudfMapping
         ~root:dummyRoot
         cudf
@@ -619,7 +625,7 @@ let solveDependenciesNaively
       | [] -> None
       | pkg::pkgs ->
         if Resolver.versionMatchesReq
-            solver.resolver
+            solver.sandbox.resolver
             req
             pkg.InstallManifest.name
             pkg.InstallManifest.version
@@ -632,10 +638,10 @@ let solveDependenciesNaively
 
   let resolveOfOutside req =
     report "%a" Req.pp req;%lwt
-    let%bind resolutions = Resolver.resolve ~name:req.name ~spec:req.spec solver.resolver in
-    match findResolutionForRequest solver.resolver req resolutions with
+    let%bind resolutions = Resolver.resolve ~name:req.name ~spec:req.spec solver.sandbox.resolver in
+    match findResolutionForRequest solver.sandbox.resolver req resolutions with
     | Some resolution ->
-      begin match%bind Resolver.package ~resolution solver.resolver with
+      begin match%bind Resolver.package ~resolution solver.sandbox.resolver with
       | Ok pkg -> return (Some pkg)
       | Error reason ->
         errorf "invalid package %a: %s" Resolution.pp resolution reason
@@ -663,7 +669,9 @@ let solveDependenciesNaively
     let solved = Hashtbl.create 100 in
     let key pkg = pkg.InstallManifest.name ^ "." ^ (Version.show pkg.InstallManifest.version) in
     let sealDependencies () =
-      let f _key (pkg, dependencies) map = InstallManifest.Map.add pkg dependencies map in
+      let f _key (pkg, dependencies) map =
+        InstallManifest.Map.add pkg dependencies map
+      in
       Hashtbl.fold f solved InstallManifest.Map.empty
       (* Hashtbl.find_opt solved (key pkg) *)
     in
@@ -690,19 +698,31 @@ let solveDependenciesNaively
 
     let%bind pkgs =
       let f req =
-        let%bind pkg =
+        let%bind manifest =
           RunAsync.contextf
             (resolve trace req)
             "resolving request %a" Req.pp req
         in
-        addToInstalled pkg;
-        return pkg
+        addToInstalled manifest;
+        return manifest
       in
       reqs
       |> List.map ~f
       |> RunAsync.List.joinAll
     in
-    return (InstallManifest.Set.elements (InstallManifest.Set.of_list pkgs))
+
+    let _, solved =
+      let f (seen, solved) manifest =
+        if InstallManifest.Set.mem manifest seen
+        then seen, solved
+        else
+          let seen = InstallManifest.Set.add manifest seen in
+          let solved = manifest::solved in
+          seen, solved
+      in
+      List.fold_left ~f ~init:(InstallManifest.Set.empty, []) pkgs
+    in
+    return solved
   in
 
   let rec loop trace seen = function
@@ -712,9 +732,12 @@ let solveDependenciesNaively
         loop trace seen rest
       | false ->
         let seen = InstallManifest.Set.add pkg seen in
+        let%bind dependencies = RunAsync.ofRun (
+          SolveSpec.eval solver.solvespec solver.sandbox.root pkg
+        ) in
         let%bind dependencies =
           RunAsync.contextf
-            (solveDependencies (pkg::trace) pkg.dependencies)
+            (solveDependencies (pkg::trace) dependencies)
             "solving dependencies of %a" InstallManifest.pp pkg
         in
         addDependencies pkg dependencies;
@@ -760,7 +783,7 @@ let solveOCamlReq (req : Req.t) resolver =
     | _ -> errorf "multiple resolutions for %a, expected one" Req.pp req
     end
 
-let solve (sandbox : Sandbox.t) =
+let solve solvespec (sandbox : Sandbox.t) =
   let open RunAsync.Syntax in
 
   let getResultOrExplain = function
@@ -770,8 +793,20 @@ let solve (sandbox : Sandbox.t) =
   in
 
   let%bind dependencies, ocamlVersion =
-    match sandbox.ocamlReq with
-    | None -> return (sandbox.dependencies, None)
+
+    let ocamlReq =
+      match sandbox.root.dependencies with
+      | InstallManifest.Dependencies.OpamFormula _ -> None
+      | InstallManifest.Dependencies.NpmFormula reqs ->
+        NpmFormula.find ~name:"ocaml" reqs
+    in
+
+    match ocamlReq with
+    | None ->
+      let%bind dependencies = RunAsync.ofRun (
+        SolveSpec.eval solvespec sandbox.root sandbox.root
+      ) in
+      return (dependencies, None)
     | Some ocamlReq ->
       let%bind (ocamlVersionOrig, ocamlVersion) =
         RunAsync.contextf
@@ -779,13 +814,16 @@ let solve (sandbox : Sandbox.t) =
           "resolving %a" Req.pp ocamlReq
       in
 
-      let dependencies =
-        match ocamlVersion, sandbox.dependencies with
+      let%bind dependencies =
+        let%bind dependencies = RunAsync.ofRun (
+          SolveSpec.eval solvespec sandbox.root sandbox.root
+        ) in
+        match ocamlVersion, dependencies with
         | Some ocamlVersion, InstallManifest.Dependencies.NpmFormula reqs ->
           let ocamlSpec = VersionSpec.ofVersion ocamlVersion in
           let ocamlReq = Req.make ~name:"ocaml" ~spec:ocamlSpec in
           let reqs = NpmFormula.override reqs [ocamlReq] in
-          InstallManifest.Dependencies.NpmFormula reqs
+          return (InstallManifest.Dependencies.NpmFormula reqs)
         | Some ocamlVersion, InstallManifest.Dependencies.OpamFormula deps ->
           let req =
             match ocamlVersion with
@@ -794,8 +832,8 @@ let solve (sandbox : Sandbox.t) =
             | Version.Opam v -> InstallManifest.Dep.Opam (OpamPackageVersion.Constraint.EQ v)
           in
           let ocamlDep = {InstallManifest.Dep. name = "ocaml"; req;} in
-          InstallManifest.Dependencies.OpamFormula (deps @ [[ocamlDep]])
-        | None, deps -> deps
+          return (InstallManifest.Dependencies.OpamFormula (deps @ [[ocamlDep]]))
+        | None, deps -> return deps
       in
 
       return (dependencies, ocamlVersionOrig)
@@ -808,12 +846,7 @@ let solve (sandbox : Sandbox.t) =
   in
 
   let%bind solver, dependencies =
-    let%bind solver = make
-      ~resolver:sandbox.resolver
-      ~cfg:sandbox.cfg
-      ~resolutions:sandbox.resolutions
-      ()
-    in
+    let%bind solver = make solvespec sandbox in
     let%bind solver, dependencies = add ~dependencies solver in
     return (solver, dependencies)
   in

--- a/esy-solve/Solver.ml
+++ b/esy-solve/Solver.ml
@@ -56,6 +56,9 @@ type t = {
   sandbox : Sandbox.t;
 }
 
+let evalDependencies solver manifest =
+  SolveSpec.eval solver.solvespec solver.sandbox.root manifest
+
 module Reason : sig
 
   type t
@@ -137,7 +140,7 @@ module Explanation = struct
     in
     Fmt.pf fmt "@[<v>No solution found:@;@;%a@]" ppReasons reasons
 
-  let collectReasons ~resolver ~cudfMapping ~root reasons =
+  let collectReasons cudfMapping solver reasons =
     let open RunAsync.Syntax in
 
     (* Find a pair of requestor, path for the current package.
@@ -163,7 +166,7 @@ module Explanation = struct
       in
 
       let resolve pkg =
-        if pkg.InstallManifest.name = root.InstallManifest.name
+        if pkg.InstallManifest.name = solver.sandbox.root.InstallManifest.name
         then pkg, []
         else
           let rec aux path pkg =
@@ -185,6 +188,12 @@ module Explanation = struct
       (requestor, path)
     in
 
+    let maybeEvalDependencies manifest =
+      match evalDependencies solver manifest with
+      | Ok deps -> deps
+      | Error _ -> Dependencies.NpmFormula []
+    in
+
     let%bind reasons =
       let f reasons = function
         | Algo.Diagnostic.Conflict (left, right, _) ->
@@ -193,7 +202,7 @@ module Explanation = struct
             let requestor, path = resolveReqViaDepChain pkg in
             let constr = Dependencies.filterDependenciesByName
               ~name:pkg.name
-              requestor.dependencies
+              (maybeEvalDependencies requestor)
             in
             {Reason. constr; trace = requestor::path}
           in
@@ -202,7 +211,7 @@ module Explanation = struct
             let requestor, path = resolveReqViaDepChain pkg in
             let constr = Dependencies.filterDependenciesByName
               ~name:pkg.name
-              requestor.dependencies
+              (maybeEvalDependencies requestor)
             in
             {Reason. constr; trace = requestor::path}
           in
@@ -214,18 +223,18 @@ module Explanation = struct
           let pkg = Universe.CudfMapping.decodePkgExn pkg cudfMapping in
           let requestor, path = resolveDepChain pkg in
           let trace =
-            if pkg.InstallManifest.name = root.InstallManifest.name
+            if pkg.InstallManifest.name = solver.sandbox.root.InstallManifest.name
             then []
             else pkg::requestor::path
           in
           let f reasons (name, _) =
             let name = Universe.CudfMapping.decodePkgName (Universe.CudfName.make name) in
             let%lwt available =
-              match%lwt Resolver.resolve ~name resolver with
+              match%lwt Resolver.resolve ~name solver.sandbox.resolver with
               | Ok available -> Lwt.return available
               | Error _ -> Lwt.return []
             in
-            let constr = Dependencies.filterDependenciesByName ~name pkg.dependencies in
+            let constr = Dependencies.filterDependenciesByName ~name (maybeEvalDependencies pkg) in
             let missing = Reason.missing ~available {constr; trace} in
             if not (Reason.Set.mem missing reasons)
             then return (Reason.Set.add missing reasons)
@@ -239,7 +248,7 @@ module Explanation = struct
 
     return (Reason.Set.elements reasons)
 
-  let explain ~resolver ~cudfMapping ~root cudf =
+  let explain cudfMapping solver cudf =
     let open RunAsync.Syntax in
     begin match Algo.Depsolver.check_request ~explain:true cudf with
     | Algo.Depsolver.Sat  _
@@ -248,7 +257,7 @@ module Explanation = struct
       return None
     | Algo.Depsolver.Unsat (Some { result = Algo.Diagnostic.Failure reasons; _ }) ->
       let reasons = reasons () in
-      let%bind reasons = collectReasons ~resolver ~cudfMapping ~root reasons in
+      let%bind reasons = collectReasons cudfMapping solver reasons in
       return (Some reasons)
     | Algo.Depsolver.Error err -> error err
     end
@@ -392,9 +401,7 @@ let add ~(dependencies : Dependencies.t) solver =
       match manifest.kind with
       | InstallManifest.Esy ->
         universe := Universe.add ~pkg:manifest !universe;
-        let%bind dependencies = RunAsync.ofRun (
-          SolveSpec.eval solver.solvespec solver.sandbox.root manifest
-        ) in
+        let%bind dependencies = RunAsync.ofRun (evalDependencies solver manifest) in
         let%bind () =
           RunAsync.contextf
             (addDependencies dependencies)
@@ -591,9 +598,8 @@ let solveDependencies ~root ~installed ~strategy dependencies solver =
     let cudf = preamble, cudfUniverse, request in
     begin match%bind
       Explanation.explain
-        ~resolver:solver.sandbox.resolver
-        ~cudfMapping
-        ~root:dummyRoot
+        cudfMapping
+        solver
         cudf
     with
     | Some reasons -> return (Error reasons)
@@ -732,9 +738,7 @@ let solveDependenciesNaively
         loop trace seen rest
       | false ->
         let seen = InstallManifest.Set.add pkg seen in
-        let%bind dependencies = RunAsync.ofRun (
-          SolveSpec.eval solver.solvespec solver.sandbox.root pkg
-        ) in
+        let%bind dependencies = RunAsync.ofRun (evalDependencies solver pkg) in
         let%bind dependencies =
           RunAsync.contextf
             (solveDependencies (pkg::trace) dependencies)
@@ -792,10 +796,14 @@ let solve solvespec (sandbox : Sandbox.t) =
       errorf "%a" Explanation.pp explanation
   in
 
+  let%bind solver = make solvespec sandbox in
+
   let%bind dependencies, ocamlVersion =
 
+    let%bind rootDependencies = RunAsync.ofRun (evalDependencies solver sandbox.root) in
+
     let ocamlReq =
-      match sandbox.root.dependencies with
+      match rootDependencies with
       | InstallManifest.Dependencies.OpamFormula _ -> None
       | InstallManifest.Dependencies.NpmFormula reqs ->
         NpmFormula.find ~name:"ocaml" reqs
@@ -803,10 +811,7 @@ let solve solvespec (sandbox : Sandbox.t) =
 
     match ocamlReq with
     | None ->
-      let%bind dependencies = RunAsync.ofRun (
-        SolveSpec.eval solvespec sandbox.root sandbox.root
-      ) in
-      return (dependencies, None)
+      return (rootDependencies, None)
     | Some ocamlReq ->
       let%bind (ocamlVersionOrig, ocamlVersion) =
         RunAsync.contextf
@@ -815,10 +820,7 @@ let solve solvespec (sandbox : Sandbox.t) =
       in
 
       let%bind dependencies =
-        let%bind dependencies = RunAsync.ofRun (
-          SolveSpec.eval solvespec sandbox.root sandbox.root
-        ) in
-        match ocamlVersion, dependencies with
+        match ocamlVersion, rootDependencies with
         | Some ocamlVersion, InstallManifest.Dependencies.NpmFormula reqs ->
           let ocamlSpec = VersionSpec.ofVersion ocamlVersion in
           let ocamlReq = Req.make ~name:"ocaml" ~spec:ocamlSpec in
@@ -846,7 +848,6 @@ let solve solvespec (sandbox : Sandbox.t) =
   in
 
   let%bind solver, dependencies =
-    let%bind solver = make solvespec sandbox in
     let%bind solver, dependencies = add ~dependencies solver in
     return (solver, dependencies)
   in

--- a/esy-solve/Solver.mli
+++ b/esy-solve/Solver.mli
@@ -2,42 +2,7 @@
  * Package dependency solver.
  *)
 
-open EsyPackageConfig
-
-(** Explanation for solve failure *)
-module Explanation : sig
-  type t
-  val pp : Format.formatter -> t -> unit
-end
-
-(** Solver *)
-type t = private {
-  cfg: Config.t;
-  resolver: Resolver.t;
-  universe: Universe.t;
-  resolutions : Resolutions.t;
-}
-
-(**
- * Result of the solver
- *
- * It's either a solution or a failure with a (possibly empty) explanation.
- *)
-(** Make new solver *)
-val make :
-  cfg:Config.t
-  -> resolver:Resolver.t
-  -> resolutions:Resolutions.t
-  -> unit
-  -> t RunAsync.t
-
-(** Add dependencies to the solver *)
-val add :
-  dependencies:InstallManifest.Dependencies.t
-  -> t
-  -> (t * InstallManifest.Dependencies.t) RunAsync.t
-
 (**
  * Solve dependencies for the root
  *)
-val solve : Sandbox.t -> EsyInstall.Solution.t RunAsync.t
+val solve : SolveSpec.t -> Sandbox.t -> EsyInstall.Solution.t RunAsync.t

--- a/esy/bin/Project.ml
+++ b/esy/bin/Project.ml
@@ -180,7 +180,12 @@ let makeSolved makeFetched (projcfg : ProjectConfig.t) files =
   let path = SandboxSpec.solutionLockPath projcfg.spec in
   let%bind info = FileInfo.ofPath Path.(path / "index.json") in
   files := info::!files;
-  let%bind checksum = ProjectConfig.computeSolutionChecksum projcfg in
+  let%bind digest =
+    EsySolve.Sandbox.digest
+      Workflow.default.solvespec
+      projcfg.solveSandbox
+  in
+  let checksum = Digestv.toHex digest in
   match%bind SolutionLock.ofPath ~checksum ~sandbox:projcfg.installSandbox path with
   | Some solution ->
     let%lwt fetched = makeFetched projcfg solution files in

--- a/esy/bin/Project.ml
+++ b/esy/bin/Project.ml
@@ -185,8 +185,7 @@ let makeSolved makeFetched (projcfg : ProjectConfig.t) files =
       Workflow.default.solvespec
       projcfg.solveSandbox
   in
-  let checksum = Digestv.toHex digest in
-  match%bind SolutionLock.ofPath ~checksum ~sandbox:projcfg.installSandbox path with
+  match%bind SolutionLock.ofPath ~digest projcfg.installSandbox path with
   | Some solution ->
     let%lwt fetched = makeFetched projcfg solution files in
     return {solution; fetched;}

--- a/esy/bin/Project.ml
+++ b/esy/bin/Project.ml
@@ -175,14 +175,14 @@ let makeProject makeSolved projcfg =
   let%lwt solved = makeSolved projcfg files in
   return ({projcfg; solved;}, !files)
 
-let makeSolved makeFetched (projcfg : ProjectConfig.t) files =
+let makeSolved solvespec makeFetched (projcfg : ProjectConfig.t) files =
   let open RunAsync.Syntax in
   let path = SandboxSpec.solutionLockPath projcfg.spec in
   let%bind info = FileInfo.ofPath Path.(path / "index.json") in
   files := info::!files;
   let%bind digest =
     EsySolve.Sandbox.digest
-      Workflow.default.solvespec
+      solvespec
       projcfg.solveSandbox
   in
   match%bind SolutionLock.ofPath ~digest projcfg.installSandbox path with
@@ -256,15 +256,46 @@ let makeFetched makeConfigured (projcfg : ProjectConfig.t) solution files =
       return {installation; sandbox; configured;}
     else errorf "project requires to update its installation, run `esy install`"
 
+type projectWithoutSolution = unit project
+type projectWithoutWorkflow = unit fetched solved project
+
+module WithoutSolution = struct
+
+  type t = projectWithoutSolution
+
+  let makeSolved _projcfg _files =
+    RunAsync.return ()
+
+  let make projcfg =
+    makeProject makeSolved projcfg
+
+  include MakeProject(struct
+    type nonrec t = t
+    let make = make
+    let setProjecyConfig projcfg proj = {proj with projcfg;}
+    let cachePath = makeCachePath "WithoutWorkflow"
+    let writeAuxCache _ = RunAsync.return ()
+  end)
+
+end
+
 module WithoutWorkflow = struct
 
-  type t = unit fetched solved project
+  type t = projectWithoutWorkflow
 
   let makeConfigured _copts _solution _installation _sandbox _files =
     RunAsync.return ()
 
+  let configureSolution solvespec =
+    makeSolved solvespec (makeFetched makeConfigured)
+
   let make projcfg =
-    makeProject (makeSolved (makeFetched makeConfigured)) projcfg
+    makeProject (configureSolution Workflow.default.solvespec) projcfg
+
+  let ofProjectWithoutSolution solvespec proj =
+    let files = ref [] in
+    let%lwt solved = configureSolution solvespec proj.projcfg files in
+    RunAsync.return {projcfg = proj.projcfg; solved;}
 
   include MakeProject(struct
     type nonrec t = t
@@ -318,7 +349,7 @@ module WithWorkflow = struct
     }
 
   let make projcfg =
-    makeProject (makeSolved (makeFetched makeConfigured)) projcfg
+    makeProject (makeSolved Workflow.default.solvespec (makeFetched makeConfigured)) projcfg
 
   let writeAuxCache proj =
     let open RunAsync.Syntax in

--- a/esy/bin/Project.mli
+++ b/esy/bin/Project.mli
@@ -27,6 +27,12 @@ val solved : 'a project -> 'a RunAsync.t
 val fetched : 'a solved project -> 'a RunAsync.t
 val configured : 'a fetched solved project -> 'a RunAsync.t
 
+module WithoutSolution : sig
+  type t = unit project
+  val make : ProjectConfig.t -> (t * FileInfo.t list) Run.t Lwt.t
+  val term : Fpath.t option -> t Cmdliner.Term.t
+end
+
 (**
  * Project without configured workflow.
  *
@@ -37,6 +43,11 @@ module WithoutWorkflow : sig
   type t = unit fetched solved project
 
   val make : ProjectConfig.t -> (t * FileInfo.t list) Run.t Lwt.t
+
+  val ofProjectWithoutSolution :
+    EsySolve.SolveSpec.t
+    -> unit project
+    -> unit fetched solved project Run.t Lwt.t
 
   val term : Fpath.t option -> t Cmdliner.Term.t
   val promiseTerm : Fpath.t option -> t RunAsync.t Cmdliner.Term.t

--- a/esy/bin/ProjectConfig.ml
+++ b/esy/bin/ProjectConfig.ml
@@ -1,4 +1,3 @@
-open EsyPackageConfig
 open Esy
 open Cmdliner
 
@@ -220,87 +219,6 @@ let make
     installSandbox;
     spec;
   }
-
-let computeSolutionChecksum projcfg =
-  let open RunAsync.Syntax in
-
-  let sandbox = projcfg.solveSandbox in
-
-  let ppDependencies fmt deps =
-
-    let ppOpamDependencies fmt deps =
-      let ppDisj fmt disj =
-        match disj with
-        | [] -> Fmt.unit "true" fmt ()
-        | [dep] -> InstallManifest.Dep.pp fmt dep
-        | deps -> Fmt.pf fmt "(%a)" Fmt.(list ~sep:(unit " || ") InstallManifest.Dep.pp) deps
-      in
-      Fmt.pf fmt "@[<h>[@;%a@;]@]" Fmt.(list ~sep:(unit " && ") ppDisj) deps
-    in
-
-    let ppNpmDependencies fmt deps =
-      let ppDnf ppConstr fmt f =
-        let ppConj = Fmt.(list ~sep:(unit " && ") ppConstr) in
-        Fmt.(list ~sep:(unit " || ") ppConj) fmt f
-      in
-      let ppVersionSpec fmt spec =
-        match spec with
-        | VersionSpec.Npm f ->
-          ppDnf SemverVersion.Constraint.pp fmt f
-        | VersionSpec.NpmDistTag tag ->
-          Fmt.string fmt tag
-        | VersionSpec.Opam f ->
-          ppDnf OpamPackageVersion.Constraint.pp fmt f
-        | VersionSpec.Source src ->
-          Fmt.pf fmt "%a" SourceSpec.pp src
-      in
-      let ppReq fmt req =
-        Fmt.fmt "%s@%a" fmt req.Req.name ppVersionSpec req.spec
-      in
-      Fmt.pf fmt "@[<hov>[@;%a@;]@]" (Fmt.list ~sep:(Fmt.unit ", ") ppReq) deps
-    in
-
-    match deps with
-    | InstallManifest.Dependencies.OpamFormula deps -> ppOpamDependencies fmt deps
-    | InstallManifest.Dependencies.NpmFormula deps -> ppNpmDependencies fmt deps
-  in
-
-  let showDependencies (deps : InstallManifest.Dependencies.t) =
-    Format.asprintf "%a" ppDependencies deps
-  in
-
-  let digest =
-    Resolutions.digest sandbox.root.resolutions
-    |> Digestv.(add (string (showDependencies sandbox.root.dependencies)))
-    |> Digestv.(add (string (showDependencies sandbox.root.devDependencies)))
-  in
-
-  let%bind digest =
-    let f digest resolution =
-      let resolution =
-        match resolution.Resolution.resolution with
-        | SourceOverride {source = Source.Link _; override = _;} -> Some resolution
-        | SourceOverride _ -> None
-        | Version (Version.Source (Source.Link _)) -> Some resolution
-        | Version _ -> None
-      in
-      match resolution with
-      | None -> return digest
-      | Some resolution ->
-        begin match%bind EsySolve.Resolver.package ~resolution sandbox.resolver with
-        | Error _ ->
-          errorf "unable to read package: %a" Resolution.pp resolution
-        | Ok pkg ->
-          return Digestv.(add (string (showDependencies pkg.InstallManifest.dependencies)) digest)
-        end
-    in
-    RunAsync.List.foldLeft
-      ~f
-      ~init:digest
-      (Resolutions.entries sandbox.resolutions)
-  in
-
-  return (Digestv.toHex digest)
 
 let promiseTerm projectPath =
   let parse

--- a/esy/bin/ProjectConfig.mli
+++ b/esy/bin/ProjectConfig.mli
@@ -16,8 +16,6 @@ type t = {
   installSandbox : EsyInstall.Sandbox.t;
 }
 
-val computeSolutionChecksum : t -> string RunAsync.t
-
 val promiseTerm : Fpath.t option -> t RunAsync.t Cmdliner.Term.t
 
 val term : Fpath.t option -> t Cmdliner.Term.t

--- a/esy/bin/Workflow.ml
+++ b/esy/bin/Workflow.ml
@@ -1,6 +1,7 @@
 open Esy
 
 type t = {
+  solvespec : EsySolve.SolveSpec.t;
   buildspec : BuildSpec.t;
   execenvspec : EnvSpec.t;
   commandenvspec : EnvSpec.t;
@@ -34,6 +35,13 @@ let defaultPlanForDevForce = {
 }
 
 let default =
+
+  let solvespec = EsySolve.{
+    SolveSpec.
+    solveRoot = DepSpec.(dependencies self + devDependencies self);
+    solveLink = DepSpec.(dependencies self);
+    solveAll = DepSpec.(dependencies self);
+  } in
 
   (* This defines how project is built. *)
   let buildspec = {
@@ -83,4 +91,4 @@ let default =
     augmentDeps = None;
   } in
 
-  {buildspec; execenvspec; commandenvspec; buildenvspec;}
+  {solvespec; buildspec; execenvspec; commandenvspec; buildenvspec;}

--- a/esy/bin/Workflow.mli
+++ b/esy/bin/Workflow.mli
@@ -1,6 +1,7 @@
 open Esy
 
 type t = {
+  solvespec : EsySolve.SolveSpec.t;
   buildspec : BuildSpec.t;
   execenvspec : EnvSpec.t;
   commandenvspec : EnvSpec.t;

--- a/esy/bin/esyCommand.ml
+++ b/esy/bin/esyCommand.ml
@@ -945,12 +945,12 @@ let getSandboxSolution (projcfg : ProjectConfig.t) =
   in
   return solution
 
-let solve (proj : Project.WithWorkflow.t) =
+let solve (proj : _ Project.project) =
   let open RunAsync.Syntax in
   let%bind _ : Solution.t = getSandboxSolution proj.projcfg in
   return ()
 
-let fetch (proj : Project.WithWorkflow.t) =
+let fetch (proj : _ Project.project) =
   let open RunAsync.Syntax in
   let lockPath = SandboxSpec.solutionLockPath proj.projcfg.spec in
   match%bind SolutionLock.ofPath proj.projcfg.installSandbox lockPath with
@@ -1803,13 +1803,13 @@ let makeCommands projectPath =
           )
       );
 
-    makeProjectWithWorkflowCommand
+    makeProjectWithoutWorkflowCommand
       ~name:"solve"
       ~doc:"Solve dependencies and store the solution"
       ~docs:lowLevelSection
       Term.(const solve);
 
-    makeProjectWithWorkflowCommand
+    makeProjectWithoutWorkflowCommand
       ~name:"fetch"
       ~doc:"Fetch dependencies using the stored solution"
       ~docs:lowLevelSection

--- a/esy/bin/esyCommand.ml
+++ b/esy/bin/esyCommand.ml
@@ -916,7 +916,7 @@ let lsModules only (proj : Project.WithWorkflow.t) =
 let getSandboxSolution (projcfg : ProjectConfig.t) =
   let open EsySolve in
   let open RunAsync.Syntax in
-  let%bind solution = Solver.solve projcfg.solveSandbox in
+  let%bind solution = Solver.solve Workflow.default.solvespec projcfg.solveSandbox in
   let lockPath = SandboxSpec.solutionLockPath projcfg.solveSandbox.Sandbox.spec in
   let%bind () =
     let%bind checksum = ProjectConfig.computeSolutionChecksum projcfg in
@@ -987,9 +987,8 @@ let add (reqs : string list) (proj : Project.WithWorkflow.t) =
       | OpamFormula _ -> error opamError
     in
     let%bind combinedDeps = addReqs solveSandbox.root.dependencies in
-    let%bind sbDeps = addReqs solveSandbox.dependencies in
     let root = { solveSandbox.root with dependencies = combinedDeps } in
-    return { solveSandbox with root; dependencies = sbDeps }
+    return { solveSandbox with root; }
   in
 
   let projcfg = {projcfg with solveSandbox;} in

--- a/esy/bin/esyCommand.ml
+++ b/esy/bin/esyCommand.ml
@@ -216,11 +216,13 @@ let resolvedPathTerm =
 let buildDependencies
   all
   devDependencies
+  solvespec
   plan
   linkDepspec
   pkgspec
-  (proj : Project.WithoutWorkflow.t) =
+  (proj : Project.WithoutSolution.t) =
   let open RunAsync.Syntax in
+  let%bind proj = Project.WithoutWorkflow.ofProjectWithoutSolution solvespec proj in
   let%bind fetched = Project.fetched proj in
   let f (pkg : Package.t) =
     let buildspec =
@@ -246,9 +248,10 @@ let buildDependencies
   in
   Project.withPackage proj pkgspec f
 
-let buildPackage plan depspec pkgspec (proj : Project.WithoutWorkflow.t)  =
+let buildPackage solvespec plan depspec pkgspec (proj : Project.WithoutSolution.t)  =
   let open RunAsync.Syntax in
 
+  let%bind proj = Project.WithoutWorkflow.ofProjectWithoutSolution solvespec proj in
   let%bind fetched = Project.fetched proj in
 
   let buildspec =
@@ -273,7 +276,7 @@ let buildPackage plan depspec pkgspec (proj : Project.WithoutWorkflow.t)  =
     Project.buildPackage
       ~quiet:true
       ~buildOnly:true
-      proj.projcfg
+      proj.Project.projcfg
       fetched.Project.sandbox
       plan
       pkg
@@ -286,13 +289,16 @@ let execCommand
   includeCurrentEnv
   includeEsyIntrospectionEnv
   includeNpmBin
+  solvespec
   plan
   linkDepspec
   envspec
   pkgspec
   cmd
-  (proj : _ Project.project)
+  (proj : Project.WithoutSolution.t)
   =
+  let open RunAsync.Syntax in
+  let%bind proj = Project.WithoutWorkflow.ofProjectWithoutSolution solvespec proj in
   let envspec = {
     EnvSpec.
     buildIsInProgress;
@@ -328,12 +334,15 @@ let printEnv
   includeCurrentEnv
   includeEsyIntrospectionEnv
   includeNpmBin
+  solvespec
   plan
   linkDepspec
   envspec
   pkgspec
-  (proj : _ Project.project)
+  (proj : Project.WithoutSolution.t)
   =
+  let open RunAsync.Syntax in
+  let%bind proj = Project.WithoutWorkflow.ofProjectWithoutSolution solvespec proj in
   let envspec = {
     EnvSpec.
     buildIsInProgress = false;
@@ -1339,6 +1348,7 @@ let makeCommands projectPath =
 
   let projectConfig = ProjectConfig.term projectPath in
   let projectWithWorkflow = Project.WithWorkflow.term projectPath in
+  let projectWithoutSolution = Project.WithoutSolution.term projectPath in
   let project = Project.WithoutWorkflow.term projectPath in
 
   let makeProjectWithWorkflowCommand ?(header=`Standard) ?docs ?doc ~name cmd =
@@ -1367,6 +1377,21 @@ let makeCommands projectPath =
         cmd project
       in
       Cmdliner.Term.(pure run $ cmd $ project)
+    in
+    makeCommand ~header:`No ?docs ?doc ~name cmd
+  in
+
+  let makeProjectWithoutSolutionCommand ?(header=`Standard) ?docs ?doc ~name cmd =
+    let cmd =
+      let run cmd project =
+        let () =
+          match header with
+          | `Standard -> Lwt_main.run (printHeader ~spec:project.Project.projcfg.spec name)
+          | `No -> ()
+        in
+        cmd project
+      in
+      Cmdliner.Term.(pure run $ cmd $ projectWithoutSolution)
     in
     makeCommand ~header:`No ?docs ?doc ~name cmd
   in
@@ -1695,12 +1720,13 @@ let makeCommands projectPath =
 
     (* LOW LEVEL PLUMBING COMMANDS *)
 
-    makeProjectWithoutWorkflowCommand
+    makeProjectWithoutSolutionCommand
       ~name:"build-package"
       ~doc:"Build a specified package"
       ~docs:lowLevelSection
       Term.(
         const buildPackage
+        $ solvespecArg
         $ planArg
         $ Arg.(
             value
@@ -1714,7 +1740,7 @@ let makeCommands projectPath =
           )
       );
 
-    makeProjectWithoutWorkflowCommand
+    makeProjectWithoutSolutionCommand
       ~name:"build-dependencies"
       ~doc:"Build dependencies for a specified package"
       ~docs:lowLevelSection
@@ -1730,6 +1756,7 @@ let makeCommands projectPath =
             & flag
             & info ["devDependencies"] ~doc:"Build devDependencies too"
           )
+        $ solvespecArg
         $ planArg
         $ Arg.(
             value
@@ -1745,7 +1772,7 @@ let makeCommands projectPath =
           )
       );
 
-    makeProjectWithoutWorkflowCommand
+    makeProjectWithoutSolutionCommand
       ~header:`No
       ~name:"exec-command"
       ~doc:"Execute command in a given environment"
@@ -1767,6 +1794,7 @@ let makeCommands projectPath =
               ~doc:"Include esy introspection environment"
           )
         $ Arg.(value & flag & info ["include-npm-bin"]  ~doc:"Include npm bin in PATH")
+        $ solvespecArg
         $ planArg
         $ Arg.(
             value
@@ -1793,7 +1821,7 @@ let makeCommands projectPath =
             (Cmdliner.Arg.pos_right 0)
       );
 
-    makeProjectWithoutWorkflowCommand
+    makeProjectWithoutSolutionCommand
       ~header:`No
       ~name:"print-env"
       ~doc:"Print a configured environment on stdout"
@@ -1810,6 +1838,7 @@ let makeCommands projectPath =
               ~doc:"Include esy introspection environment"
           )
         $ Arg.(value & flag & info ["include-npm-bin"]  ~doc:"Include npm bin in PATH")
+        $ solvespecArg
         $ planArg
         $ Arg.(
             value


### PR DESCRIPTION
This PR implements add an ability to configure solve with DEPSPEC.

Note that solver operates on a different kind of depspec than builder: while
builder uses DEPSPEC to select a subgraph from installed packages solver uses
DEPSPEC to select packages from a package universe - put differently DEPSPEC in
solver it describes how solver should collect dependencies (collect only
`"dependencies"` or collect `"devDependencies"` too?)

Thus DEPSPEC mechanism in solver generalizes the current specification we use for `esy install`: "install all dependencies and devDependencies of the root".

## Motivation

In monorepo workflow we want to install devDependencies of the linked packages
so we can develop linked packages using convenient tools like refmterr and so
on.

While we can specify all devDependencies at the root and then use
`dependencies(self)+devDependencies(root)` builder DEPSPEC in some setups it's
not possible as some devtools might be developed as a part of a monorepo and
thus causing cyclic dependency graph (see reason-native with refmterr with a
part of it).

Therefore we can specify devDependencies both at the root (common ones like
merlin) and at specific packages (some packages might specify refmterr and some
might not) and then using the following configuration:

- solver DEPSPEC: for linked `dependencies(self)+devDependencies(self)`
- builder DEPSPEC: for linked `dependencies(self)+devDependencies(self)+devDependencies(root)`

That makes sure devDependencies of linked packages are solved and installed and then used (along with root's devDependencies) for build environment.

## Implementation Details

Solver DEPSPEC configuration is exposed in CLI only via `--include-link-devDependencies` flag which if true means `dependencies(self)+devDependencies(self)` and other `dependencies(self)` otherwise.