### PR TITLE
Better discovery for project root

### DIFF
--- a/.ci/build-release.yml
+++ b/.ci/build-release.yml
@@ -44,6 +44,7 @@ jobs:
       demands: node.js
 
     variables:
+        HOMEBREW_NO_AUTO_UPDATE: yes
         STAGING_DIRECTORY: /Users/vsts/STAGING
         STAGING_DIRECTORY_UNIX: /Users/vsts/STAGING
         ESY__CACHE_INSTALL_PATH: /Users/vsts/.esy/3____________________________________________________________________/i

--- a/bin/Project.re
+++ b/bin/Project.re
@@ -553,7 +553,7 @@ module OfTerm = {
       write'(projcfg, v, files),
     );
 
-  let promiseTerm = projectPath => {
+  let promiseTerm = {
     let parse = projcfg => {
       open RunAsync.Syntax;
       let%bind projcfg = projcfg;
@@ -566,13 +566,11 @@ module OfTerm = {
       };
     };
 
-    Cmdliner.Term.(const(parse) $ ProjectConfig.promiseTerm(projectPath));
+    Cmdliner.Term.(const(parse) $ ProjectConfig.promiseTerm);
   };
 
-  let term = sandboxPath =>
-    Cmdliner.Term.(
-      ret(const(Cli.runAsyncToCmdlinerRet) $ promiseTerm(sandboxPath))
-    );
+  let term =
+    Cmdliner.Term.(ret(const(Cli.runAsyncToCmdlinerRet) $ promiseTerm));
 };
 
 include OfTerm;

--- a/bin/Project.rei
+++ b/bin/Project.rei
@@ -37,9 +37,7 @@ let solved: project => RunAsync.t(solved);
 let fetched: project => RunAsync.t(fetched);
 let configured: project => RunAsync.t(configured);
 
-let make:
-  (ProjectConfig.t) =>
-  Lwt.t(Run.t((project, list(FileInfo.t))));
+let make: ProjectConfig.t => Lwt.t(Run.t((project, list(FileInfo.t))));
 
 let plan: (BuildSpec.mode, project) => RunAsync.t(BuildSandbox.Plan.t);
 
@@ -51,8 +49,8 @@ let ocaml: project => RunAsync.t(Fpath.t);
 
 let ocamlfind: project => RunAsync.t(Fpath.t);
 
-let term: option(Fpath.t) => Cmdliner.Term.t(project);
-let promiseTerm: option(Fpath.t) => Cmdliner.Term.t(RunAsync.t(project));
+let term: Cmdliner.Term.t(project);
+let promiseTerm: Cmdliner.Term.t(RunAsync.t(project));
 
 let withPackage:
   (project, PkgArg.t, Package.t => Lwt.t(Run.t('a))) => RunAsync.t('a);

--- a/bin/Project.rei
+++ b/bin/Project.rei
@@ -38,7 +38,7 @@ let fetched: project => RunAsync.t(fetched);
 let configured: project => RunAsync.t(configured);
 
 let make:
-  (ProjectConfig.t, SandboxSpec.t) =>
+  (ProjectConfig.t) =>
   Lwt.t(Run.t((project, list(FileInfo.t))));
 
 let plan: (BuildSpec.mode, project) => RunAsync.t(BuildSandbox.Plan.t);

--- a/bin/ProjectConfig.re
+++ b/bin/ProjectConfig.re
@@ -106,8 +106,7 @@ module FindProject = {
         | Ok((Kind.Project | NoProject, _)) => return((kind, path))
         | Ok((ProjectForced, path)) => return((Kind.ProjectForced, path))
         };
-      | ProjectForced =>
-        return((kind, path));
+      | ProjectForced => return((kind, path))
       };
     };
 
@@ -149,6 +148,16 @@ module FindProject = {
 };
 
 let commonOptionsSection = Manpage.s_common_options;
