### PR TITLE
Add missing -p/--package argument to subcommands

### DIFF
--- a/esy/bin/esyCommand.ml
+++ b/esy/bin/esyCommand.ml
@@ -541,7 +541,7 @@ let build ?(buildOnly=true) mode pkgarg cmd (proj : Project.WithWorkflow.t) =
   in
   Project.withPackage proj pkgarg f
 
-let buildEnv mode asJson pkgarg (proj : Project.WithWorkflow.t) =
+let buildEnv asJson mode pkgarg (proj : Project.WithWorkflow.t) =
   let open RunAsync.Syntax in
   let%bind configured = Project.configured proj in
   Project.printEnv
@@ -1637,8 +1637,8 @@ let makeCommands projectPath =
       ~docs:introspectionSection
       Term.(
         const buildEnv
-        $ modeTerm
         $ Arg.(value & flag & info ["json"]  ~doc:"Format output as JSON")
+        $ modeTerm
         $ pkgTerm
       );
 

--- a/esy/bin/esyCommand.ml
+++ b/esy/bin/esyCommand.ml
@@ -541,7 +541,7 @@ let build ?(buildOnly=true) mode pkgarg cmd (proj : Project.WithWorkflow.t) =
   in
   Project.withPackage proj pkgarg f
 
-let buildEnv mode asJson packagePath (proj : Project.WithWorkflow.t) =
+let buildEnv mode asJson pkgarg (proj : Project.WithWorkflow.t) =
   let open RunAsync.Syntax in
   let%bind configured = Project.configured proj in
   Project.printEnv
@@ -551,10 +551,10 @@ let buildEnv mode asJson packagePath (proj : Project.WithWorkflow.t) =
     configured.Project.WithWorkflow.workflow.buildspec
     mode
     asJson
-    packagePath
+    pkgarg
     ()
 
-let commandEnv asJson packagePath (proj : Project.WithWorkflow.t) =
+let commandEnv asJson pkgarg (proj : Project.WithWorkflow.t) =
   let open RunAsync.Syntax in
   let%bind configured = Project.configured proj in
   Project.printEnv
@@ -564,10 +564,10 @@ let commandEnv asJson packagePath (proj : Project.WithWorkflow.t) =
     configured.Project.WithWorkflow.workflow.buildspec
     BuildDev
     asJson
-    packagePath
+    pkgarg
     ()
 
-let execEnv asJson packagePath (proj : Project.WithWorkflow.t) =
+let execEnv asJson pkgarg (proj : Project.WithWorkflow.t) =
   let open RunAsync.Syntax in
   let%bind configured = Project.configured proj in
   Project.printEnv
@@ -577,7 +577,7 @@ let execEnv asJson packagePath (proj : Project.WithWorkflow.t) =
     configured.Project.WithWorkflow.workflow.buildspec
     BuildDev
     asJson
-    packagePath
+    pkgarg
     ()
 
 let exec mode cmd (proj : Project.WithWorkflow.t) =

--- a/test-e2e/esy-x-CMD.test.js
+++ b/test-e2e/esy-x-CMD.test.js
@@ -238,4 +238,31 @@ describe(`'esy x CMD' invocation`, () => {
       stdout: 'X' + os.EOL,
     });
   });
+
+  it('can be passed -p/--package PKG to run a command in specified package scope', async () => {
+    const p = await createTestSandbox();
+    await p.esy('install');
+    await p.esy('build');
+
+    await expect(p.esy('x -p linkedDep linkedDep.cmd')).resolves.toEqual({
+      stdout: '__linkedDep__' + os.EOL,
+      stderr: '',
+    });
+
+    await expect(p.esy('x -p linkedDep echo "#{self.name}"')).resolves.toEqual({
+      stdout: 'linkedDep' + os.EOL,
+      stderr: '',
+    });
+
+    await expect(p.esy('x --package linkedDep linkedDep.cmd')).resolves.toEqual({
+      stdout: '__linkedDep__' + os.EOL,
+      stderr: '',
+    });
+
+    await expect(p.esy('x --package linkedDep echo "#{self.name}"')).resolves.toEqual({
+      stdout: 'linkedDep' + os.EOL,
+      stderr: '',
+    });
+  });
+
 });


### PR DESCRIPTION
- `esy ls-builds/ls-modules/ls-libs -p/--package`
- `esy x -p/--package CMD`
- `esy shell -p/--package`

Also more consistent naming in `esyCommand.ml`.