### PR TITLE
Implement 'link-dev:` dependency type

### DIFF
--- a/esy-install/Fetch.ml
+++ b/esy-install/Fetch.ml
@@ -168,7 +168,7 @@ module PackagePaths = struct
 
   let installPath sandbox pkg =
     match pkg.Package.source with
-    | Link { path; manifest = _; } ->
+    | Link { path; manifest = _; kind = _; } ->
       DistPath.toPath sandbox.Sandbox.spec.path path
     | Install _ ->
       Path.(sandbox.Sandbox.cfg.sourceInstallPath / key pkg)

--- a/esy-install/Solution.ml
+++ b/esy-install/Solution.ml
@@ -22,10 +22,10 @@ let findByPath p solution =
   let open Option.Syntax in
   let f _id pkg =
     match pkg.Package.source with
-    | Link {path; manifest = None;} ->
+    | Link {path; manifest = None; kind = _; } ->
       let path = DistPath.(path / "package.json") in
       DistPath.compare path p = 0
-    | Link {path; manifest = Some filename;} ->
+    | Link {path; manifest = Some filename; kind = _;} ->
       let path = DistPath.(path / ManifestSpec.show filename) in
       DistPath.compare path p = 0
     | _ -> false

--- a/esy-install/SolutionLock.ml
+++ b/esy-install/SolutionLock.ml
@@ -159,7 +159,7 @@ let writePackage sandbox (pkg : Package.t) =
   let open RunAsync.Syntax in
   let%bind source =
     match pkg.source with
-    | Link { path; manifest } -> return (PackageSource.Link {path; manifest;})
+    | Link { path; manifest; kind; } -> return (PackageSource.Link {path; manifest; kind})
     | Install {source; opam = None;} -> return (PackageSource.Install {source; opam = None;})
     | Install {source; opam = Some opam;} ->
       let%bind opam = writeOpam sandbox opam in
@@ -180,7 +180,7 @@ let readPackage sandbox (node : node) =
   let open RunAsync.Syntax in
   let%bind source =
     match node.source with
-    | Link { path; manifest } -> return (PackageSource.Link {path;manifest;})
+    | Link { path; manifest; kind } -> return (PackageSource.Link {path;manifest; kind;})
     | Install {source; opam = None;} -> return (PackageSource.Install {source; opam = None;})
     | Install {source; opam = Some opam;} ->
       let%bind opam = readOpam sandbox opam in

--- a/esy-package-config/OfPackageJson.ml
+++ b/esy-package-config/OfPackageJson.ml
@@ -125,8 +125,8 @@ module InstallManifestV1 = struct
 
     let source =
       match source with
-      | Source.Link {path; manifest;} ->
-        PackageSource.Link {path; manifest;}
+      | Source.Link {path; manifest; kind;} ->
+        PackageSource.Link {path; manifest; kind;}
       | Source.Dist dist ->
         PackageSource.Install {source = dist, []; opam = None;}
     in

--- a/esy-package-config/PackageSource.mli
+++ b/esy-package-config/PackageSource.mli
@@ -1,5 +1,9 @@
 type t =
