### PR TITLE
Remove configuring depspecs for builds in CLI

### DIFF
--- a/docs/low-level-commands.md
+++ b/docs/low-level-commands.md
@@ -67,32 +67,6 @@ Options:
   in their corresponding `package.json` manifests, passing `--release` makes
   build process use `"esy.build"` commands instead.
 
-### `esy build-package`
-
-`esy-build-package` command builds a specified package in a given build
-environment:
-
-```bash
-esy build-package [OPTION]... [PACKAGE]
-```
-
-Arguments:
-
-- `PACKAGE` (optional, default: `root`) Package to run the build for.
-
-Options:
-
-- `--link-depspec=DEPSPEC` Define DEPSPEC expression for linked packages'
-  build environments. This is only applicable if the currently selected package
-  is a linked package (including the project root package).
-
-- `--release` Force to use "esy.build" commands (by default "esy.buildDev"
-  commands are used)
-
-  By default linked packages are built using `"esy.buildDev"` commands defined
-  in their corresponding `package.json` manifests, passing `--release` makes
-  build process use `"esy.build"` commands instead.
-
 ### `esy command-exec`
 
 `esy-exec-command` command executes a command in a given environment:

--- a/docs/low-level-commands.md
+++ b/docs/low-level-commands.md
@@ -57,9 +57,6 @@ Options:
 
 - `--all` Build all dependencies (including linked packages)
 
-- `--link-depspec=DEPSPEC` Define DEPSPEC expression for linked packages'
-  build environments.
-
 - `--release` Force to use "esy.build" commands (by default "esy.buildDev"
   commands are used)
 
@@ -96,10 +93,6 @@ Options:
 
 - `--include-npm-bin` Include npm bin in `$PATH`.
 
-- `--link-depspec=DEPSPEC` Define DEPSPEC expression for linked packages'
-  build environments. This is only applicable if the currently selected package
-  is a linked package (including the project root package).
-
 ### `esy print-env`
 
 `esy-print-env` command prints a configured environment on stdout:
@@ -123,18 +116,13 @@ Options:
 
 - `--include-npm-bin` Include npm bin in `$PATH`.
 
-- `--link-depspec=DEPSPEC` Define DEPSPEC expression for linked packages'
-  build environments. This is only applicable if the currently selected package
-  is a linked package (including the project root package).
-
 - `--json` Format output as JSON
 
 ## DEPSPEC
 
-Some commands allow to define how a build or a command environment is constructed
-for each package based on other packages in a dependency graph (see `--envspec`
-and `--link-depspec` command options described above). This is done via
-DEPSPEC expressions.
+Some commands allow to define how an environment is constructed for each package
+based on other packages in a dependency graph (see `--envspec` command option
+described above). This is done via DEPSPEC expressions.
 
 There are the following constructs available in DEPSPEC:
 

--- a/esy/bin/NpmReleaseCommand.ml
+++ b/esy/bin/NpmReleaseCommand.ml
@@ -587,7 +587,7 @@ let make
   let%lwt () = Logs_lwt.app (fun m -> m "Done!") in
   return ()
 
-let run (proj : Project.WithWorkflow.t) =
+let run (proj : Project.t) =
   let open RunAsync.Syntax in
 
   let%bind solved = Project.solved proj in
@@ -606,10 +606,10 @@ let run (proj : Project.WithWorkflow.t) =
       Project.buildDependencies
         ~buildLinked:true
         proj
-        configured.Project.WithWorkflow.planForDev
-        configured.Project.WithWorkflow.root.pkg
+        configured.Project.planForDev
+        configured.Project.root.pkg
     in
-    let%bind p = Project.WithWorkflow.ocaml proj in
+    let%bind p = Project.ocaml proj in
     return Path.(p / "bin" / "ocamlopt")
   in
 

--- a/esy/bin/NpmReleaseCommand.mli
+++ b/esy/bin/NpmReleaseCommand.mli
@@ -1,1 +1,1 @@
-val run : Project.WithWorkflow.t -> unit RunAsync.t
+val run : Project.t -> unit RunAsync.t

--- a/esy/bin/Project.ml
+++ b/esy/bin/Project.ml
@@ -255,29 +255,6 @@ let makeFetched makeConfigured (projcfg : ProjectConfig.t) solution files =
       return {installation; sandbox; configured;}
     else errorf "project requires to update its installation, run `esy install`"
 
