### PR TITLE
Package-specific `esy CMD` invocations

### DIFF
--- a/test-e2e/esy-CMD.test.js
+++ b/test-e2e/esy-CMD.test.js
@@ -123,6 +123,15 @@ describe(`'esy CMD' invocation`, () => {
     );
   });
 
+  test(`execute commands in a specified dependency's environment`, async () => {
+    const p = await createTestSandbox();
+    await p.esy('install');
+    await expect(p.esy('-p dep bash -c "echo #{self.name}"')).resolves.toEqual({
+      stdout: 'dep\n',
+      stderr: '',
+    });
+  });
+
   test(`can be invoked from project's subdirectories`, async () => {
     const p = await createTestSandbox();
     await p.esy('install');

--- a/test-e2e/esy-CMD.test.js
+++ b/test-e2e/esy-CMD.test.js
@@ -123,12 +123,22 @@ describe(`'esy CMD' invocation`, () => {
     );
   });
 
-  test(`execute commands in a specified dependency's environment`, async () => {
+  test(`-p: execute commands in a specified package's environment`, async () => {
     const p = await createTestSandbox();
     await p.esy('install');
-    await expect(p.esy('-p dep bash -c "echo #{self.name}"')).resolves.toEqual({
+    await expect(p.esy('-p dep echo "#{self.name}"')).resolves.toEqual({
       stdout: 'dep\n',
       stderr: '',
+    });
+  });
+
+  test(`-p: requires a command`, async () => {
+    const p = await createTestSandbox();
+    await p.esy('install');
+    await expect(p.esy('-p dep')).rejects.toMatchObject({
+      message: expect.stringMatching(
+				"esy: missing a command to execute \\(required when '-p <name>' is passed\\)"
+			)
     });
   });
 


### PR DESCRIPTION
This PR adds a new `-p package_name` option for `esy CMD` invocations allowing, for instance, to run arbitrary commands specifically in a linked package environment.

It could be especially useful in monorepo setups where one could setup bunch of script commands that need to run in an isolated environment.