### PR TITLE
Add --skip-staleness-check for 'esy build' command

### DIFF
--- a/bin/NpmReleaseCommand.re
+++ b/bin/NpmReleaseCommand.re
@@ -427,6 +427,7 @@ let make =
     let%lwt () = Logs_lwt.app(m => m("Building packages"));
     BuildSandbox.build(
       ~buildLinked=true,
+      ~skipStalenessCheck=true,
       ~concurrency,
       sandbox,
       plan,

--- a/bin/Project.re
+++ b/bin/Project.re
@@ -681,7 +681,8 @@ let withPackage = (proj, pkgArg: PkgArg.t, f) => {
   runWith(pkg);
 };
 
-let buildDependencies = (~buildLinked, proj: project, plan, pkg) => {
+let buildDependencies =
+    (~skipStalenessCheck=false, ~buildLinked, proj: project, plan, pkg) => {
   open RunAsync.Syntax;
   let%bind fetched = fetched(proj);
   let%bind solved = solved(proj);
@@ -704,6 +705,7 @@ let buildDependencies = (~buildLinked, proj: project, plan, pkg) => {
     let dependencies =
       Solution.dependenciesByDepSpec(solved.solution, depspec, task.pkg);
     BuildSandbox.build(
+      ~skipStalenessCheck,
       ~concurrency=EsyRuntime.concurrency,
       ~buildLinked,
       fetched.sandbox,

--- a/bin/Project.rei
+++ b/bin/Project.rei
@@ -58,7 +58,13 @@ let withPackage:
   (project, PkgArg.t, Package.t => Lwt.t(Run.t('a))) => RunAsync.t('a);
 
 let buildDependencies:
-  (~buildLinked: bool, project, BuildSandbox.Plan.t, Package.t) =>
+  (
+    ~skipStalenessCheck: bool=?,
+    ~buildLinked: bool,
+    project,
+    BuildSandbox.Plan.t,
+    Package.t
+  ) =>
   RunAsync.t(unit);
 
 let buildPackage:

--- a/esy-build/BuildSandbox.rei
+++ b/esy-build/BuildSandbox.rei
@@ -101,7 +101,14 @@ let buildOnly:
   RunAsync.t(unit);
 
 let build:
-  (~concurrency: int=?, ~buildLinked: bool, t, Plan.t, list(PackageId.t)) =>
+  (
+    ~skipStalenessCheck: bool,
+    ~concurrency: int=?,
+    ~buildLinked: bool,
+    t,
+    Plan.t,
+    list(PackageId.t)
+  ) =>
   RunAsync.t(unit);
 
 let buildRoot:

--- a/test-e2e/complete/symlink-workflow.test.js
+++ b/test-e2e/complete/symlink-workflow.test.js
@@ -105,6 +105,14 @@ describe('Symlink workflow', () => {
       expect(stderr).not.toContain('info building dep@link:../dep');
     }
 
+    {
+      // builds again if we pass --skip-staleness-check
+      const {stderr} = await p.esy('build --skip-staleness-check');
+
+      expect(stderr).toContain('info building anotherDep@link:../anotherDep');
+      expect(stderr).toContain('info building dep@link:../dep');
+    }
+
     const dep = await p.esy('dep.cmd');
     expect(dep.stdout.trim()).toEqual('__dep__');
     const anotherDep = await p.esy('anotherDep.cmd');


### PR DESCRIPTION
This allows to skip staleness check when building `link-dev:` packages.

Fixes #803