-module WithoutWorkflow = struct
-
-  type t = unit fetched solved project
-
-  let makeConfigured _copts _solution _installation _sandbox _files =
-    RunAsync.return ()
-
-  let configureSolution =
-    makeSolved (makeFetched makeConfigured)
-
-  let make projcfg =
-    makeProject configureSolution projcfg
-
-  include MakeProject(struct
-    type nonrec t = t
-    let make = make
-    let setProjecyConfig projcfg proj = {proj with projcfg;}
-    let cachePath = makeCachePath "WithoutWorkflow"
-    let writeAuxCache _ = RunAsync.return ()
-  end)
-
-end
-
 module WithWorkflow = struct
 
   type configured = {

--- a/esy/bin/Project.ml
+++ b/esy/bin/Project.ml
@@ -56,9 +56,6 @@ module TermPp = struct
       (ppFlag "--include-npm-bin") includeNpmBin
       (ppFlag "--include-esy-introspection-env") includeEsyIntrospectionEnv
       (ppFlag "--include-build-env") includeBuildEnv
-
-  let ppBuildSpec fmt buildspec =
-    Fmt.pf fmt "%a" (ppOption "--dev-depspec" Solution.DepSpec.pp) (Some buildspec.BuildSpec.dev)
 end
 
 let makeCachePath prefix (projcfg : ProjectConfig.t) =
@@ -420,9 +417,8 @@ let buildDependencies
   let%bind solved = solved proj in
   let () =
     Logs.info (fun m ->
-      m "running:@[<v>@;%s build-dependencies \\@;%a%a%a@]"
+      m "running:@[<v>@;%s build-dependencies \\@;%a%a@]"
       proj.projcfg.ProjectConfig.mainprg
-      TermPp.ppBuildSpec (BuildSandbox.Plan.spec plan)
       TermPp.(ppFlag "--all") buildLinked
       PackageId.pp pkg.Package.id
     )
@@ -449,9 +445,8 @@ let buildPackage
   =
   let () =
     Logs.info (fun m ->
-      m "running:@[<v>@;%s build-package \\@;%a%a@]"
+      m "running:@[<v>@;%s build-package \\@;%a@]"
       projcfg.ProjectConfig.mainprg
-      TermPp.ppBuildSpec (BuildSandbox.Plan.spec plan)
       PackageId.pp pkg.Package.id
     )
   in
@@ -575,9 +570,8 @@ let execCommand
 
   let () =
     Logs.info (fun m ->
-      m "running:@[<v>@;%s exec-command \\@;%a%a%a \\@;-- %a@]"
+      m "running:@[<v>@;%s exec-command \\@;%a%a \\@;-- %a@]"
       proj.projcfg.ProjectConfig.mainprg
-      TermPp.ppBuildSpec buildspec
       TermPp.ppEnvSpec envspec
       PackageId.pp pkg.Package.id
       Cmd.pp cmd

--- a/esy/bin/Project.mli
+++ b/esy/bin/Project.mli
@@ -7,66 +7,57 @@
 open Esy
 open EsyInstall
 
-type 'solved project = {
+type project = {
   projcfg : ProjectConfig.t;
   scripts : Scripts.t;
-  solved : 'solved Run.t;
+  solved : solved Run.t;
 }
 
-and 'fetched solved = {
+and solved = {
   solution : Solution.t;
-  fetched : 'fetched Run.t;
+  fetched : fetched Run.t;
 }
 
-and 'configured fetched = {
+and fetched = {
   installation : Installation.t;
   sandbox : BuildSandbox.t;
-  configured : 'configured Run.t;
+  configured : configured Run.t;
 }
 
-val solved : 'a project -> 'a RunAsync.t
-val fetched : 'a solved project -> 'a RunAsync.t
-val configured : 'a fetched solved project -> 'a RunAsync.t
+and configured = {
+  workflow : Workflow.t;
+  planForDev : BuildSandbox.Plan.t;
+  root : BuildSandbox.Task.t;
+}
 
-(**
- * Project configured with a default workflow.
- *
- * Most esy commands use this kind of a project.
- *)
-module WithWorkflow : sig
+type t = project
 
-  type t = configured fetched solved project
+val solved : project -> solved RunAsync.t
+val fetched : project -> fetched RunAsync.t
+val configured : project -> configured RunAsync.t
 
-  and configured = {
-    workflow : Workflow.t;
-    planForDev : BuildSandbox.Plan.t;
-    root : BuildSandbox.Task.t;
-  }
+val make : ProjectConfig.t -> (project * FileInfo.t list) Run.t Lwt.t
 
-  val make : ProjectConfig.t -> (t * FileInfo.t list) Run.t Lwt.t
+val plan : BuildSpec.mode -> project -> BuildSandbox.Plan.t RunAsync.t
 
-  val plan : BuildSpec.mode -> t -> BuildSandbox.Plan.t RunAsync.t
+val ocaml : project -> Fpath.t RunAsync.t
+(** Built and installed ocaml package resolved in a project env. *)
 
-  val ocaml : t -> Fpath.t RunAsync.t
-  (** Built and installed ocaml package resolved in a project env. *)
+val ocamlfind : project -> Fpath.t RunAsync.t
+(** Build & installed ocamlfind package resolved in a project env. *)
 
-  val ocamlfind : t -> Fpath.t RunAsync.t
-  (** Build & installed ocamlfind package resolved in a project env. *)
-
-  val term : Fpath.t option -> t Cmdliner.Term.t
-  val promiseTerm : Fpath.t option -> t RunAsync.t Cmdliner.Term.t
-
-end
+val term : Fpath.t option -> project Cmdliner.Term.t
+val promiseTerm : Fpath.t option -> project RunAsync.t Cmdliner.Term.t
 
 val withPackage :
-  _ solved project
+  project
   -> PkgArg.t
   -> (Package.t -> 'a Run.t Lwt.t)
   -> 'a RunAsync.t
 
 val buildDependencies :
   buildLinked:bool
-  -> _ fetched solved project
+  -> project
   -> BuildSandbox.Plan.t
   -> Package.t
   -> unit RunAsync.t
@@ -83,7 +74,7 @@ val buildPackage :
 val execCommand :
   checkIfDependenciesAreBuilt:bool
   -> buildLinked:bool
-  -> _ fetched solved project
+  -> project
   -> EnvSpec.t
   -> BuildSpec.t
   -> BuildSpec.mode
@@ -93,7 +84,7 @@ val execCommand :
 
 val printEnv :
   ?name:string
-  -> _ fetched solved project
+  -> project
   -> EnvSpec.t
   -> BuildSpec.t
   -> BuildSpec.mode

--- a/esy/bin/Project.mli
+++ b/esy/bin/Project.mli
@@ -9,6 +9,7 @@ open EsyInstall
 
 type project = {
   projcfg : ProjectConfig.t;
+  workflow : Workflow.t;
   scripts : Scripts.t;
   solved : solved Run.t;
 }
@@ -25,7 +26,6 @@ and fetched = {
 }
 
 and configured = {
-  workflow : Workflow.t;
   planForDev : BuildSandbox.Plan.t;
   root : BuildSandbox.Task.t;
 }
@@ -76,7 +76,6 @@ val execCommand :
   -> buildLinked:bool
   -> project
   -> EnvSpec.t
-  -> BuildSpec.t
   -> BuildSpec.mode
   -> Package.t
   -> Cmd.t
@@ -86,7 +85,6 @@ val printEnv :
   ?name:string
   -> project
   -> EnvSpec.t
-  -> BuildSpec.t
   -> BuildSpec.mode
   -> bool
   -> PkgArg.t

--- a/esy/bin/Project.mli
+++ b/esy/bin/Project.mli
@@ -29,21 +29,6 @@ val fetched : 'a solved project -> 'a RunAsync.t
 val configured : 'a fetched solved project -> 'a RunAsync.t
 
 (**
- * Project without configured workflow.
- *
- * This kind of a project is used by low level plumbing esy commands.
- *)
-module WithoutWorkflow : sig
-
-  type t = unit fetched solved project
-
-  val make : ProjectConfig.t -> (t * FileInfo.t list) Run.t Lwt.t
-
-  val term : Fpath.t option -> t Cmdliner.Term.t
-  val promiseTerm : Fpath.t option -> t RunAsync.t Cmdliner.Term.t
-end
-
-(**
  * Project configured with a default workflow.
  *
  * Most esy commands use this kind of a project.

--- a/esy/bin/esyCommand.ml
+++ b/esy/bin/esyCommand.ml
@@ -196,7 +196,7 @@ let resolvedPathTerm =
   let print = Path.pp in
   Arg.conv ~docv:"PATH" (parse, print)
 
-let buildDependencies all mode pkgarg (proj : Project.WithoutWorkflow.t) =
+let buildDependencies all mode pkgarg (proj : Project.WithWorkflow.t) =
   let open RunAsync.Syntax in
   let%bind fetched = Project.fetched proj in
   let f (pkg : Package.t) =
@@ -225,7 +225,7 @@ let execCommand
   envspec
   pkgarg
   cmd
-  (proj : Project.WithoutWorkflow.t)
+  (proj : Project.WithWorkflow.t)
   =
   let envspec = {
     EnvSpec.
@@ -259,7 +259,7 @@ let printEnv
   plan
   envspec
   pkgarg
-  (proj : Project.WithoutWorkflow.t)
+  (proj : Project.WithWorkflow.t)
   =
   let envspec = {
     EnvSpec.
@@ -1257,7 +1257,6 @@ let makeCommands projectPath =
 
   let projectConfig = ProjectConfig.term projectPath in
   let projectWithWorkflow = Project.WithWorkflow.term projectPath in
-  let project = Project.WithoutWorkflow.term projectPath in
 
   let makeProjectWithWorkflowCommand ?(header=`Standard) ?docs ?doc ?stop_on_pos ~name cmd =
     let cmd =
@@ -1270,21 +1269,6 @@ let makeCommands projectPath =
         cmd project
       in
       Cmdliner.Term.(pure run $ cmd $ projectWithWorkflow)
-    in
-    makeCommand ~header:`No ?docs ?doc ?stop_on_pos ~name cmd
-  in
-
-  let makeProjectWithoutWorkflowCommand ?(header=`Standard) ?docs ?doc ?stop_on_pos ~name cmd =
-    let cmd =
-      let run cmd project =
-        let () =
-          match header with
-          | `Standard -> Lwt_main.run (printHeader ~spec:project.Project.projcfg.spec name)
-          | `No -> ()
-        in
-        cmd project
-      in
-      Cmdliner.Term.(pure run $ cmd $ project)
     in
     makeCommand ~header:`No ?docs ?doc ?stop_on_pos ~name cmd
   in
@@ -1597,7 +1581,7 @@ let makeCommands projectPath =
 
     (* LOW LEVEL PLUMBING COMMANDS *)
 
-    makeProjectWithoutWorkflowCommand
+    makeProjectWithWorkflowCommand
       ~name:"build-dependencies"
       ~doc:"Build dependencies for a specified package"
       ~docs:lowLevelSection
@@ -1612,7 +1596,7 @@ let makeCommands projectPath =
         $ pkgTerm
       );
 
-    makeProjectWithoutWorkflowCommand
+    makeProjectWithWorkflowCommand
       ~header:`No
       ~name:"exec-command"
       ~doc:"Execute command in a given environment"
@@ -1650,7 +1634,7 @@ let makeCommands projectPath =
             Cmdliner.Arg.pos_all
       );
 
-    makeProjectWithoutWorkflowCommand
+    makeProjectWithWorkflowCommand
       ~header:`No
       ~name:"print-env"
       ~doc:"Print a configured environment on stdout"
@@ -1678,7 +1662,7 @@ let makeCommands projectPath =
         $ pkgTerm
       );
 
-    makeProjectWithoutWorkflowCommand
+    makeProjectWithWorkflowCommand
       ~name:"solve"
       ~doc:"Solve dependencies and store the solution"
       ~docs:lowLevelSection
@@ -1692,7 +1676,7 @@ let makeCommands projectPath =
           )
       );
 
-    makeProjectWithoutWorkflowCommand
+    makeProjectWithWorkflowCommand
       ~name:"fetch"
       ~doc:"Fetch dependencies using the stored solution"
       ~docs:lowLevelSection

--- a/esy/bin/esyCommand.ml
+++ b/esy/bin/esyCommand.ml
@@ -1225,9 +1225,9 @@ let makeCommands projectPath =
   let open Cmdliner in
 
   let projectConfig = ProjectConfig.term projectPath in
-  let projectWithWorkflow = Project.term projectPath in
+  let project = Project.term projectPath in
 
-  let makeProjectWithWorkflowCommand ?(header=`Standard) ?docs ?doc ?stop_on_pos ~name cmd =
+  let makeProjectCommand ?(header=`Standard) ?docs ?doc ?stop_on_pos ~name cmd =
     let cmd =
       let run cmd project =
         let () =
@@ -1237,13 +1237,13 @@ let makeCommands projectPath =
         in
         cmd project
       in
-      Cmdliner.Term.(pure run $ cmd $ projectWithWorkflow)
+      Cmdliner.Term.(pure run $ cmd $ project)
     in
     makeCommand ~header:`No ?docs ?doc ?stop_on_pos ~name cmd
   in
 
   let defaultCommand =
-    makeProjectWithWorkflowCommand
+    makeProjectCommand
       ~header:`No
       ~name:"esy"
       ~doc:"package.json workflow for native development with Reason/OCaml"
@@ -1265,7 +1265,7 @@ let makeCommands projectPath =
         build ~buildOnly:true mode pkgarg cmd proj
       in
 
-      makeProjectWithWorkflowCommand
+      makeProjectCommand
         ~header:`No
         ~name:"build"
         ~doc:"Build the entire sandbox"
@@ -1282,7 +1282,7 @@ let makeCommands projectPath =
     in
 
     let installCommand =
-      makeProjectWithWorkflowCommand
+      makeProjectCommand
         ~name:"install"
         ~doc:"Solve & fetch dependencies"
         ~docs:commonSection
@@ -1290,7 +1290,7 @@ let makeCommands projectPath =
     in
 
     let npmReleaseCommand =
-      makeProjectWithWorkflowCommand
+      makeProjectCommand
         ~name:"npm-release"
         ~doc:"Produce npm package with prebuilt artifacts"
         ~docs:otherSection
@@ -1304,7 +1304,7 @@ let makeCommands projectPath =
     installCommand;
     buildCommand;
 
-    makeProjectWithWorkflowCommand
+    makeProjectCommand
       ~name:"build-shell"
       ~doc:"Enter the build shell"
       ~docs:commonSection
@@ -1314,7 +1314,7 @@ let makeCommands projectPath =
         $ pkgTerm
       );
 
-    makeProjectWithWorkflowCommand
+    makeProjectCommand
       ~name:"shell"
       ~doc:"Enter esy sandbox shell"
       ~docs:commonSection
@@ -1323,7 +1323,7 @@ let makeCommands projectPath =
         $ pkgTerm
       );
 
-    makeProjectWithWorkflowCommand
+    makeProjectCommand
       ~header:`No
       ~name:"x"
       ~doc:"Execute command as if the package is installed"
@@ -1339,7 +1339,7 @@ let makeCommands projectPath =
             (Cmdliner.Arg.pos_all)
       );
 
-    makeProjectWithWorkflowCommand
+    makeProjectCommand
       ~name:"add"
       ~doc:"Add a new dependency"
       ~docs:commonSection
@@ -1396,7 +1396,7 @@ let makeCommands projectPath =
     npmReleaseCommand;
     makeAlias ~docs:otherSection npmReleaseCommand "release";
 
-    makeProjectWithWorkflowCommand
+    makeProjectCommand
       ~name:"export-build"
       ~doc:"Export build from the store"
       ~docs:otherSection
@@ -1428,13 +1428,13 @@ let makeCommands projectPath =
         $ projectConfig
       );
 
-    makeProjectWithWorkflowCommand
+    makeProjectCommand
       ~name:"export-dependencies"
       ~doc:"Export sandbox dependendencies as prebuilt artifacts"
       ~docs:otherSection
       Term.(const exportDependencies);
 
-    makeProjectWithWorkflowCommand
+    makeProjectCommand
       ~name:"import-dependencies"
       ~doc:"Import sandbox dependencies"
       ~docs:otherSection
@@ -1449,7 +1449,7 @@ let makeCommands projectPath =
 
     (* INTROSPECTION COMMANDS *)
 
-    makeProjectWithWorkflowCommand
+    makeProjectCommand
       ~name:"ls-builds"
       ~doc:"Output a tree of packages in the sandbox along with their status"
       ~docs:introspectionSection
@@ -1463,7 +1463,7 @@ let makeCommands projectPath =
         $ pkgTerm
       );
 
-    makeProjectWithWorkflowCommand
+    makeProjectCommand
       ~name:"ls-libs"
       ~doc:"Output a tree of packages along with the set of libraries made available by each package dependency."
       ~docs:introspectionSection
@@ -1477,7 +1477,7 @@ let makeCommands projectPath =
         $ pkgTerm
       );
 