+
+let projectPath = {
+  let doc = "Specifies esy project path.";
+  let env = Arg.env_var("ESY__PROJECT", ~doc);
+  Arg.(
+    value
+    & opt(some(Cli.pathConv), None)
+    & info(["P", "project-path"], ~env, ~docs=commonOptionsSection, ~doc)
+  );
+};
 
 let prefixPath = {
   let doc = "Specifies esy prefix path.";
@@ -294,10 +303,11 @@ let make =
   });
 };
 
-let promiseTerm = projectPath => {
+let promiseTerm = {
   let parse =
       (
         mainprg,
+        projectPath,
         prefixPath,
         cachePath,
         cacheTarballsPath,
@@ -326,6 +336,7 @@ let promiseTerm = projectPath => {
   Cmdliner.Term.(
     const(parse)
     $ main_name
+    $ projectPath
     $ prefixPath
     $ cachePathArg
     $ cacheTarballsPath
@@ -339,7 +350,5 @@ let promiseTerm = projectPath => {
   );
 };
 
-let term = projectPath =>
-  Cmdliner.Term.(
-    ret(const(Cli.runAsyncToCmdlinerRet) $ promiseTerm(projectPath))
-  );
+let term =
+  Cmdliner.Term.(ret(const(Cli.runAsyncToCmdlinerRet) $ promiseTerm));

--- a/bin/ProjectConfig.rei
+++ b/bin/ProjectConfig.rei
@@ -26,6 +26,5 @@ let show: t => string;
 let pp: Fmt.t(t);
 let to_yojson: t => Json.t;
 
-let promiseTerm: option(Fpath.t) => Cmdliner.Term.t(RunAsync.t(t));
-
-let term: option(Fpath.t) => Cmdliner.Term.t(t);
+let promiseTerm: Cmdliner.Term.t(RunAsync.t(t));
+let term: Cmdliner.Term.t(t);

--- a/bin/esy.re
+++ b/bin/esy.re
@@ -1398,11 +1398,8 @@ let makeAlias = (~docs=aliasesSection, ~stop_on_pos=false, command, alias) => {
   (term, info);
 };
 
-let makeCommands = projectPath => {
+let commandsConfig = {
   open Cmdliner;
-
-  let projectConfig = ProjectConfig.term(projectPath);
-  let project = Project.term(projectPath);
 
   let makeProjectCommand =
       (~header=`Standard, ~docs=?, ~doc=?, ~stop_on_pos=?, ~name, cmd) => {
@@ -1420,7 +1417,7 @@ let makeCommands = projectPath => {
         cmd(project);
       };
 
-      Cmdliner.Term.(pure(run) $ cmd $ project);
+      Cmdliner.Term.(pure(run) $ cmd $ Project.term);
     };
 
     makeCommand(~header=`No, ~docs?, ~doc?, ~stop_on_pos?, ~name, cmd);
@@ -1558,7 +1555,7 @@ let makeCommands = projectPath => {
                   ~doc="Package to display information about",
                 )
             )
-          $ project
+          $ Project.term
         ),
       ),
       makeCommand(
@@ -1612,7 +1609,7 @@ let makeCommands = projectPath => {
           $ Arg.(
               value & pos_all(resolvedPathTerm, []) & info([], ~docv="BUILD")
             )
-          $ projectConfig
+          $ ProjectConfig.term
         ),
       ),
       makeProjectCommand(
@@ -1700,7 +1697,7 @@ let makeCommands = projectPath => {
         ~docs=introspectionSection,
         Term.(
           const(status)
-          $ Project.promiseTerm(projectPath)
+          $ Project.promiseTerm
           $ Arg.(
               value & flag & info(["json"], ~doc="Format output as JSON")
             )
@@ -1934,22 +1931,48 @@ let checkSymlinks = () =>
 let () = {
   let () = checkSymlinks();
 
-  let (argv, rootPackagePath) = {
+  let (defaultCommand, commands) = commandsConfig;
+
+  /*
+      Preparse command line arguments to expand syntax:
+
+        esy @projectPath
+
+      into
+
+        esy --project-path projectPath
+
+     which we can't parse with cmdliner
+   */
+  let argv = {
+    let commandNames = {
+      let f = (names, (_term, info)) => {
+        let name = Cmdliner.Term.name(info);
+        StringSet.add(name, names);
+      };
+      List.fold_left(~f, ~init=StringSet.empty, commands);
+    };
+
     let argv = Array.to_list(Sys.argv);
 
-    let (rootPackagePath, argv) =
+    let argv =
       switch (argv) {
-      | [] => (None, argv)
-      | [prg, elem, ...rest] when elem.[0] == '@' =>
+      | [] => argv
+      | [prg, elem, maybeCommandName, ...rest] when elem.[0] == '@' =>
         let sandbox = String.sub(elem, 1, String.length(elem) - 1);
-        (Some(Path.v(sandbox)), [prg, ...rest]);
-      | _ => (None, argv)
+        if (StringSet.mem(maybeCommandName, commandNames)) {
+          [prg, maybeCommandName, "--project-path", sandbox, ...rest];
+        } else {
+          [prg, "--project-path", sandbox, maybeCommandName, ...rest];
+        };
+      | [prg, elem] when elem.[0] == '@' =>
+        let sandbox = String.sub(elem, 1, String.length(elem) - 1);
+        [prg, "--project-path", sandbox];
+      | _ => argv
       };
 
-    (Array.of_list(argv), rootPackagePath);
+    Array.of_list(argv);
   };
-
-  let (defaultCommand, commands) = makeCommands(rootPackagePath);
 
   Cmdliner.Term.(
     exit @@ eval_choice(~main_on_err=true, ~argv, defaultCommand, commands)

--- a/bin/esy.re
+++ b/bin/esy.re
@@ -1339,7 +1339,7 @@ let default = (cmdAndPkg, proj: Project.t) => {
   | (Error(_), None) =>
     let%lwt () = printHeader(~spec=proj.projcfg.spec, "esy");
     let%bind () = solveAndFetch(proj);
-    let%bind (proj, _) = Project.make(proj.projcfg, proj.spec);
+    let%bind (proj, _) = Project.make(proj.projcfg);
     build(BuildDev, PkgArg.root, None, proj);
   | (Error(_) as err, Some((PkgArg.ByPkgSpec(Root), cmd))) =>
     switch (Scripts.find(Cmd.getTool(cmd), proj.scripts)) {

--- a/bin/esy.re
+++ b/bin/esy.re
@@ -369,11 +369,8 @@ let status = (maybeProject: RunAsync.t(Project.t), _asJson, ()) => {
         );
       };
 
-      let%lwt rootPackageConfigPath = {
-        open RunAsync.Syntax;
-        let%bind fetched = Project.fetched(proj);
-        return(BuildSandbox.rootPackageConfigPath(fetched.Project.sandbox));
-      };
+      let rootPackageConfigPath =
+        EsyInstall.SandboxSpec.manifestPath(proj.projcfg.spec);
 
       return({
         isProject: true,
@@ -382,7 +379,7 @@ let status = (maybeProject: RunAsync.t(Project.t), _asJson, ()) => {
         isProjectReadyForDev: Result.getOr(false, built),
         rootBuildPath: Result.getOr(None, rootBuildPath),
         rootInstallPath: Result.getOr(None, rootInstallPath),
-        rootPackageConfigPath: Result.getOr(None, rootPackageConfigPath),
+        rootPackageConfigPath,
       });
     };
 

--- a/esy-build/BuildSandbox.rei
+++ b/esy-build/BuildSandbox.rei
@@ -17,8 +17,6 @@ let make:
 
 let renderExpression: (t, Scope.t, string) => Run.t(string);
 
-let rootPackageConfigPath: t => option(Fpath.t);
-
 let configure:
   (
     ~forceImmutable: bool=?,

--- a/esy-install/SandboxSpec.re
+++ b/esy-install/SandboxSpec.re
@@ -41,11 +41,15 @@ let localPrefixPath = spec => {
   Path.(spec.path / "_esy" / name);
 };
 
+let manifestPath = spec =>
+  switch (spec.manifest) {
+  | Manifest((_kind, filename)) => Some(Path.(spec.path / filename))
+  | ManifestAggregate(_) => None
+  };
+
 let manifestPaths = spec =>
   switch (spec.manifest) {
-  | [@implicit_arity] Manifest(_kind, filename) => [
-      Path.(spec.path / filename),
-    ]
+  | Manifest((_kind, filename)) => [Path.(spec.path / filename)]
   | ManifestAggregate(filenames) =>
     List.map(
       ~f=((_kind, filename)) => Path.(spec.path / filename),

--- a/esy-install/SandboxSpec.rei
+++ b/esy-install/SandboxSpec.rei
@@ -19,6 +19,7 @@ let isDefault: t => bool;
 let projectName: t => string;
 
 let manifestPaths: t => list(Path.t);
+let manifestPath: t => option(Path.t);
 let distPath: t => Path.t;
 let tempPath: t => Path.t;
 let cachePath: t => Path.t;

--- a/test-e2e/esy-status.test.js
+++ b/test-e2e/esy-status.test.js
@@ -17,7 +17,7 @@ describe(`'esy status' command`, function() {
       isProjectSolved: false,
       rootBuildPath: null,
       rootInstallPath: null,
-      rootPackageConfigPath: null,
+      rootPackageConfigPath: null
     });
   });
 
@@ -56,7 +56,7 @@ describe(`'esy status' command`, function() {
       isProjectSolved: false,
       rootBuildPath: null,
       rootInstallPath: null,
-      rootPackageConfigPath: null,
+      rootPackageConfigPath: path.join(p.projectPath, 'package.json')
     });
   });
 
@@ -74,7 +74,7 @@ describe(`'esy status' command`, function() {
       isProjectSolved: true,
       rootBuildPath: null,
       rootInstallPath: null,
-      rootPackageConfigPath: null,
+      rootPackageConfigPath: path.join(p.projectPath, 'package.json')
     });
   });
 
@@ -132,5 +132,27 @@ describe(`'esy status' command`, function() {
     });
     expect(status.rootBuildPath).not.toBe(null);
     expect(status.rootInstallPath).not.toBe(null);
+  });
+
+  test('finding root with .esyproject', async function() {
+    const p = await helpers.createTestSandbox();
+    await p.fixture(
+      helpers.file('.esyproject', ''),
+      helpers.packageJson({
+        name: 'root',
+      }),
+      helpers.dir('subpackage',
+        helpers.packageJson({
+          name: 'subpackage',
+        }),
+      )
+    );
+    p.cd('./subpackage');
+
+    const {stdout} = await p.esy('status --json');
+    const status = JSON.parse(stdout);
+    expect(status).toMatchObject({
+      rootPackageConfigPath: path.join(p.projectPath, 'package.json')
+    });
   });
 });


### PR DESCRIPTION
The main change of this PR is the introduction of `.esyproject` marker which
`esy` consults when climbing filesystem to find a project root: if esy finds
`.esyproject` then it prefers it even if some package config (`package.json`,
`esy.json`, `*.opam`, `opam`) was found before.

The main use case is the monorepo:

  /.esyproject
  /package.json
  /src/packageA/package.json
  /src/packageB/package.json

where we want `esy` within `/src/packageA` to find `/` as the root and not
`/src/packageA`.

This PR also contains fixes for `esy status` - it now can report
`"rootPackageConfigPath"` even if project isn't fetched.

And finally this PR makes `esy @name` a sugar for `esy --project-path name`
which simplifies implementation and provides a much less magical UI for setting
a project path.