-  | Link of Dist.local
+  | Link of {
+      path : DistPath.t;
+      manifest : ManifestSpec.t option;
+      kind : Source.linkKind;
+    }
   | Install of {
       source : Dist.t * Dist.t list;
       opam : opam option;

--- a/esy-package-config/Source.mli
+++ b/esy-package-config/Source.mli
@@ -1,6 +1,14 @@
 type t =
   | Dist of Dist.t
-  | Link of Dist.local
+  | Link of {
+      path : DistPath.t;
+      manifest : ManifestSpec.t option;
+      kind : linkKind;
+    }
+
+and linkKind =
+  | LinkRegular
+  | LinkDev
 
 include S.COMMON with type t := t
 

--- a/esy-package-config/SourceSpec.ml
+++ b/esy-package-config/SourceSpec.ml
@@ -66,7 +66,7 @@ let ofSource (src : Source.t) =
   | Dist LocalPath {path; manifest;} ->
     LocalPath {path; manifest;}
   | Dist NoSource -> NoSource
-  | Link {path; manifest;} ->
+  | Link {path; manifest;kind=_;} ->
     LocalPath {path; manifest;}
 
 module Parse = struct

--- a/esy-package-config/Version.ml
+++ b/esy-package-config/Version.ml
@@ -109,11 +109,11 @@ let%test_module "parsing" = (module struct
 
   let%expect_test "link:/some/path" =
     parse "link:/some/path";
-    [%expect {| (Source (Link ((path /some/path) (manifest ())))) |}]
+    [%expect {| (Source (Link (path /some/path) (manifest ()) (kind LinkRegular))) |}]
 
   let%expect_test "link:/some/path" =
     parse ~tryAsOpam:true "link:/some/path";
-    [%expect {| (Source (Link ((path /some/path) (manifest ())))) |}]
+    [%expect {| (Source (Link (path /some/path) (manifest ()) (kind LinkRegular))) |}]
 
   let%expect_test "some/path" =
     parse "some/path";

--- a/esy-solve/OpamManifest.ml
+++ b/esy-solve/OpamManifest.ml
@@ -269,8 +269,8 @@ let toInstallManifest ?source ~name ~version manifest =
       match source with
       | None ->
         PackageSource.Install {source = sourceFromOpam; opam;}
-      | Some (Source.Link {path; manifest;}) ->
-        Link {path; manifest;}
+      | Some (Source.Link {path; manifest; kind;}) ->
+        Link {path; manifest; kind;}
       | Some (Source.Dist source) ->
         Install {source = source, []; opam;}
     in

--- a/esy-solve/Resolver.ml
+++ b/esy-solve/Resolver.ml
@@ -69,16 +69,17 @@ type t = {
   sourceToSource : (Source.t, Source.t) Hashtbl.t;
 }
 
-let emptyLink ~name ~path ~manifest () =
+let emptyLink ~name ~path ~manifest ~kind () =
   {
     InstallManifest.
     name;
-    version = Version.Source (Source.Link {path; manifest;});
+    version = Version.Source (Source.Link {path; manifest; kind;});
     originalVersion = None;
     originalName = None;
     source = PackageSource.Link {
       path;
       manifest = None;
+      kind;
     };
     overrides = Overrides.empty;
     dependencies = InstallManifest.Dependencies.NpmFormula [];
@@ -258,8 +259,8 @@ let packageOfSource ~name ~overrides (source : Source.t) resolver =
     let%bind resolvedSource =
       match source, resolvedDist with
       | Source.Dist _, _ -> return (Source.Dist resolvedDist)
-      | Source.Link _, Dist.LocalPath {path; manifest;} ->
-        return (Source.Link {path; manifest;})
+      | Source.Link {kind;_}, Dist.LocalPath {path; manifest;} ->
+        return (Source.Link {path; manifest;kind;})
       | Source.Link _, dist -> errorf "unable to link to %a" Dist.pp dist
     in
 
@@ -271,8 +272,8 @@ let packageOfSource ~name ~overrides (source : Source.t) resolver =
         if not (Overrides.isEmpty overrides)
         then
           match source with
-          | Source.Link {path; manifest;} ->
-            let pkg = emptyLink ~name ~path ~manifest () in
+          | Source.Link {path; manifest; kind;} ->
+            let pkg = emptyLink ~name ~path ~manifest ~kind () in
             return (Ok pkg)
           | _ ->
             let pkg = emptyInstall ~name ~source:resolvedDist () in

--- a/esy-solve/Sandbox.ml
+++ b/esy-solve/Sandbox.ml
@@ -40,7 +40,7 @@ let make ~cfg (spec : EsyInstall.SandboxSpec.t) =
   let open RunAsync.Syntax in
   let path = DistPath.make ~base:spec.path spec.path in
   let makeSource manifest =
-    Source.Link {path; manifest = Some manifest;}
+    Source.Link {path; manifest = Some manifest; kind = LinkDev;}
   in
   RunAsync.contextf (
     let%bind resolver = Resolver.make ~cfg ~sandbox:spec () in
@@ -109,8 +109,7 @@ let make ~cfg (spec : EsyInstall.SandboxSpec.t) =
 
 let defaultSolvespec = {
   SolveSpec.
-  solveRoot = DepSpec.(dependencies self + devDependencies self);
-  solveLink = DepSpec.(dependencies self);
+  solveDev = DepSpec.(dependencies self + devDependencies self);
   solveAll = DepSpec.(dependencies self);
 }
 
@@ -175,7 +174,7 @@ let digest solvespec sandbox =
       rootDigest, linkDigest
     | false ->
       let manifestDigest manifest =
-        match SolveSpec.eval solvespec sandbox.root manifest with
+        match SolveSpec.eval solvespec manifest with
         | Ok dependencies ->
           Digestv.(add (string (showDependencies dependencies)))
         | Error _ ->

--- a/esy-solve/SolveSpec.ml
+++ b/esy-solve/SolveSpec.ml
@@ -1,20 +1,16 @@
 open EsyPackageConfig
 
 type t = {
-  solveRoot : DepSpec.t;
-  solveLink : DepSpec.t;
+  solveDev : DepSpec.t;
   solveAll : DepSpec.t;
 } [@@deriving ord]
 
-let eval spec root manifest =
+let eval spec manifest =
   let depspec =
-    let isRoot = InstallManifest.compare root manifest = 0 in
-    if isRoot
-    then spec.solveRoot
-    else
-      match manifest.InstallManifest.source with
-      | PackageSource.Link _ -> spec.solveLink
-      | _ -> spec.solveAll
+    match manifest.InstallManifest.source with
+    | Link {kind = LinkDev; _} -> spec.solveDev
+    | Link {kind = LinkRegular; _}
+    | Install _ -> spec.solveAll
   in
   DepSpec.eval manifest depspec
 

--- a/esy-solve/SolveSpec.mli
+++ b/esy-solve/SolveSpec.mli
@@ -1,10 +1,9 @@
 open EsyPackageConfig
 
 type t = {
-  solveRoot : DepSpec.t;
-  solveLink : DepSpec.t;
+  solveDev : DepSpec.t;
   solveAll : DepSpec.t;
 }
 
-val eval : t -> InstallManifest.t -> InstallManifest.t -> InstallManifest.Dependencies.t Run.t
+val eval : t -> InstallManifest.t -> InstallManifest.Dependencies.t Run.t
 val compare : t -> t -> int

--- a/esy-solve/Solver.ml
+++ b/esy-solve/Solver.ml
@@ -57,7 +57,7 @@ type t = {
 }
 
 let evalDependencies solver manifest =
-  SolveSpec.eval solver.solvespec solver.sandbox.root manifest
+  SolveSpec.eval solver.solvespec manifest
 
 module Reason : sig
 
@@ -515,6 +515,7 @@ let solveDependencies ~root ~installed ~strategy dependencies solver =
     source = PackageSource.Link {
       path = DistPath.v ".";
       manifest = None;
+      kind = LinkRegular;
     };
     overrides = Overrides.empty;
     dependencies;

--- a/esy/BuildId.ml
+++ b/esy/BuildId.ml
@@ -123,9 +123,9 @@ module Repr = struct
       let buildCommands =
         match (mode : BuildSpec.mode), sourceType, buildDev with
         | Build, _, _
-        | (BuildDev | BuildDevForce), (SourceType.ImmutableWithTransientDependencies | Immutable), _
-        | (BuildDev | BuildDevForce), Transient, None -> build
-        | (BuildDev | BuildDevForce), SourceType.Transient, Some commands ->
+        | BuildDev, (SourceType.ImmutableWithTransientDependencies | Immutable), _
+        | BuildDev, Transient, None -> build
+        | BuildDev, SourceType.Transient, Some commands ->
           BuildManifest.EsyCommands commands
       in
       {

--- a/esy/BuildSandbox.mli
+++ b/esy/BuildSandbox.mli
@@ -21,7 +21,7 @@ val configure :
   ?forceImmutable:bool
   -> EnvSpec.t
   -> BuildSpec.t
-  -> BuildSpec.plan
+  -> BuildSpec.mode
   -> t
   -> PackageId.t
   -> (Scope.SandboxEnvironment.Bindings.t * Scope.t) Run.t
@@ -30,7 +30,7 @@ val env :
   ?forceImmutable:bool
   -> EnvSpec.t
   -> BuildSpec.t
-  -> BuildSpec.plan
+  -> BuildSpec.mode
   -> t
   -> PackageId.t
   -> Scope.SandboxEnvironment.Bindings.t Run.t
@@ -38,7 +38,7 @@ val env :
 val exec :
   EnvSpec.t
   -> BuildSpec.t
-  -> BuildSpec.plan
+  -> BuildSpec.mode
   -> t
   -> PackageId.t
   -> Cmd.t
@@ -73,19 +73,19 @@ module Plan : sig
   val getByNameVersion : t -> string -> Version.t -> Task.t option
 
   val all : t -> Task.t list
-  val plan : t -> BuildSpec.plan
+  val mode : t -> BuildSpec.mode
 end
 
 val makePlan :
   ?forceImmutable : bool
   -> BuildSpec.t
-  -> BuildSpec.plan
+  -> BuildSpec.mode
   -> t
   -> Plan.t Run.t
 
 val buildShell :
   BuildSpec.t
-  -> BuildSpec.plan
+  -> BuildSpec.mode
   -> t
   -> PackageId.t
   -> Unix.process_status RunAsync.t

--- a/esy/BuildSpec.ml
+++ b/esy/BuildSpec.ml
@@ -2,98 +2,42 @@ open EsyPackageConfig
 module Package = EsyInstall.Package
 
 type t = {
-  build : DepSpec.t;
-  buildLink : DepSpec.t option;
-  buildRootForRelease : DepSpec.t option;
-  buildRootForDev : DepSpec.t option;
+  buildAll : DepSpec.t;
+  buildDev : DepSpec.t option;
 }
 
 type mode =
   | Build
   | BuildDev
-  | BuildDevForce
 
 let pp_mode fmt = function
   | Build -> Fmt.string fmt "build"
   | BuildDev -> Fmt.string fmt "buildDev"
-  | BuildDevForce -> Fmt.string fmt "buildDevForce"
 
 let show_mode = function
   | Build -> "build"
   | BuildDev -> "buildDev"
-  | BuildDevForce -> "buildDevForce"
 
 let mode_to_yojson = function
   | Build -> `String "build"
   | BuildDev -> `String "buildDev"
-  | BuildDevForce -> `String "buildDevForce"
 
 let mode_of_yojson = function
   | `String "build" -> Ok Build
   | `String "buildDev" -> Ok BuildDev
   | _json -> Result.errorf {|invalid BuildSpec.mode: expected "build" or "buildDev"|}
 
-type plan = {
-  all : mode;
-  link : mode;
-  root : mode;
-}
-
-let pp_plan fmt plan =
-  Fmt.pf
-    fmt "root=%a link=%a all=%a"
-    pp_mode plan.root pp_mode plan.link pp_mode plan.all
-
-let show_plan plan = Fmt.strf "%a" pp_plan plan
-
-type build = {
-  mode : mode;
-  deps : DepSpec.t;
-}
-
-let classify spec plan solution pkg buildManifest =
-  let root = EsyInstall.Solution.root solution in
-  let isRoot = Package.compare root pkg = 0 in
-  let commands = buildManifest.BuildManifest.build in
-  let kind, mode =
-    if isRoot
-    then `Root, plan.root
-    else match pkg.Package.source with
-    | Link _ -> `Link, plan.link
-    | Install _ -> `All, plan.all
-  in
-  (* force Build mode if no build commands is provided *)
-  let mode, commands =
-    match mode, buildManifest.BuildManifest.buildDev with
-    | Build, _ -> mode, commands
-    | BuildDev, None -> Build, commands
-    | BuildDev, Some commands -> BuildDev, BuildManifest.EsyCommands commands
-    | BuildDevForce, None -> mode, commands
-    | BuildDevForce, Some commands -> mode, BuildManifest.EsyCommands commands
-  in
-  let build =
-    match kind with
-    | `All -> spec.build
-    | `Link ->
-      begin match spec.buildLink with
-      | None -> spec.build
-      | Some build -> build
-      end
-    | `Root ->
-      begin match mode with
-      | BuildDev | BuildDevForce ->
-        begin match spec.buildRootForDev, spec.buildRootForRelease, spec.buildLink with
-        | Some build, _,          _     -> build
-        | None,       Some build, _     -> build
-        | None,       None, Some build  -> build
-        | None,       None,      None   -> spec.build
-        end
-      | Build ->
-        begin match spec.buildRootForRelease, spec.buildLink with
-        | Some build, _     -> build
-        | None, Some build  -> build
-        | None, None        -> spec.build
-        end
-      end
-  in
-  {deps = build; mode;}, commands
+let classify spec mode pkg build =
+  match pkg.Package.source, mode with
+  | Link {kind = LinkDev; _}, BuildDev ->
+    let depspec = Option.orDefault ~default:spec.buildAll spec.buildDev in
+    let commands =
+      match build.BuildManifest.buildDev with
+      | None -> build.BuildManifest.build
+      | Some cmds -> BuildManifest.EsyCommands cmds
+    in
+    depspec, commands
+  | Link {kind = LinkDev; _}, Build
+  | Link {kind = LinkRegular; _}, _
+  | Install _, _ ->
+    spec.buildAll, build.build

--- a/esy/BuildSpec.mli
+++ b/esy/BuildSpec.mli
@@ -6,28 +6,19 @@ type t = {
   (**
     Define how we build packages.
     *)
-  build : DepSpec.t;
+  buildAll : DepSpec.t;
 
   (**
     Optionally define if we need to treat linked packages in a specific way.
 
     (this overrides buildLink and build)
     *)
-  buildLink : DepSpec.t option;
-
-  (**
-    Optionally define if we need to treat the root package in a specific way.
-
-    (this overrides buildLink and build)
-    *)
-  buildRootForRelease : DepSpec.t option;
-  buildRootForDev : DepSpec.t option;
+  buildDev : DepSpec.t option;
 }
 
 type mode =
   | Build
   | BuildDev
-  | BuildDevForce
 
 val pp_mode : mode Fmt.t
 val show_mode : mode -> string
@@ -35,28 +26,9 @@ val show_mode : mode -> string
 val mode_to_yojson : mode Json.encoder
 val mode_of_yojson : mode Json.decoder
 
-(**
-  This is a pair of which build command to use ("build" or "buildDev") and
-  a specification of what to bring into the build env.
- *)
-type build = {
-  mode : mode;
-  deps : DepSpec.t;
-}
-
-type plan = {
-  all : mode;
-  link : mode;
-  root : mode;
-}
-
-val pp_plan : plan Fmt.t
-val show_plan : plan -> string
-
 val classify :
   t
-  -> plan
-  -> EsyInstall.Solution.t
+  -> mode
   -> EsyInstall.Package.t
   -> BuildManifest.t
-  -> build * BuildManifest.commands
+  -> DepSpec.t * BuildManifest.commands

--- a/esy/ReadBuildManifest.ml
+++ b/esy/ReadBuildManifest.ml
@@ -220,7 +220,7 @@ let ofPath ?manifest (path : Path.t) =
 let ofInstallationLocation ~cfg (pkg : EsyInstall.Package.t) (loc : EsyInstall.Installation.location) =
   let open RunAsync.Syntax in
   match pkg.source with
-  | Link { path; manifest; } ->
+  | Link { path; manifest; kind = _; } ->
     let dist = Dist.LocalPath {path; manifest;} in
     let%bind res =
       EsyInstall.DistResolver.resolve

--- a/esy/Scope.mli
+++ b/esy/Scope.mli
@@ -12,7 +12,8 @@ val make :
   -> id:BuildId.t
   -> name:string
   -> version:Version.t
-  -> build:BuildSpec.build
+  -> mode:BuildSpec.mode
+  -> depspec:DepSpec.t
   -> sourceType:SourceType.t
   -> sourcePath:SandboxPath.t
   -> EsyInstall.Package.t
@@ -25,7 +26,8 @@ val add : direct:bool -> dep:t -> t -> t
 
 val pkg : t -> EsyInstall.Package.t
 val id : t -> BuildId.t
-val build : t -> BuildSpec.build
+val mode : t -> BuildSpec.mode
+val depspec : t -> DepSpec.t
 val name : t -> string
 val version : t -> Version.t
 val sourceType : t -> SourceType.t

--- a/esy/bin/NpmReleaseCommand.ml
+++ b/esy/bin/NpmReleaseCommand.ml
@@ -288,12 +288,9 @@ let envspec = {
 }
 let buildspec = {
   BuildSpec.
-  build = DepSpec.(dependencies self);
-  buildLink = Some DepSpec.(dependencies self);
-  buildRootForDev = Some DepSpec.(dependencies self);
-  buildRootForRelease = Some DepSpec.(dependencies self);
+  buildAll = DepSpec.(dependencies self);
+  buildDev = Some DepSpec.(dependencies self);
 }
-
 let cleanupLinksFromGlobalStore cfg tasks =
   let open RunAsync.Syntax in
   let f task =
@@ -327,7 +324,7 @@ let make
     BuildSandbox.makePlan
       ~forceImmutable:true
       buildspec
-      {all = Build; link = Build; root = Build;}
+      Build
       sandbox
   ) in
   let tasks = BuildSandbox.Plan.all plan in
@@ -433,7 +430,7 @@ let make
           ~forceImmutable:true
           envspec
           buildspec
-          {all = Build; link = Build; root = Build;}
+          Build
           sandbox
           root.Package.id
       ) in

--- a/esy/bin/Project.mli
+++ b/esy/bin/Project.mli
@@ -112,7 +112,7 @@ val execCommand :
   -> _ fetched solved project
   -> EnvSpec.t
   -> BuildSpec.t
-  -> BuildSpec.plan
+  -> BuildSpec.mode
   -> PkgArg.t
   -> Cmd.t
   -> unit
@@ -123,7 +123,7 @@ val printEnv :
   -> _ fetched solved project
   -> EnvSpec.t
   -> BuildSpec.t
-  -> BuildSpec.plan
+  -> BuildSpec.mode
   -> bool
   -> PkgArg.t
   -> unit

--- a/esy/bin/Workflow.ml
+++ b/esy/bin/Workflow.ml
@@ -8,38 +8,14 @@ type t = {
   buildenvspec : EnvSpec.t;
 }
 
-let defaultDepspec = DepSpec.(dependencies self)
-let defaultDepspecForLink = DepSpec.(dependencies self)
-let defaultDepspecForRootForRelease = DepSpec.(dependencies self)
-let defaultDepspecForRootForDev = DepSpec.(dependencies self + devDependencies self)
-
-let defaultPlanForRelease = {
-  BuildSpec.
-  all = Build;
-  link = Build;
-  root = Build;
-}
-
-let defaultPlanForDev = {
-  BuildSpec.
-  all = Build;
-  link = Build;
-  root = BuildDev;
-}
-
-let defaultPlanForDevForce = {
-  BuildSpec.
-  all = Build;
-  link = Build;
-  root = BuildDevForce;
-}
+let buildAll = DepSpec.(dependencies self)
+let buildDev = DepSpec.(dependencies self + devDependencies self)
 
 let default =
 
   let solvespec = EsySolve.{
     SolveSpec.
-    solveRoot = DepSpec.(dependencies self + devDependencies self);
-    solveLink = DepSpec.(dependencies self);
+    solveDev = DepSpec.(dependencies self + devDependencies self);
     solveAll = DepSpec.(dependencies self);
   } in
 
@@ -47,12 +23,9 @@ let default =
   let buildspec = {
     BuildSpec.
     (* build all other packages using "build" command with dependencies in the env *)
-    build = defaultDepspec;
+    buildAll = buildAll;
     (* build linked packages using "build" command with dependencies in the env *)
-    buildLink = Some defaultDepspecForLink;
-
-    buildRootForRelease = Some defaultDepspecForRootForRelease;
-    buildRootForDev = Some defaultDepspecForRootForDev;
+    buildDev = Some buildDev;
   } in
 
   (* This defines environment for "esy x CMD" invocation. *)

--- a/esy/bin/Workflow.mli
+++ b/esy/bin/Workflow.mli
@@ -8,13 +8,7 @@ type t = {
   buildenvspec : EnvSpec.t;
 }
 
-val defaultDepspec : DepSpec.t
-val defaultDepspecForLink : DepSpec.t
-val defaultDepspecForRootForDev : DepSpec.t
-val defaultDepspecForRootForRelease : DepSpec.t
-
-val defaultPlanForRelease : BuildSpec.plan
-val defaultPlanForDev : BuildSpec.plan
-val defaultPlanForDevForce : BuildSpec.plan
+val buildAll : DepSpec.t
+val buildDev : DepSpec.t
 
 val default : t

--- a/test-e2e/common/build-errors.test.js
+++ b/test-e2e/common/build-errors.test.js
@@ -30,7 +30,7 @@ describe('build errors', function() {
     expect(err.stderr.trim()).toEqual(
       outdent`
       error: reading "dependencies": expected an object
-        reading package metadata from link:./package.json
+        reading package metadata from link-dev:./package.json
         loading root package metadata
       esy: exiting due to errors above
       `,

--- a/test-e2e/common/solve-errors.test.js
+++ b/test-e2e/common/solve-errors.test.js
@@ -414,7 +414,7 @@ describe('"resolutions" misconfiguration errors', function() {
     expect(err.stderr.trim()).toEqual(
       outdent`
       error: parsing "github:author/pkg": <author>/<repo>(:<manifest>)?#<commit>: missing or incorrect <commit>
-        reading package metadata from link:./package.json
+        reading package metadata from link-dev:./package.json
         loading root package metadata
       esy: exiting due to errors above
       `,
@@ -445,7 +445,7 @@ describe('"resolutions" misconfiguration errors', function() {
     expect(err.stderr.trim()).toEqual(
       outdent`
       error: parsing "author/pkg#ref": <author>/<repo>(:<manifest>)?#<commit>: missing or incorrect <commit>
-        reading package metadata from link:./package.json
+        reading package metadata from link-dev:./package.json
         loading root package metadata
       esy: exiting due to errors above
       `,

--- a/test-e2e/complete/lock-invalidation.test.js
+++ b/test-e2e/complete/lock-invalidation.test.js
@@ -38,7 +38,7 @@ describe('lock invalidation', () => {
 
     expect(await helpers.readInstalledPackages(p.projectPath)).toEqual({
       name: 'root',
-      version: 'link:./package.json',
+      version: 'link-dev:./package.json',
       dependencies: {
         a: {name: 'a', version: '1.0.0', dependencies: {}},
       },
@@ -55,7 +55,7 @@ describe('lock invalidation', () => {
 
     expect(await helpers.readInstalledPackages(p.projectPath)).toEqual({
       name: 'root',
-      version: 'link:./package.json',
+      version: 'link-dev:./package.json',
       dependencies: {
         a: {name: 'a', version: '1.0.0', dependencies: {}},
         b: {name: 'b', version: '1.0.0', dependencies: {}},
@@ -73,7 +73,7 @@ describe('lock invalidation', () => {
 
     expect(await helpers.readInstalledPackages(p.projectPath)).toEqual({
       name: 'root',
-      version: 'link:./package.json',
+      version: 'link-dev:./package.json',
       dependencies: {
         a: {name: 'a', version: '1.0.0', dependencies: {}},
       },
@@ -114,7 +114,7 @@ describe('lock invalidation', () => {
 
     expect(await helpers.readInstalledPackages(p.projectPath)).toEqual({
       name: 'root',
-      version: 'link:./package.json',
+      version: 'link-dev:./package.json',
       dependencies: {
         dep: {
           name: 'dep',
@@ -137,7 +137,7 @@ describe('lock invalidation', () => {
 
     expect(await helpers.readInstalledPackages(p.projectPath)).toEqual({
       name: 'root',
-      version: 'link:./package.json',
+      version: 'link-dev:./package.json',
       dependencies: {
         dep: {
           name: 'dep',
@@ -161,7 +161,7 @@ describe('lock invalidation', () => {
 
     expect(await helpers.readInstalledPackages(p.projectPath)).toEqual({
       name: 'root',
-      version: 'link:./package.json',
+      version: 'link-dev:./package.json',
       dependencies: {
         dep: {
           name: 'dep',
@@ -213,7 +213,7 @@ describe('lock invalidation', () => {
 
     expect(await helpers.readInstalledPackages(p.projectPath)).toEqual({
       name: 'root',
-      version: 'link:./package.json',
+      version: 'link-dev:./package.json',
       dependencies: {
         a: {name: 'a', version: '1.0.0', dependencies: {}},
         dep: {
@@ -235,7 +235,7 @@ describe('lock invalidation', () => {
 
     expect(await helpers.readInstalledPackages(p.projectPath)).toEqual({
       name: 'root',
-      version: 'link:./package.json',
+      version: 'link-dev:./package.json',
       dependencies: {
         a: {name: 'a', version: '1.0.0', dependencies: {}},
         dep: {
@@ -264,7 +264,7 @@ describe('lock invalidation', () => {
 
     expect(await helpers.readInstalledPackages(p.projectPath)).toEqual({
       name: 'root',
-      version: 'link:./package.json',
+      version: 'link-dev:./package.json',
       dependencies: {
         dep: {
           name: 'dep',

--- a/test-e2e/complete/monorepo-workflow.test.js
+++ b/test-e2e/complete/monorepo-workflow.test.js
@@ -77,9 +77,9 @@ async function createTestSandbox() {
         devDep: 'path:./devDep',
       },
       resolutions: {
-        pkga: 'link:./pkga',
-        pkgb: 'link:./pkgb',
-        pkgc: 'link:./pkgc',
+        pkga: 'link-dev:./pkga',
+        pkgb: 'link-dev:./pkgb',
+        pkgc: 'link-dev:./pkgc',
       },
     }),
     dir(
@@ -122,7 +122,7 @@ describe('Monorepo workflow using low level commands', function() {
     const p = await createTestSandbox();
 
     // simple build doesn't work as we are using devDep of the root in "buildDev"
-    await expect(p.esy('build-dependencies --all --link-mode dev')).rejects.toThrowError(
+    await expect(p.esy('build-dependencies --all')).rejects.toThrowError(
       'unable to resolve command: devDep.cmd',
     );
   });
@@ -133,11 +133,11 @@ describe('Monorepo workflow using low level commands', function() {
     // now try to build with a custom DEPSPEC
     const p = await createTestSandbox();
 
-    await p.esy(`build-dependencies --all --link-mode dev --link-depspec "${depspec}"`);
+    await p.esy(`build-dependencies --all --link-depspec "${depspec}"`);
 
     for (const pkg of ['pkga', 'pkgb', 'pkgc']) {
       const {stdout} = await p.esy(
-        `exec-command --include-current-env --link-mode dev --link-depspec "${depspec}" root -- ${pkg}.cmd`,
+        `exec-command --include-current-env --link-depspec "${depspec}" root -- ${pkg}.cmd`,
       );
       expect(stdout.trim()).toBe(`__${pkg}__`);
     }
@@ -147,11 +147,11 @@ describe('Monorepo workflow using low level commands', function() {
     // release build should work as-is as we are building using `"esy.build"`
     // commands.
     const p = await createTestSandbox();
-    await p.esy('build-dependencies --all --link-mode release');
+    await p.esy('build-dependencies --all --release');
 
     for (const pkg of ['pkga', 'pkgb', 'pkgc']) {
       const {stdout} = await p.esy(
-        `exec-command --link-mode release --include-current-env root -- ${pkg}.cmd`,
+        `exec-command --release --include-current-env root -- ${pkg}.cmd`,
       );
       expect(stdout.trim()).toBe(`__${pkg}__`);
     }
@@ -163,7 +163,7 @@ describe('Monorepo workflow using low level commands', function() {
       // run commands in a specified package environment.
       const p = await createTestSandbox();
       const {stdout} = await p.esy(
-        `exec-command --link-mode dev --link-depspec "${depspec}" pkga -- echo '#{self.name}'`,
+        `exec-command --link-depspec "${depspec}" pkga -- echo '#{self.name}'`,
       );
 
       expect(stdout.trim()).toBe('pkga');
@@ -176,7 +176,7 @@ describe('Monorepo workflow using low level commands', function() {
       // we can also refer to linked package by its manifest path
       const p = await createTestSandbox();
       const {stdout} = await p.esy(
-        `exec-command --link-mode dev --link-depspec "${depspec}" ./pkgb/package.json -- echo '#{self.name}'`,
+        `exec-command --link-depspec "${depspec}" ./pkgb/package.json -- echo '#{self.name}'`,
       );
 
       expect(stdout.trim()).toBe('pkgb');

--- a/test-e2e/esy-build-dependencies.test.js
+++ b/test-e2e/esy-build-dependencies.test.js
@@ -89,13 +89,13 @@ describe(`'esy build-dependencies' command`, () => {
     });
   });
 
-  it(`doesn't build devDependencies`, async () => {
+  it(`build devDependencies`, async () => {
     const p = await createTestSandbox();
     await p.esy('install');
     await p.esy('build-dependencies');
     const env = await getCommandEnv(p);
-    await expect(p.run('devDep.cmd', env)).rejects.toMatchObject({
-      code: 127,
+    await expect(p.run('devDep.cmd', env)).resolves.toMatchObject({
+      stdout: '__devDep__' + os.EOL,
     });
   });
 

--- a/test-e2e/esy-build-env.test.js
+++ b/test-e2e/esy-build-env.test.js
@@ -89,7 +89,7 @@ describe(`'esy build-env' command`, () => {
       promiseExec('. ./build-env && devDep.cmd', {
         cwd: p.projectPath,
       }),
-    ).rejects.toThrow();
+    ).resolves.toEqual({stdout: '__devDep__\n', stderr: ''});
   });
 
   it('generates an environment in JSON', async () => {
@@ -101,7 +101,7 @@ describe(`'esy build-env' command`, () => {
 
     expect(env.cur__name).toBe('simple-project');
     expect(env.cur__version).toBe('1.0.0');
-    expect(env.cur__dev).toBe('false');
+    expect(env.cur__dev).toBe('true');
     expect(env.cur__toplevel).toBeTruthy();
     expect(env.cur__target_dir).toBeTruthy();
     expect(env.cur__stublibs).toBeTruthy();
@@ -144,9 +144,9 @@ describe(`'esy build-env' command`, () => {
     expect(env.depOfDep__local).toBe(undefined);
     expect(env.depOfDep__global).toBe('depOfDep__global__value');
 
-    // dev deps are not present in build env
-    expect(env.devDep__local).toBe(undefined);
-    expect(env.devDep__global).toBe(undefined);
+    // dev deps are present in build env in dev mode
+    expect(env.devDep__local).toBe('devDep__local__value');
+    expect(env.devDep__global).toBe('devDep__global__value');
   });
 
   it('allows to query build env for a dep (by name)', async () => {

--- a/test-e2e/esy-build/__snapshots__/no-deps.test.js.snap
+++ b/test-e2e/esy-build/__snapshots__/no-deps.test.js.snap
@@ -2,9 +2,9 @@
 
 exports[`'esy build': simple executable with no deps out of source build macos || linux: build-env snapshot 1`] = `
 "# Build environment
-# package:            no-deps@link:./package.json
-# depspec:            dependencies(self)
-# plan:               root=buildDev link=build all=build
+# package:            no-deps@link-dev:./package.json
+# depspec:            dependencies(self)+devDependencies(self)
+# mode:               buildDev
 # envspec:            
 # buildIsInProgress:  true
 # includeBuildEnv:    true
@@ -28,7 +28,7 @@ export cur__install=\\"%projectPath%/_esy/default/store/i/%id%\\"
 export cur__target_dir=\\"%projectPath%/_esy/default/store/b/%id%\\"
 export cur__original_root=\\"%projectPath%\\"
 export cur__root=\\"%projectPath%\\"
-export cur__dev=\\"false\\"
+export cur__dev=\\"true\\"
 export cur__version=\\"1.0.0\\"
 export cur__name=\\"no-deps\\"
 export OCAMLFIND_LDCONF=\\"ignore\\"

--- a/test-e2e/esy-build/__snapshots__/optDependencies.test.js.snap
+++ b/test-e2e/esy-build/__snapshots__/optDependencies.test.js.snap
@@ -2,9 +2,9 @@
 
 exports[`Build with optDependencies builds w/ opt dependency installed snapshot build-env 1`] = `
 "# Build environment
-# package:            root@link:./package.json
-# depspec:            dependencies(self)
-# plan:               root=buildDev link=build all=build
+# package:            root@link-dev:./package.json
+# depspec:            dependencies(self)+devDependencies(self)
+# mode:               buildDev
 # envspec:            
 # buildIsInProgress:  true
 # includeBuildEnv:    true
@@ -28,7 +28,7 @@ export cur__install=\\"%projectPath%/_esy/default/store/i/%id%\\"
 export cur__target_dir=\\"%projectPath%/_esy/default/store/b/%id%\\"
 export cur__original_root=\\"%projectPath%\\"
 export cur__root=\\"%projectPath%\\"
-export cur__dev=\\"false\\"
+export cur__dev=\\"true\\"
 export cur__version=\\"1.0.0\\"
 export cur__name=\\"root\\"
 
@@ -62,7 +62,7 @@ exports[`Build with optDependencies builds w/ opt dependency installed snapshot 
 "# Build environment
 # package:            dep@path:dep
 # depspec:            dependencies(self)
-# plan:               root=buildDev link=build all=build
+# mode:               buildDev
 # envspec:            
 # buildIsInProgress:  true
 # includeBuildEnv:    true
@@ -110,9 +110,9 @@ export PATH=\\"$PATH:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\""
 
 exports[`Build with optDependencies builds w/o opt dependency installed snapshot build-env 1`] = `
 "# Build environment
-# package:            root@link:./package.json
-# depspec:            dependencies(self)
-# plan:               root=buildDev link=build all=build
+# package:            root@link-dev:./package.json
+# depspec:            dependencies(self)+devDependencies(self)
+# mode:               buildDev
 # envspec:            
 # buildIsInProgress:  true
 # includeBuildEnv:    true
@@ -136,7 +136,7 @@ export cur__install=\\"%projectPath%/_esy/default/store/i/%id%\\"
 export cur__target_dir=\\"%projectPath%/_esy/default/store/b/%id%\\"
 export cur__original_root=\\"%projectPath%\\"
 export cur__root=\\"%projectPath%\\"
-export cur__dev=\\"false\\"
+export cur__dev=\\"true\\"
 export cur__version=\\"1.0.0\\"
 export cur__name=\\"root\\"
 
@@ -162,7 +162,7 @@ exports[`Build with optDependencies builds w/o opt dependency installed snapshot
 "# Build environment
 # package:            dep@path:dep
 # depspec:            dependencies(self)
-# plan:               root=buildDev link=build all=build
+# mode:               buildDev
 # envspec:            
 # buildIsInProgress:  true
 # includeBuildEnv:    true

--- a/test-e2e/esy-build/__snapshots__/with-dep.test.js.snap
+++ b/test-e2e/esy-build/__snapshots__/with-dep.test.js.snap
@@ -4,7 +4,7 @@ exports[`Build with dep out of source build macos || linux: build-env dep snapsh
 "# Build environment
 # package:            dep@path:dep
 # depspec:            dependencies(self)
-# plan:               root=buildDev link=build all=build
+# mode:               buildDev
 # envspec:            
 # buildIsInProgress:  true
 # includeBuildEnv:    true
@@ -56,9 +56,9 @@ export PATH=\\"$PATH:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\""
 
 exports[`Build with dep out of source build macos || linux: build-env snapshot 1`] = `
 "# Build environment
-# package:            withDep@link:./package.json
-# depspec:            dependencies(self)
-# plan:               root=buildDev link=build all=build
+# package:            withDep@link-dev:./package.json
+# depspec:            dependencies(self)+devDependencies(self)
+# mode:               buildDev
 # envspec:            
 # buildIsInProgress:  true
 # includeBuildEnv:    true
@@ -82,7 +82,7 @@ export cur__install=\\"%projectPath%/_esy/default/store/i/%id%\\"
 export cur__target_dir=\\"%projectPath%/_esy/default/store/b/%id%\\"
 export cur__original_root=\\"%projectPath%\\"
 export cur__root=\\"%projectPath%\\"
-export cur__dev=\\"false\\"
+export cur__dev=\\"true\\"
 export cur__version=\\"1.0.0\\"
 export cur__name=\\"withDep\\"
 

--- a/test-e2e/esy-build/__snapshots__/with-dev-dep.test.js.snap
+++ b/test-e2e/esy-build/__snapshots__/with-dev-dep.test.js.snap
@@ -121,10 +121,10 @@ export cur__name=\\"withDevDep\\"
 #
 # depOfDevDep@path:depOfDevDep@d41d8cd9
 #
-export CAML_LD_LIBRARY_PATH=\\"%esyStorePath%/i/depofdevdep-cb1178c2/stublibs:%esyStorePath%/i/depofdevdep-cb1178c2/lib/stublibs:$CAML_LD_LIBRARY_PATH\\"
-export OCAMLPATH=\\"%esyStorePath%/i/depofdevdep-cb1178c2/lib:$OCAMLPATH\\"
-export MAN_PATH=\\"%esyStorePath%/i/depofdevdep-cb1178c2/man:$MAN_PATH\\"
-export PATH=\\"%esyStorePath%/i/depofdevdep-cb1178c2/bin:$PATH\\"
+export CAML_LD_LIBRARY_PATH=\\"%esyStorePath%/i/%depofdevdepid%/stublibs:%esyStorePath%/i/%depofdevdepid%/lib/stublibs:$CAML_LD_LIBRARY_PATH\\"
+export OCAMLPATH=\\"%esyStorePath%/i/%depofdevdepid%/lib:$OCAMLPATH\\"
+export MAN_PATH=\\"%esyStorePath%/i/%depofdevdepid%/man:$MAN_PATH\\"
+export PATH=\\"%esyStorePath%/i/%depofdevdepid%/bin:$PATH\\"
 
 #
 # devDep@path:devDep@d41d8cd9

--- a/test-e2e/esy-build/__snapshots__/with-dev-dep.test.js.snap
+++ b/test-e2e/esy-build/__snapshots__/with-dev-dep.test.js.snap
@@ -4,7 +4,7 @@ exports[`Project with "devDependencies" macos || linux: build-env dep snapshot 1
 "# Build environment
 # package:            dep@path:dep
 # depspec:            dependencies(self)
-# plan:               root=buildDev link=build all=build
+# mode:               buildDev
 # envspec:            
 # buildIsInProgress:  true
 # includeBuildEnv:    true
@@ -41,7 +41,7 @@ exports[`Project with "devDependencies" macos || linux: build-env devDep snapsho
 "# Build environment
 # package:            devDep@path:devDep
 # depspec:            dependencies(self)
-# plan:               root=buildDev link=build all=build
+# mode:               buildDev
 # envspec:            
 # buildIsInProgress:  true
 # includeBuildEnv:    true
@@ -88,9 +88,9 @@ export PATH=\\"$PATH:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\""
 
 exports[`Project with "devDependencies" macos || linux: build-env snapshot 1`] = `
 "# Build environment
-# package:            withDevDep@link:./package.json
-# depspec:            dependencies(self)
-# plan:               root=buildDev link=build all=build
+# package:            withDevDep@link-dev:./package.json
+# depspec:            dependencies(self)+devDependencies(self)
+# mode:               buildDev
 # envspec:            
 # buildIsInProgress:  true
 # includeBuildEnv:    true
@@ -114,9 +114,25 @@ export cur__install=\\"%projectPath%/_esy/default/store/i/%id%\\"
 export cur__target_dir=\\"%projectPath%/_esy/default/store/b/%id%\\"
 export cur__original_root=\\"%projectPath%\\"
 export cur__root=\\"%projectPath%\\"
-export cur__dev=\\"false\\"
+export cur__dev=\\"true\\"
 export cur__version=\\"1.0.0\\"
 export cur__name=\\"withDevDep\\"
+
+#
+# depOfDevDep@path:depOfDevDep@d41d8cd9
+#
+export CAML_LD_LIBRARY_PATH=\\"%esyStorePath%/i/depofdevdep-cb1178c2/stublibs:%esyStorePath%/i/depofdevdep-cb1178c2/lib/stublibs:$CAML_LD_LIBRARY_PATH\\"
+export OCAMLPATH=\\"%esyStorePath%/i/depofdevdep-cb1178c2/lib:$OCAMLPATH\\"
+export MAN_PATH=\\"%esyStorePath%/i/depofdevdep-cb1178c2/man:$MAN_PATH\\"
+export PATH=\\"%esyStorePath%/i/depofdevdep-cb1178c2/bin:$PATH\\"
+
+#
+# devDep@path:devDep@d41d8cd9
+#
+export CAML_LD_LIBRARY_PATH=\\"%esyStorePath%/i/%devdepid%/stublibs:%esyStorePath%/i/%devdepid%/lib/stublibs:$CAML_LD_LIBRARY_PATH\\"
+export OCAMLPATH=\\"%esyStorePath%/i/%devdepid%/lib:$OCAMLPATH\\"
+export MAN_PATH=\\"%esyStorePath%/i/%devdepid%/man:$MAN_PATH\\"
+export PATH=\\"%esyStorePath%/i/%devdepid%/bin:$PATH\\"
 
 #
 # dep@path:dep@d41d8cd9

--- a/test-e2e/esy-build/__snapshots__/with-linked-dep.test.js.snap
+++ b/test-e2e/esy-build/__snapshots__/with-linked-dep.test.js.snap
@@ -4,7 +4,7 @@ exports[`Build with a linked dep out of source build macos || linux: build-env d
 "# Build environment
 # package:            dep@link:dep
 # depspec:            dependencies(self)
-# plan:               root=buildDev link=build all=build
+# mode:               buildDev
 # envspec:            
 # buildIsInProgress:  true
 # includeBuildEnv:    true
@@ -40,9 +40,9 @@ export PATH=\\"$PATH:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\""
 
 exports[`Build with a linked dep out of source build macos || linux: build-env snapshot 1`] = `
 "# Build environment
-# package:            with-linked-dep-_build@link:./package.json
-# depspec:            dependencies(self)
-# plan:               root=buildDev link=build all=build
+# package:            with-linked-dep-_build@link-dev:./package.json
+# depspec:            dependencies(self)+devDependencies(self)
+# mode:               buildDev
 # envspec:            
 # buildIsInProgress:  true
 # includeBuildEnv:    true
@@ -66,7 +66,7 @@ export cur__install=\\"%projectPath%/_esy/default/store/i/%id%\\"
 export cur__target_dir=\\"%projectPath%/_esy/default/store/b/%id%\\"
 export cur__original_root=\\"%projectPath%\\"
 export cur__root=\\"%projectPath%\\"
-export cur__dev=\\"false\\"
+export cur__dev=\\"true\\"
 export cur__version=\\"1.0.0\\"
 export cur__name=\\"with-linked-dep-_build\\"
 

--- a/test-e2e/esy-build/circular-deps-error.test.js
+++ b/test-e2e/esy-build/circular-deps-error.test.js
@@ -56,8 +56,8 @@ describe(`'esy build' command: circular dependency error`, () => {
         error: found circular dependency on: dep@path:dep
           processing depOfDep@path:depOfDep
           processing dep@path:dep
-          processing hasCircularDeps@link:./package.json
-          creating task for hasCircularDeps@link:./package.json
+          processing hasCircularDeps@link-dev:./package.json
+          creating task for hasCircularDeps@link-dev:./package.json
         esy: exiting due to errors above
 
       `,

--- a/test-e2e/esy-build/with-dev-dep.test.js
+++ b/test-e2e/esy-build/with-dev-dep.test.js
@@ -122,7 +122,8 @@ describe(`Project with "devDependencies"`, () => {
     const p = await createTestSandbox();
     const id = JSON.parse((await p.esy('build-plan')).stdout).id;
     const depId = JSON.parse((await p.esy('build-plan dep')).stdout).id;
-    const devDepId = JSON.parse((await p.esy('build-plan devDep')).stdout).id;
+    const devdepId = JSON.parse((await p.esy('build-plan devDep')).stdout).id;
+    const depofdevdepId = JSON.parse((await p.esy('build-plan depOfDevDep')).stdout).id;
 
     const {stdout} = await p.esy('build-env --json');
     const env = JSON.parse(stdout);
@@ -144,6 +145,8 @@ describe(`Project with "devDependencies"`, () => {
       cur__bin: `${p.projectPath}/_esy/default/store/i/${id}/bin`,
       PATH: [
         `${p.esyStorePath}/i/${depId}/bin`,
+        `${p.esyStorePath}/i/${devdepId}/bin`,
+        `${p.esyStorePath}/i/${depofdevdepId}/bin`,
         ``,
         `/usr/local/bin`,
         `/usr/bin`,

--- a/test-e2e/esy-build/with-dev-dep.test.js
+++ b/test-e2e/esy-build/with-dev-dep.test.js
@@ -205,9 +205,10 @@ describe(`Project with "devDependencies"`, () => {
       const id = JSON.parse((await p.esy('build-plan')).stdout).id;
       const depid = JSON.parse((await p.esy('build-plan dep')).stdout).id;
       const devdepid = JSON.parse((await p.esy('build-plan devDep')).stdout).id;
+      const depofdevdepid = JSON.parse((await p.esy('build-plan depOfDevDep')).stdout).id;
       const {stdout} = await p.esy('build-env');
       expect(
-        p.normalizePathsForSnapshot(stdout, {id, depid, devdepid}),
+        p.normalizePathsForSnapshot(stdout, {id, depid, devdepid, depofdevdepid}),
       ).toMatchSnapshot();
     },
   );

--- a/test-e2e/esy-install/basic-esy.test.js
+++ b/test-e2e/esy-install/basic-esy.test.js
@@ -348,7 +348,7 @@ describe(`Basic tests`, () => {
     await expect(p.esy(`install`)).rejects.toThrowError(
       outdent`
         error: invalid "esy" version: ^3.0.0 must be one of: 1.0.0
-          reading package metadata from link:./package.json
+          reading package metadata from link-dev:./package.json
           loading root package metadata
         esy: exiting due to errors above
       `,
@@ -371,7 +371,7 @@ describe(`Basic tests`, () => {
     await expect(p.esy(`install`)).rejects.toThrowError(
       outdent`
         error: invalid "esy" version: =3.4.5 must be one of: 1.0.0
-          reading package metadata from link:./package.json
+          reading package metadata from link-dev:./package.json
           loading root package metadata
         esy: exiting due to errors above
       `,


### PR DESCRIPTION
This implements new dependency type `link-dev` which links a package but
also installs its `"devDependencies"` and uses them for the build.

Thus `link-dev:` is exactly the same as root package previously and in
fact we do model root package as `link-dev:.`.