### PR TITLE
Cleanup CLI

### DIFF
--- a/esy/bin/Project.ml
+++ b/esy/bin/Project.ml
@@ -290,6 +290,21 @@ module WithWorkflow = struct
 
   type t = configured fetched solved project
 
+  let plan mode proj =
+    let open RunAsync.Syntax in
+    match mode with
+    | BuildSpec.Build ->
+      let%bind fetched = fetched proj in
+      Lwt.return (
+        BuildSandbox.makePlan
+          Workflow.default.buildspec
+          Build
+          fetched.sandbox
+      )
+    | BuildSpec.BuildDev | BuildDevForce ->
+      let%bind configured = configured proj in
+      return configured.planForDev
+
   let makeConfigured projcfg solution _installation sandbox _files =
     let open RunAsync.Syntax in
     let workflow = Workflow.default in

--- a/esy/bin/Project.ml
+++ b/esy/bin/Project.ml
@@ -175,14 +175,14 @@ let makeProject makeSolved projcfg =
   let%lwt solved = makeSolved projcfg files in
   return ({projcfg; solved;}, !files)
 
-let makeSolved solvespec makeFetched (projcfg : ProjectConfig.t) files =
+let makeSolved makeFetched (projcfg : ProjectConfig.t) files =
   let open RunAsync.Syntax in
   let path = SandboxSpec.solutionLockPath projcfg.spec in
   let%bind info = FileInfo.ofPath Path.(path / "index.json") in
   files := info::!files;
   let%bind digest =
     EsySolve.Sandbox.digest
-      solvespec
+      Workflow.default.solvespec
       projcfg.solveSandbox
   in
   match%bind SolutionLock.ofPath ~digest projcfg.installSandbox path with
@@ -256,46 +256,18 @@ let makeFetched makeConfigured (projcfg : ProjectConfig.t) solution files =
       return {installation; sandbox; configured;}
     else errorf "project requires to update its installation, run `esy install`"
 
-type projectWithoutSolution = unit project
-type projectWithoutWorkflow = unit fetched solved project
-
-module WithoutSolution = struct
-
-  type t = projectWithoutSolution
-
-  let makeSolved _projcfg _files =
-    RunAsync.return ()
-
-  let make projcfg =
-    makeProject makeSolved projcfg
-
-  include MakeProject(struct
-    type nonrec t = t
-    let make = make
-    let setProjecyConfig projcfg proj = {proj with projcfg;}
-    let cachePath = makeCachePath "WithoutWorkflow"
-    let writeAuxCache _ = RunAsync.return ()
-  end)
-
-end
-
 module WithoutWorkflow = struct
 
-  type t = projectWithoutWorkflow
+  type t = unit fetched solved project
 
   let makeConfigured _copts _solution _installation _sandbox _files =
     RunAsync.return ()
 
-  let configureSolution solvespec =
-    makeSolved solvespec (makeFetched makeConfigured)
+  let configureSolution =
+    makeSolved (makeFetched makeConfigured)
 
   let make projcfg =
-    makeProject (configureSolution Workflow.default.solvespec) projcfg
-
-  let ofProjectWithoutSolution solvespec proj =
-    let files = ref [] in
-    let%lwt solved = configureSolution solvespec proj.projcfg files in
-    RunAsync.return {projcfg = proj.projcfg; solved;}
+    makeProject configureSolution projcfg
 
   include MakeProject(struct
     type nonrec t = t
@@ -349,7 +321,7 @@ module WithWorkflow = struct
     }
 
   let make projcfg =
-    makeProject (makeSolved Workflow.default.solvespec (makeFetched makeConfigured)) projcfg
+    makeProject (makeSolved (makeFetched makeConfigured)) projcfg
 
   let writeAuxCache proj =
     let open RunAsync.Syntax in

--- a/esy/bin/Project.mli
+++ b/esy/bin/Project.mli
@@ -60,6 +60,8 @@ module WithWorkflow : sig
 
   val make : ProjectConfig.t -> (t * FileInfo.t list) Run.t Lwt.t
 
+  val plan : BuildSpec.mode -> t -> BuildSandbox.Plan.t RunAsync.t
+
   val ocaml : t -> Fpath.t RunAsync.t
   (** Built and installed ocaml package resolved in a project env. *)
 

--- a/esy/bin/Project.mli
+++ b/esy/bin/Project.mli
@@ -27,12 +27,6 @@ val solved : 'a project -> 'a RunAsync.t
 val fetched : 'a solved project -> 'a RunAsync.t
 val configured : 'a fetched solved project -> 'a RunAsync.t
 
-module WithoutSolution : sig
-  type t = unit project
-  val make : ProjectConfig.t -> (t * FileInfo.t list) Run.t Lwt.t
-  val term : Fpath.t option -> t Cmdliner.Term.t
-end
-
 (**
  * Project without configured workflow.
  *
@@ -43,11 +37,6 @@ module WithoutWorkflow : sig
   type t = unit fetched solved project
 
   val make : ProjectConfig.t -> (t * FileInfo.t list) Run.t Lwt.t
-
-  val ofProjectWithoutSolution :
-    EsySolve.SolveSpec.t
-    -> unit project
-    -> unit fetched solved project Run.t Lwt.t
 
   val term : Fpath.t option -> t Cmdliner.Term.t
   val promiseTerm : Fpath.t option -> t RunAsync.t Cmdliner.Term.t


### PR DESCRIPTION
- Add missing `--release` option for relevant commands:
  - `esy build-plan`
  - `esy build-env`
  - ...
- Remove `solvespec` options (we are going to keep them non configurable for now.