### PR TITLE
Make sure we run `"build"` w/o devDeps

### DIFF
--- a/esy/BuildId.ml
+++ b/esy/BuildId.ml
@@ -123,9 +123,9 @@ module Repr = struct
       let buildCommands =
         match (mode : BuildSpec.mode), sourceType, buildDev with
         | Build, _, _
-        | BuildDev, (SourceType.ImmutableWithTransientDependencies | Immutable), _
-        | BuildDev, Transient, None -> build
-        | BuildDev, SourceType.Transient, Some commands ->
+        | (BuildDev | BuildDevForce), (SourceType.ImmutableWithTransientDependencies | Immutable), _
+        | (BuildDev | BuildDevForce), Transient, None -> build
+        | (BuildDev | BuildDevForce), SourceType.Transient, Some commands ->
           BuildManifest.EsyCommands commands
       in
       {

--- a/esy/BuildSandbox.ml
+++ b/esy/BuildSandbox.ml
@@ -308,7 +308,7 @@ let makeScope
     let pkg = Solution.getExn id sandbox.solution in
     let location = Installation.findExn id sandbox.installation in
 
-    let depspec, _commands =
+    let mode, depspec, _commands =
       BuildSpec.classify buildspec mode pkg buildManifest
     in
 
@@ -589,7 +589,7 @@ let makePlan
 
       let%bind buildCommands =
 
-        let _, commands =
+        let _, _, commands =
           BuildSpec.classify
             buildspec
             mode

--- a/esy/BuildSpec.ml
+++ b/esy/BuildSpec.ml
@@ -9,35 +9,37 @@ type t = {
 type mode =
   | Build
   | BuildDev
-
-let pp_mode fmt = function
-  | Build -> Fmt.string fmt "build"
-  | BuildDev -> Fmt.string fmt "buildDev"
+  | BuildDevForce
 
 let show_mode = function
   | Build -> "build"
   | BuildDev -> "buildDev"
+  | BuildDevForce -> "buildDevForce"
+
+let pp_mode fmt mode =
+  Fmt.string fmt (show_mode mode)
 
 let mode_to_yojson = function
   | Build -> `String "build"
   | BuildDev -> `String "buildDev"
+  | BuildDevForce -> `String "buildDevForce"
 
 let mode_of_yojson = function
   | `String "build" -> Ok Build
   | `String "buildDev" -> Ok BuildDev
   | _json -> Result.errorf {|invalid BuildSpec.mode: expected "build" or "buildDev"|}
 
-let classify spec mode pkg build =
-  match pkg.Package.source, mode with
-  | Link {kind = LinkDev; _}, BuildDev ->
+let classify spec mode pkg (build : BuildManifest.t) =
+  match pkg.Package.source, mode, build.buildDev with
+  | Link {kind = LinkDev; _}, BuildDevForce, _ ->
     let depspec = Option.orDefault ~default:spec.buildAll spec.buildDev in
-    let commands =
-      match build.BuildManifest.buildDev with
-      | None -> build.BuildManifest.build
-      | Some cmds -> BuildManifest.EsyCommands cmds
-    in
-    depspec, commands
-  | Link {kind = LinkDev; _}, Build
-  | Link {kind = LinkRegular; _}, _
-  | Install _, _ ->
-    spec.buildAll, build.build
+    BuildDev, depspec, build.build
+  | Link {kind = LinkDev; _}, BuildDev, Some buildDev ->
+    let depspec = Option.orDefault ~default:spec.buildAll spec.buildDev in
+    let commands = BuildManifest.EsyCommands buildDev in
+    BuildDev, depspec, commands
+  | Link {kind = LinkDev; _}, BuildDev, None
+  | Link {kind = LinkDev; _}, Build, _
+  | Link {kind = LinkRegular; _}, _, _
+  | Install _, _, _ ->
+    Build, spec.buildAll, build.build

--- a/esy/BuildSpec.mli
+++ b/esy/BuildSpec.mli
@@ -19,6 +19,7 @@ type t = {
 type mode =
   | Build
   | BuildDev
+  | BuildDevForce
 
 val pp_mode : mode Fmt.t
 val show_mode : mode -> string
@@ -31,4 +32,4 @@ val classify :
   -> mode
   -> EsyInstall.Package.t
   -> BuildManifest.t
-  -> DepSpec.t * BuildManifest.commands
+  -> mode * DepSpec.t * BuildManifest.commands

--- a/esy/bin/esyCommand.ml
+++ b/esy/bin/esyCommand.ml
@@ -546,7 +546,7 @@ let build ?(buildOnly=true) ?(release=false) (proj : Project.WithWorkflow.t) cmd
       configured.workflow.buildspec
       (if release
       then Build
-      else BuildDev)
+      else BuildDevForce)
       PkgArg.root
       cmd
       ()

--- a/test-e2e/esy-build-dependencies.test.js
+++ b/test-e2e/esy-build-dependencies.test.js
@@ -89,13 +89,13 @@ describe(`'esy build-dependencies' command`, () => {
     });
   });
 
-  it(`build devDependencies`, async () => {
+  it(`does not build devDependencies by default`, async () => {
     const p = await createTestSandbox();
     await p.esy('install');
     await p.esy('build-dependencies');
     const env = await getCommandEnv(p);
-    await expect(p.run('devDep.cmd', env)).resolves.toMatchObject({
-      stdout: '__devDep__' + os.EOL,
+    await expect(p.run('devDep.cmd', env)).rejects.toMatchObject({
+      message: expect.stringMatching('devDep.cmd: command not found'),
     });
   });
 

--- a/test-e2e/esy-build-env.test.js
+++ b/test-e2e/esy-build-env.test.js
@@ -89,7 +89,9 @@ describe(`'esy build-env' command`, () => {
       promiseExec('. ./build-env && devDep.cmd', {
         cwd: p.projectPath,
       }),
-    ).resolves.toEqual({stdout: '__devDep__\n', stderr: ''});
+    ).rejects.toMatchObject({
+      message: expect.stringMatching('devDep.cmd: command not found'),
+    });
   });
 
   it('generates an environment in JSON', async () => {
@@ -144,9 +146,9 @@ describe(`'esy build-env' command`, () => {
     expect(env.depOfDep__local).toBe(undefined);
     expect(env.depOfDep__global).toBe('depOfDep__global__value');
 
-    // dev deps are present in build env in dev mode
-    expect(env.devDep__local).toBe('devDep__local__value');
-    expect(env.devDep__global).toBe('devDep__global__value');
+    // dev deps are not present in build env
+    expect(env.devDep__local).toBe(undefined);
+    expect(env.devDep__global).toBe(undefined);
   });
 
   it('allows to query build env for a dep (by name)', async () => {

--- a/test-e2e/esy-build/__snapshots__/no-deps.test.js.snap
+++ b/test-e2e/esy-build/__snapshots__/no-deps.test.js.snap
@@ -3,8 +3,8 @@
 exports[`'esy build': simple executable with no deps out of source build macos || linux: build-env snapshot 1`] = `
 "# Build environment
 # package:            no-deps@link-dev:./package.json
-# depspec:            dependencies(self)+devDependencies(self)
-# mode:               buildDev
+# depspec:            dependencies(self)
+# mode:               build
 # envspec:            
 # buildIsInProgress:  true
 # includeBuildEnv:    true

--- a/test-e2e/esy-build/__snapshots__/optDependencies.test.js.snap
+++ b/test-e2e/esy-build/__snapshots__/optDependencies.test.js.snap
@@ -3,8 +3,8 @@
 exports[`Build with optDependencies builds w/ opt dependency installed snapshot build-env 1`] = `
 "# Build environment
 # package:            root@link-dev:./package.json
-# depspec:            dependencies(self)+devDependencies(self)
-# mode:               buildDev
+# depspec:            dependencies(self)
+# mode:               build
 # envspec:            
 # buildIsInProgress:  true
 # includeBuildEnv:    true
@@ -62,7 +62,7 @@ exports[`Build with optDependencies builds w/ opt dependency installed snapshot 
 "# Build environment
 # package:            dep@path:dep
 # depspec:            dependencies(self)
-# mode:               buildDev
+# mode:               build
 # envspec:            
 # buildIsInProgress:  true
 # includeBuildEnv:    true
@@ -111,8 +111,8 @@ export PATH=\\"$PATH:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\""
 exports[`Build with optDependencies builds w/o opt dependency installed snapshot build-env 1`] = `
 "# Build environment
 # package:            root@link-dev:./package.json
-# depspec:            dependencies(self)+devDependencies(self)
-# mode:               buildDev
+# depspec:            dependencies(self)
+# mode:               build
 # envspec:            
 # buildIsInProgress:  true
 # includeBuildEnv:    true
@@ -162,7 +162,7 @@ exports[`Build with optDependencies builds w/o opt dependency installed snapshot
 "# Build environment
 # package:            dep@path:dep
 # depspec:            dependencies(self)
-# mode:               buildDev
+# mode:               build
 # envspec:            
 # buildIsInProgress:  true
 # includeBuildEnv:    true

--- a/test-e2e/esy-build/__snapshots__/with-dep.test.js.snap
+++ b/test-e2e/esy-build/__snapshots__/with-dep.test.js.snap
@@ -4,7 +4,7 @@ exports[`Build with dep out of source build macos || linux: build-env dep snapsh
 "# Build environment
 # package:            dep@path:dep
 # depspec:            dependencies(self)
-# mode:               buildDev
+# mode:               build
 # envspec:            
 # buildIsInProgress:  true
 # includeBuildEnv:    true
@@ -57,8 +57,8 @@ export PATH=\\"$PATH:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\""
 exports[`Build with dep out of source build macos || linux: build-env snapshot 1`] = `
 "# Build environment
 # package:            withDep@link-dev:./package.json
-# depspec:            dependencies(self)+devDependencies(self)
-# mode:               buildDev
+# depspec:            dependencies(self)
+# mode:               build
 # envspec:            
 # buildIsInProgress:  true
 # includeBuildEnv:    true

--- a/test-e2e/esy-build/__snapshots__/with-dev-dep.test.js.snap
+++ b/test-e2e/esy-build/__snapshots__/with-dev-dep.test.js.snap
@@ -4,7 +4,7 @@ exports[`Project with "devDependencies" macos || linux: build-env dep snapshot 1
 "# Build environment
 # package:            dep@path:dep
 # depspec:            dependencies(self)
-# mode:               buildDev
+# mode:               build
 # envspec:            
 # buildIsInProgress:  true
 # includeBuildEnv:    true
@@ -41,7 +41,7 @@ exports[`Project with "devDependencies" macos || linux: build-env devDep snapsho
 "# Build environment
 # package:            devDep@path:devDep
 # depspec:            dependencies(self)
-# mode:               buildDev
+# mode:               build
 # envspec:            
 # buildIsInProgress:  true
 # includeBuildEnv:    true
@@ -89,8 +89,8 @@ export PATH=\\"$PATH:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\""
 exports[`Project with "devDependencies" macos || linux: build-env snapshot 1`] = `
 "# Build environment
 # package:            withDevDep@link-dev:./package.json
-# depspec:            dependencies(self)+devDependencies(self)
-# mode:               buildDev
+# depspec:            dependencies(self)
+# mode:               build
 # envspec:            
 # buildIsInProgress:  true
 # includeBuildEnv:    true
@@ -117,22 +117,6 @@ export cur__root=\\"%projectPath%\\"
 export cur__dev=\\"true\\"
 export cur__version=\\"1.0.0\\"
 export cur__name=\\"withDevDep\\"
-
-#
-# depOfDevDep@path:depOfDevDep@d41d8cd9
-#
-export CAML_LD_LIBRARY_PATH=\\"%esyStorePath%/i/%depofdevdepid%/stublibs:%esyStorePath%/i/%depofdevdepid%/lib/stublibs:$CAML_LD_LIBRARY_PATH\\"
-export OCAMLPATH=\\"%esyStorePath%/i/%depofdevdepid%/lib:$OCAMLPATH\\"
-export MAN_PATH=\\"%esyStorePath%/i/%depofdevdepid%/man:$MAN_PATH\\"
-export PATH=\\"%esyStorePath%/i/%depofdevdepid%/bin:$PATH\\"
-
-#
-# devDep@path:devDep@d41d8cd9
-#
-export CAML_LD_LIBRARY_PATH=\\"%esyStorePath%/i/%devdepid%/stublibs:%esyStorePath%/i/%devdepid%/lib/stublibs:$CAML_LD_LIBRARY_PATH\\"
-export OCAMLPATH=\\"%esyStorePath%/i/%devdepid%/lib:$OCAMLPATH\\"
-export MAN_PATH=\\"%esyStorePath%/i/%devdepid%/man:$MAN_PATH\\"
-export PATH=\\"%esyStorePath%/i/%devdepid%/bin:$PATH\\"
 
 #
 # dep@path:dep@d41d8cd9

--- a/test-e2e/esy-build/__snapshots__/with-linked-dep.test.js.snap
+++ b/test-e2e/esy-build/__snapshots__/with-linked-dep.test.js.snap
@@ -4,7 +4,7 @@ exports[`Build with a linked dep out of source build macos || linux: build-env d
 "# Build environment
 # package:            dep@link:dep
 # depspec:            dependencies(self)
-# mode:               buildDev
+# mode:               build
 # envspec:            
 # buildIsInProgress:  true
 # includeBuildEnv:    true
@@ -41,8 +41,8 @@ export PATH=\\"$PATH:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\\""
 exports[`Build with a linked dep out of source build macos || linux: build-env snapshot 1`] = `
 "# Build environment
 # package:            with-linked-dep-_build@link-dev:./package.json
-# depspec:            dependencies(self)+devDependencies(self)
-# mode:               buildDev
+# depspec:            dependencies(self)
+# mode:               build
 # envspec:            
 # buildIsInProgress:  true
 # includeBuildEnv:    true

--- a/test-e2e/esy-build/with-dev-dep.test.js
+++ b/test-e2e/esy-build/with-dev-dep.test.js
@@ -145,8 +145,6 @@ describe(`Project with "devDependencies"`, () => {
       cur__bin: `${p.projectPath}/_esy/default/store/i/${id}/bin`,
       PATH: [
         `${p.esyStorePath}/i/${depId}/bin`,
-        `${p.esyStorePath}/i/${devdepId}/bin`,
-        `${p.esyStorePath}/i/${depofdevdepId}/bin`,
         ``,
         `/usr/local/bin`,
         `/usr/bin`,


### PR DESCRIPTION
There's a clear distinction between `"build"` and `"buildDev"`:

- `"buildDev"` always have access to `"devDependencies"`
- `"build"` doesn't