### PR TITLE
Fix opam file copying to account for subdirectories

### DIFF
--- a/esy-package-config/File.ml
+++ b/esy-package-config/File.ml
@@ -1,26 +1,41 @@
 type t = {
   root : Path.t;
-  name : string;
+  name : Path.t;
 }
 
 let pp fmt file =
-  Fmt.pf fmt "%a/%s" Path.pp file.root file.name
+  Fmt.pf fmt "%a/%a" Path.pp file.root Path.pp file.name
 
 let digest file =
-  let path = Path.(file.root / file.name) in
+  let path = Path.(file.root // file.name) in
   Digestv.ofFile path
 
-let ofDir root =
-  let open RunAsync.Syntax in
-  if%bind Fs.exists root
-  then
-    let%bind files = Fs.listDir root in
-    let f name = return {name; root;} in
-    RunAsync.List.mapAndJoin ~concurrency:20 ~f files
-  else
-    return []
+let ofDir base =
+  let rec loop sub =
+    let open RunAsync.Syntax in
+    let root = Path.(base // sub) in
+    if%bind Fs.exists root
+    then
+      let%bind files = Fs.listDir root in
+      let f name =
+        if%bind Fs.isDir Path.(root / name)
+        then
+          loop Path.(sub / name)
+        else
+          return [{name=Path.(sub / name); root=base;}]
+      in
+      let%bind lists = RunAsync.List.mapAndJoin ~concurrency:20 ~f files in
+      return (List.concat lists)
+    else
+      return []
+  in
+  loop (Path.v ".")
 
 let placeAt path file =
-  Fs.copyFile
-    ~src:Path.(file.root // v file.name)
-    ~dst:Path.(path // v file.name)
+  let open RunAsync.Syntax in
+  let src = Path.(file.root // file.name) in
+  let dst = Path.(path // file.name) in
+  let () = Logs.debug(fun m -> m "Copying file from %s to %s" (Path.showPretty src) (Path.showPretty dst)) in
+  let%bind () = Fs.createDir (Path.parent dst) in
+  Fs.copyFile ~src ~dst
+  


### PR DESCRIPTION
While working on getting opam-cross-windows going, I discovered that if
an opam package's `files` folder has subfolers, esy will crash, trying
to read a directory as a file when generating the digest hash.

This fixes `File.ml` to read a directory recursively, and then properly
copy those files over (with placeAt) into the respective subdirectories
at the destination.