### PR TITLE
Create symlinks to build/install dirs for root package

### DIFF
--- a/bin/Project.re
+++ b/bin/Project.re
@@ -145,7 +145,6 @@ let makeProject = (makeSolved, projcfg: ProjectConfig.t) => {
       EsyBuildPackage.Config.make(
         ~storePath,
         ~localStorePath=EsyInstall.SandboxSpec.storePath(projcfg.spec),
-        ~buildPath=EsyInstall.SandboxSpec.buildPath(projcfg.spec),
         ~projectPath=projcfg.spec.path,
         (),
       ),

--- a/esy-build-package/Config.re
+++ b/esy-build-package/Config.re
@@ -3,7 +3,6 @@ module Store = EsyLib.Store;
 [@deriving (show, to_yojson)]
 type t = {
   projectPath: EsyLib.Path.t,
-  buildPath: EsyLib.Path.t,
   storePath: EsyLib.Path.t,
   localStorePath: EsyLib.Path.t,
 };
@@ -43,7 +42,7 @@ let rec configureStorePath = cfg => {
   return(path);
 };
 
-let make = (~storePath, ~projectPath, ~buildPath, ~localStorePath, ()) => {
+let make = (~storePath, ~projectPath, ~localStorePath, ()) => {
   open Run;
   let%bind storePath = configureStorePath(storePath);
   let%bind () = {
@@ -58,7 +57,7 @@ let make = (~storePath, ~projectPath, ~buildPath, ~localStorePath, ()) => {
     };
   };
   let%bind () = initStore(localStorePath);
-  return({projectPath, storePath, localStorePath, buildPath});
+  return({projectPath, storePath, localStorePath});
 };
 
 let render = (cfg, v) => {

--- a/esy-build-package/Config.rei
+++ b/esy-build-package/Config.rei
@@ -1,7 +1,6 @@
 type t =
   pri {
     projectPath: Fpath.t,
-    buildPath: Fpath.t,
     storePath: Fpath.t,
     localStorePath: Fpath.t,
   };
@@ -21,7 +20,6 @@ let make:
   (
     ~storePath: storePathConfig,
     ~projectPath: Fpath.t,
-    ~buildPath: Fpath.t,
     ~localStorePath: Fpath.t,
     unit
   ) =>

--- a/esy-build-package/bin/esyBuildPackageCommand.re
+++ b/esy-build-package/bin/esyBuildPackageCommand.re
@@ -10,7 +10,6 @@ type verb =
 
 type commonOpts = {
   planPath: option(Fpath.t),
-  buildPath: option(Fpath.t),
   storePath: option(Fpath.t),
   localStorePath: option(Fpath.t),
   projectPath: option(Fpath.t),
@@ -27,7 +26,7 @@ let setupLog = (style_renderer, level) => {
 
 let createConfig = (copts: commonOpts) => {
   open Run;
-  let {storePath, buildPath, localStorePath, projectPath, _} = copts;
+  let {storePath, localStorePath, projectPath, _} = copts;
   let%bind currentPath = Bos.OS.Dir.current();
   let projectPath = Option.orDefault(~default=currentPath, projectPath);
   let storePath =
@@ -37,7 +36,6 @@ let createConfig = (copts: commonOpts) => {
     };
   Config.make(
     ~storePath,
-    ~buildPath=Option.orDefault(~default=projectPath / "_build", buildPath),
     ~localStorePath=
       Option.orDefault(~default=projectPath / "_store", localStorePath),
     ~projectPath,
@@ -229,15 +227,6 @@ let () = {
         & info(["local-store-path"], ~env, ~docs, ~docv="PATH", ~doc)
       );
     };
-    let buildPath = {
-      let doc = "Specifies esy build path.";
-      let env = Arg.env_var("ESY__BUILD_PATH", ~doc);
-      Arg.(
-        value
-        & opt(some(path), None)
-        & info(["build-path"], ~env, ~docs, ~docv="PATH", ~doc)
-      );
-    };
     let planPath = {
       let doc = "Specifies path to build plan.";
       let env = Arg.env_var("ESY__PLAN", ~doc);
@@ -253,19 +242,10 @@ let () = {
         $ Fmt_cli.style_renderer()
         $ Logs_cli.level(~env=Arg.env_var("ESY__LOG"), ())
       );
-    let parse =
-        (
-          projectPath,
-          storePath,
-          localStorePath,
-          buildPath,
-          planPath,
-          logLevel,
-        ) => {
+    let parse = (projectPath, storePath, localStorePath, planPath, logLevel) => {
       projectPath,
       storePath,
       localStorePath,
-      buildPath,
       planPath,
       logLevel,
     };
@@ -274,7 +254,6 @@ let () = {
       $ projectPath
       $ storePath
       $ localStorePath
-      $ buildPath
       $ planPath
       $ setupLogT
     );

--- a/esy-build/BuildSandbox.re
+++ b/esy-build/BuildSandbox.re
@@ -1117,26 +1117,6 @@ let buildOnly =
     }
   );
 
-let buildRoot = (~quiet=?, ~buildOnly=?, sandbox, plan) => {
-  open RunAsync.Syntax;
-  let root = Solution.root(sandbox.solution);
-  switch (Plan.get(plan, root.id)) {
-  | Some(task) =>
-    let%bind () = buildTask(~quiet?, ~buildOnly?, sandbox, task);
-    let%bind () = {
-      let buildPath = Task.buildPath(sandbox.cfg, task);
-      let buildPathLink = EsyInstall.SandboxSpec.buildPath(sandbox.spec);
-      switch (System.Platform.host) {
-      | Windows => return()
-      | _ => Fs.symlink(~force=true, ~src=buildPath, buildPathLink)
-      };
-    };
-
-    return();
-  | None => RunAsync.return()
-  };
-};
-
 let build' =
     (~skipStalenessCheck, ~concurrency, ~buildLinked, sandbox, plan, ids) => {
   open RunAsync.Syntax;

--- a/esy-build/BuildSandbox.rei
+++ b/esy-build/BuildSandbox.rei
@@ -117,9 +117,6 @@ let build:
   ) =>
   RunAsync.t(unit);
 
-let buildRoot:
-  (~quiet: bool=?, ~buildOnly: bool=?, t, Plan.t) => RunAsync.t(unit);
-
 let isBuilt: (t, Task.t) => RunAsync.t(bool);
 
 let exportBuild:

--- a/esy-build/EsyBuildPackageApi.re
+++ b/esy-build/EsyBuildPackageApi.re
@@ -38,8 +38,6 @@ let run =
               % p(cfg.localStorePath)
               % "--project-path"
               % p(cfg.projectPath)
-              % "--build-path"
-              % p(cfg.buildPath)
               % "--plan"
               % p(buildJsonFilename)
               |> addArgs(args)

--- a/esy-install/SandboxSpec.re
+++ b/esy-install/SandboxSpec.re
@@ -63,6 +63,7 @@ let pnpJsPath = spec => Path.(localPrefixPath(spec) / "pnp.js");
 let cachePath = spec => Path.(localPrefixPath(spec) / "cache");
 let storePath = spec => Path.(localPrefixPath(spec) / "store");
 let buildPath = spec => Path.(localPrefixPath(spec) / "build");
+let installPath = spec => Path.(localPrefixPath(spec) / "install");
 let binPath = spec => Path.(localPrefixPath(spec) / "bin");
 let distPath = spec => Path.(localPrefixPath(spec) / "dist");
 let tempPath = spec => Path.(localPrefixPath(spec) / "tmp");

--- a/esy-install/SandboxSpec.rei
+++ b/esy-install/SandboxSpec.rei
@@ -25,6 +25,7 @@ let tempPath: t => Path.t;
 let cachePath: t => Path.t;
 let storePath: t => Path.t;
 let buildPath: t => Path.t;
+let installPath: t => Path.t;
 let installationPath: t => Path.t;
 let pnpJsPath: t => Path.t;
 let solutionLockPath: t => Path.t;

--- a/test-e2e/esy-build/no-deps.test.js
+++ b/test-e2e/esy-build/no-deps.test.js
@@ -50,6 +50,18 @@ describe(`'esy build': simple executable with no deps`, () => {
       expect(stdout.trim()).toEqual('__no-deps__');
     }));
 
+    test.disableIf(isWindows)('prodices _esy/*/build link to #{self.target_dir} for root', withProject(async (p) => {
+      await p.esy('build');
+      const {stdout} = await p.run("./_esy/default/build/no-deps.cmd");
+      expect(stdout.trim()).toEqual('__no-deps__');
+    }));
+
+    test.disableIf(isWindows)('prodices _esy/*/install link to #{self.install} for root', withProject(async (p) => {
+      await p.esy('build --install');
+      const {stdout} = await p.run("./_esy/default/install/bin/no-deps.cmd");
+      expect(stdout.trim()).toEqual('__no-deps__');
+    }));
+
     test(
       'build-env',
       withProject(async function(p) {


### PR DESCRIPTION
For root packagfe we create:

- `_esy/*/build` -> `#{self.target_dir}`
- `_esy/*/install` -> `#{self.install}`

on non Windows systems. Those are not for direct use but for debug &
introspection.