-    makeProjectWithWorkflowCommand
+    makeProjectCommand
       ~name:"ls-modules"
       ~doc:"Output a tree of packages along with the set of libraries and modules made available by each package dependency."
       ~docs:introspectionSection
@@ -1503,7 +1503,7 @@ let makeCommands projectPath =
         $ Cli.setupLogTerm
       );
 
-    makeProjectWithWorkflowCommand
+    makeProjectCommand
       ~header:`No
       ~name:"build-plan"
       ~doc:"Print build plan to stdout"
@@ -1514,7 +1514,7 @@ let makeCommands projectPath =
         $ pkgTerm
       );
 
-    makeProjectWithWorkflowCommand
+    makeProjectCommand
       ~header:`No
       ~name:"build-env"
       ~doc:"Print build environment to stdout"
@@ -1526,7 +1526,7 @@ let makeCommands projectPath =
         $ pkgTerm
       );
 
-    makeProjectWithWorkflowCommand
+    makeProjectCommand
       ~header:`No
       ~name:"command-env"
       ~doc:"Print command environment to stdout"
@@ -1537,7 +1537,7 @@ let makeCommands projectPath =
         $ pkgTerm
       );
 
-    makeProjectWithWorkflowCommand
+    makeProjectCommand
       ~header:`No
       ~name:"exec-env"
       ~doc:"Print exec environment to stdout"
