### PR TITLE
Create symlinks to build/install dirs on --release builds

### DIFF
--- a/test-e2e/esy-build/no-deps.test.js
+++ b/test-e2e/esy-build/no-deps.test.js
@@ -62,6 +62,22 @@ describe(`'esy build': simple executable with no deps`, () => {
       expect(stdout.trim()).toEqual('__no-deps__');
     }));
 
+    test.disableIf(isWindows)(
+      'produces _esy/*/build-release link to #{self.target_dir} for root --release',
+      withProject(async (p) => {
+        await p.esy('build --release');
+        const {stdout} = await p.run("./_esy/default/build-release/no-deps.cmd");
+        expect(stdout.trim()).toEqual('__no-deps__');
+      }));
+
+    test.disableIf(isWindows)(
+      'produces _esy/*/install-release link to #{self.install} for root on --release',
+      withProject(async (p) => {
+        await p.esy('build --release --install');
+        const {stdout} = await p.run("./_esy/default/install-release/bin/no-deps.cmd");
+        expect(stdout.trim()).toEqual('__no-deps__');
+      }));
+
     test(
       'build-env',
       withProject(async function(p) {

--- a/test-e2e/esy-build/no-deps.test.js
+++ b/test-e2e/esy-build/no-deps.test.js
@@ -50,13 +50,13 @@ describe(`'esy build': simple executable with no deps`, () => {
       expect(stdout.trim()).toEqual('__no-deps__');
     }));
 
-    test.disableIf(isWindows)('prodices _esy/*/build link to #{self.target_dir} for root', withProject(async (p) => {
+    test.disableIf(isWindows)('produces _esy/*/build link to #{self.target_dir} for root', withProject(async (p) => {
       await p.esy('build');
       const {stdout} = await p.run("./_esy/default/build/no-deps.cmd");
       expect(stdout.trim()).toEqual('__no-deps__');
     }));
 
-    test.disableIf(isWindows)('prodices _esy/*/install link to #{self.install} for root', withProject(async (p) => {
+    test.disableIf(isWindows)('produces _esy/*/install link to #{self.install} for root', withProject(async (p) => {
       await p.esy('build --install');
       const {stdout} = await p.run("./_esy/default/install/bin/no-deps.cmd");
       expect(stdout.trim()).toEqual('__no-deps__');


### PR DESCRIPTION
This is a followup for #811 which creates `build-release` and `install-release`
links if `esy build --release` was invoked.