### PR TITLE
Set process CWD for `esy CMD` invocations

### DIFF
--- a/bin/Project.re
+++ b/bin/Project.re
@@ -746,6 +746,7 @@ let execCommand =
     (
       ~checkIfDependenciesAreBuilt,
       ~buildLinked,
+      ~chdirToRoot=false,
       proj: project,
       envspec,
       mode,
@@ -780,6 +781,7 @@ let execCommand =
 
   let%bind status =
     BuildSandbox.exec(
+      ~chdirToRoot,
       envspec,
       Workflow.default.buildspec,
       mode,

--- a/bin/Project.re
+++ b/bin/Project.re
@@ -746,7 +746,7 @@ let execCommand =
     (
       ~checkIfDependenciesAreBuilt,
       ~buildLinked,
-      ~chdirToRoot=false,
+      ~changeDirectoryToPackageRoot=false,
       proj: project,
       envspec,
       mode,
@@ -781,7 +781,7 @@ let execCommand =
 
   let%bind status =
     BuildSandbox.exec(
-      ~chdirToRoot,
+      ~changeDirectoryToPackageRoot,
       envspec,
       Workflow.default.buildspec,
       mode,

--- a/bin/Project.rei
+++ b/bin/Project.rei
@@ -80,6 +80,7 @@ let execCommand:
   (
     ~checkIfDependenciesAreBuilt: bool,
     ~buildLinked: bool,
+    ~chdirToRoot: bool=?,
     project,
     EnvSpec.t,
     BuildSpec.mode,

--- a/bin/Project.rei
+++ b/bin/Project.rei
@@ -80,7 +80,7 @@ let execCommand:
   (
     ~checkIfDependenciesAreBuilt: bool,
     ~buildLinked: bool,
-    ~chdirToRoot: bool=?,
+    ~changeDirectoryToPackageRoot: bool=?,
     project,
     EnvSpec.t,
     BuildSpec.mode,

--- a/bin/esy.re
+++ b/bin/esy.re
@@ -259,7 +259,7 @@ let execCommand =
     Project.execCommand(
       ~checkIfDependenciesAreBuilt=false,
       ~buildLinked=false,
-      ~chdirToRoot=chdir,
+      ~changeDirectoryToPackageRoot=chdir,
       proj,
       envspec,
       plan,
@@ -554,7 +554,7 @@ let exec = (mode, chdir, pkgarg, cmd, proj: Project.t) => {
     Project.execCommand(
       ~checkIfDependenciesAreBuilt=false, /* not needed as we build an entire sandbox above */
       ~buildLinked=false,
-      ~chdirToRoot=chdir,
+      ~changeDirectoryToPackageRoot=chdir,
       proj,
       proj.workflow.execenvspec,
       mode,
@@ -663,7 +663,7 @@ let devExec = (chdir: bool, pkgarg: PkgArg.t, proj: Project.t, cmd, ()) => {
     Project.execCommand(
       ~checkIfDependenciesAreBuilt=true,
       ~buildLinked=false,
-      ~chdirToRoot=chdir,
+      ~changeDirectoryToPackageRoot=chdir,
       proj,
       proj.workflow.commandenvspec,
       BuildDev,

--- a/esy-build/BuildSandbox.re
+++ b/esy-build/BuildSandbox.re
@@ -919,7 +919,16 @@ let env = (~forceImmutable=?, envspec, buildspec, mode, sandbox, id) => {
   env;
 };
 
-let exec = (~chdirToRoot=false, envspec, buildspec, mode, sandbox, id, cmd) => {
+let exec =
+    (
+      ~changeDirectoryToPackageRoot=false,
+      envspec,
+      buildspec,
+      mode,
+      sandbox,
+      id,
+      cmd,
+    ) => {
   open RunAsync.Syntax;
   let%bind (env, scope) =
     RunAsync.ofRun(
@@ -967,7 +976,7 @@ let exec = (~chdirToRoot=false, envspec, buildspec, mode, sandbox, id, cmd) => {
     };
 
     let cwd =
-      chdirToRoot ?
+      changeDirectoryToPackageRoot ?
         Some(
           Scope.(
             rootPath(scope)

--- a/esy-build/BuildSandbox.re
+++ b/esy-build/BuildSandbox.re
@@ -919,7 +919,7 @@ let env = (~forceImmutable=?, envspec, buildspec, mode, sandbox, id) => {
   env;
 };
 
-let exec = (envspec, buildspec, mode, sandbox, id, cmd) => {
+let exec = (~chdirToRoot=false, envspec, buildspec, mode, sandbox, id, cmd) => {
   open RunAsync.Syntax;
   let%bind (env, scope) =
     RunAsync.ofRun(
@@ -966,12 +966,25 @@ let exec = (envspec, buildspec, mode, sandbox, id, cmd) => {
       return(status);
     };
 
+    let cwd =
+      chdirToRoot ?
+        Some(
+          Scope.(
+            rootPath(scope)
+            |> SandboxPath.toValue
+            |> SandboxValue.render(sandbox.cfg)
+          ),
+        ) :
+        None;
+
     let env = Scope.SandboxEnvironment.render(sandbox.cfg, env);
+
     /* TODO: make sure we resolve 'esy' to the current executable, needed nested
      * invokations */
     ChildProcess.withProcess(
       ~env=CustomEnv(env),
       ~resolveProgramInEnv=true,
+      ~cwd?,
       ~stderr=`FD_copy(Unix.stderr),
       ~stdout=`FD_copy(Unix.stdout),
       ~stdin=`FD_copy(Unix.stdin),

--- a/esy-build/BuildSandbox.rei
+++ b/esy-build/BuildSandbox.rei
@@ -41,7 +41,7 @@ let env:
 
 let exec:
   (
-    ~chdirToRoot: bool=?,
+    ~changeDirectoryToPackageRoot: bool=?,
     EnvSpec.t,
     BuildSpec.t,
     BuildSpec.mode,

--- a/esy-build/BuildSandbox.rei
+++ b/esy-build/BuildSandbox.rei
@@ -40,7 +40,15 @@ let env:
   Run.t(Scope.SandboxEnvironment.Bindings.t);
 
 let exec:
-  (EnvSpec.t, BuildSpec.t, BuildSpec.mode, t, PackageId.t, Cmd.t) =>
+  (
+    ~chdirToRoot: bool=?,
+    EnvSpec.t,
+    BuildSpec.t,
+    BuildSpec.mode,
+    t,
+    PackageId.t,
+    Cmd.t
+  ) =>
   RunAsync.t(Unix.process_status);
 
 module Task: {

--- a/esy-lib/ChildProcess.rei
+++ b/esy-lib/ChildProcess.rei
@@ -53,6 +53,7 @@ let withProcess:
   (
     ~env: env=?,
     ~resolveProgramInEnv: bool=?,
+    ~cwd: string=?,
     ~stdin: Lwt_process.redirection=?,
     ~stdout: Lwt_process.redirection=?,
     ~stderr: Lwt_process.redirection=?,

--- a/test-e2e/esy-CMD.test.js
+++ b/test-e2e/esy-CMD.test.js
@@ -142,13 +142,16 @@ describe(`'esy CMD' invocation`, () => {
     });
   });
 
-  test(`-p: -C flag sets CWD to a specified dependency's root`, async () => {
+  it(`-p: -C flag sets CWD to a specified dependency's root`, async () => {
     const p = await createTestSandbox();
+
+    await fs.mkdir(path.join(p.projectPath, 'dep', 'subdir'));
+    await fs.writeFile(path.join(p.projectPath, 'dep', 'subdir', 'X'), '');
+
     await p.esy('install');
-    const cwd = path.join(p.rootPath, 'dep');
-    await expect(p.esy(`-C -p dep bash -c 'diff <(pwd) <(echo "#{self.root}")'`)).resolves.toEqual({
-      stdout: '',
-      stderr: '',
+
+    await expect(p.esy('-C -p dep ls -1 ./subdir')).resolves.toMatchObject({
+      stdout: 'X' + os.EOL,
     });
   });
 

--- a/test-e2e/esy-CMD.test.js
+++ b/test-e2e/esy-CMD.test.js
@@ -142,6 +142,16 @@ describe(`'esy CMD' invocation`, () => {
     });
   });
 
+  test(`-p: -C flag sets CWD to a specified dependency's root`, async () => {
+    const p = await createTestSandbox();
+    await p.esy('install');
+    const cwd = path.join(p.rootPath, 'dep');
+    await expect(p.esy(`-C -p dep bash -c 'diff <(pwd) <(echo "#{self.root}")'`)).resolves.toEqual({
+      stdout: '',
+      stderr: '',
+    });
+  });
+
   test(`can be invoked from project's subdirectories`, async () => {
     const p = await createTestSandbox();
     await p.esy('install');

--- a/test-e2e/esy-x-CMD.test.js
+++ b/test-e2e/esy-x-CMD.test.js
@@ -239,6 +239,22 @@ describe(`'esy x CMD' invocation`, () => {
     });
   });
 
+  it(`-C flag sets CWD to the root`, async () => {
+    const p = await createTestSandbox();
+    await p.esy('install');
+    await p.esy('build');
+
+    await fs.mkdir(path.join(p.projectPath, 'subdir'));
+
+    await fs.mkdir(path.join(p.projectPath, 'subdir2'));
+    await fs.writeFile(path.join(p.projectPath, 'subdir2', 'X'), '');
+
+    p.cd('./subdir');
+    await expect(p.esy('x -C ls -1 ./subdir2')).resolves.toMatchObject({
+      stdout: 'X' + os.EOL,
+    });
+  });
+
   it('can be passed -p/--package PKG to run a command in specified package scope', async () => {
     const p = await createTestSandbox();
     await p.esy('install');


### PR DESCRIPTION
This PR sets CWD to the package root when commands are invoked with `-C` flag. According to docs, CHROOT is not available on Windows, so I've followed suggestions from https://github.com/ocsigen/lwt/issues/163 and simply set CHDIR in an lwt mutex before shelling out.

This behaviour is consistent for command and exec environments. I.e:

```
esy -C -p pkg cmd
esy exec-command -C cmd
esy x -C cmd
```

From my point of view, setting CWD to package root is crucial in monorepo cases because it allows me to narrow the scope. I'd even like to add support for package-specific scripts (probably, only for `link-dev`).

For example, let's assume we have a monorepo with sub-packages that each has their own tests. Here's what I'd want to have in my root config:

```
  "scripts": {
    "build:core": "esy build-package -p core",
    "build:mac": "esy build-package -p mac",
    "test:core": "esy -C -p core dune runtest",
    "test:mac": "esy -C -p mac dune runtest"
  },
```