@@ -1550,7 +1550,7 @@ let makeCommands projectPath =
 
     (* LOW LEVEL PLUMBING COMMANDS *)
 
-    makeProjectWithWorkflowCommand
+    makeProjectCommand
       ~name:"build-dependencies"
       ~doc:"Build dependencies for a specified package"
       ~docs:lowLevelSection
@@ -1565,7 +1565,7 @@ let makeCommands projectPath =
         $ pkgTerm
       );
 
-    makeProjectWithWorkflowCommand
+    makeProjectCommand
       ~header:`No
       ~name:"exec-command"
       ~doc:"Execute command in a given environment"
@@ -1603,7 +1603,7 @@ let makeCommands projectPath =
             Cmdliner.Arg.pos_all
       );
 
-    makeProjectWithWorkflowCommand
+    makeProjectCommand
       ~header:`No
       ~name:"print-env"
       ~doc:"Print a configured environment on stdout"
@@ -1631,7 +1631,7 @@ let makeCommands projectPath =
         $ pkgTerm
       );
 
-    makeProjectWithWorkflowCommand
+    makeProjectCommand
       ~name:"solve"
       ~doc:"Solve dependencies and store the solution"
       ~docs:lowLevelSection
@@ -1645,7 +1645,7 @@ let makeCommands projectPath =
           )
       );
 
