### PR TITLE
Add `esy build-exec` command

### DIFF
--- a/esy/bin/Project.mli
+++ b/esy/bin/Project.mli
@@ -104,9 +104,8 @@ val execCommand :
   -> EnvSpec.t
   -> BuildSpec.t
   -> BuildSpec.mode
-  -> PkgArg.t
+  -> Package.t
   -> Cmd.t
-  -> unit
   -> unit RunAsync.t
 
 val printEnv :


### PR DESCRIPTION
This allows to run a build command in a context of a specified package.
Thus this is the same as `esy b CMD` but not for the root only:

```
% esy build-exec ./src/rely/package.json echo '#{self.name}'
```