-    makeProjectWithWorkflowCommand
+    makeProjectCommand
       ~name:"fetch"
       ~doc:"Fetch dependencies using the stored solution"
       ~docs:lowLevelSection

--- a/esy/bin/esyCommand.ml
+++ b/esy/bin/esyCommand.ml
@@ -196,23 +196,11 @@ let resolvedPathTerm =
   let print = Path.pp in
   Arg.conv ~docv:"PATH" (parse, print)
 
-let buildDependencies
-  all
-  mode
-  devDepspec
-  pkgarg
-  (proj : Project.WithoutWorkflow.t) =
+let buildDependencies all mode pkgarg (proj : Project.WithoutWorkflow.t) =
   let open RunAsync.Syntax in
   let%bind fetched = Project.fetched proj in
   let f (pkg : Package.t) =
-    let buildspec =
-      let deps =
-        match devDepspec with
-        | Some depspec -> depspec
-        | None -> Workflow.buildDev
-      in
-      {Workflow.default.buildspec with dev = deps}
-    in
+    let buildspec = Workflow.default.buildspec in
     let%bind plan = RunAsync.ofRun (
       BuildSandbox.makePlan
         buildspec
@@ -234,7 +222,6 @@ let execCommand
   includeEsyIntrospectionEnv
   includeNpmBin
   plan
-  devDepspec
   envspec
   pkgarg
   cmd
@@ -249,14 +236,7 @@ let execCommand
     includeEsyIntrospectionEnv;
     augmentDeps = envspec;
   } in
-  let buildspec =
-    let deps =
-      match devDepspec with
-      | Some depspec -> depspec
-      | None -> Workflow.buildDev
-    in
-    {Workflow.default.buildspec with dev = deps;}
-  in
+  let buildspec = Workflow.default.buildspec in
   let f pkg =
     Project.execCommand
       ~checkIfDependenciesAreBuilt:false
@@ -277,7 +257,6 @@ let printEnv
   includeEsyIntrospectionEnv
   includeNpmBin
   plan
-  devDepspec
   envspec
   pkgarg
   (proj : Project.WithoutWorkflow.t)
@@ -291,14 +270,7 @@ let printEnv
     includeNpmBin;
     augmentDeps = envspec;
   } in
-  let buildspec =
-    let deps =
-      match devDepspec with
-      | Some depspec -> depspec
-      | None -> Workflow.buildDev
-    in
-    {Workflow.default.buildspec with dev = deps;}
-  in
+  let buildspec = Workflow.default.buildspec in
   Project.printEnv
     proj
     envspec
@@ -1637,13 +1609,6 @@ let makeCommands projectPath =
             & info ["all"] ~doc:"Build all dependencies (including linked packages)"
           )
         $ modeTerm
-        $ Arg.(
-            value
-            & opt (some depspecConv) None
-            & info ["dev-depspec"]
-              ~doc:"Define DEPSPEC expression for linked packages' build environments"
-              ~docv:"DEPSPEC"
-          )
         $ pkgTerm
       );
 
@@ -1671,13 +1636,6 @@ let makeCommands projectPath =
           )
         $ Arg.(value & flag & info ["include-npm-bin"]  ~doc:"Include npm bin in PATH")
         $ modeTerm
-        $ Arg.(
-            value
-            & opt (some depspecConv) None
-            & info ["dev-depspec"]
-              ~doc:"Define DEPSPEC expression for linked packages' build environments"
-              ~docv:"DEPSPEC"
-          )
         $ Arg.(
             value
             & opt (some depspecConv) None
@@ -1710,13 +1668,6 @@ let makeCommands projectPath =
           )
         $ Arg.(value & flag & info ["include-npm-bin"]  ~doc:"Include npm bin in PATH")
         $ modeTerm
-        $ Arg.(
-            value
-            & opt (some depspecConv) None
-            & info ["dev-depspec"]
-              ~doc:"Define DEPSPEC expression for linked packages' build environments"
-              ~docv:"DEPSPEC"
-          )
         $ Arg.(
             value
             & opt (some depspecConv) None

--- a/test-e2e/esy-build/circular-deps-error.test.js
+++ b/test-e2e/esy-build/circular-deps-error.test.js
@@ -52,12 +52,10 @@ describe(`'esy build' command: circular dependency error`, () => {
     await p.esy('install');
     await expect(p.esy('build')).rejects.toMatchObject({
       stderr: outdent`
-        info esy build ${helpers.esyVersion} (using package.json)
         error: found circular dependency on: dep@path:dep
           processing depOfDep@path:depOfDep
           processing dep@path:dep
           processing hasCircularDeps@link-dev:./package.json
-          creating task for hasCircularDeps@link-dev:./package.json
         esy: exiting due to errors above
 
       `,


### PR DESCRIPTION
This PR removes configurable depspec for builds in CLI which is now unneccessary
as we are settling on `link-dev:` approach for monorepo configuration.

Also:

- Remove `esy build-package` command, now superseeded by `esy build` command
- Simplify `Project` module by removing two kinds of projects (workflow vs non-workflow)
- Fix `monorepo.test` to model monorepo via `link-dev:` and not via `--dev-depspec`