### PR TITLE
Project/package root discovery improvements

### DIFF
--- a/bin/PkgArg.re
+++ b/bin/PkgArg.re
@@ -2,12 +2,14 @@ open EsyInstall;
 
 type t =
   | ByPkgSpec(PkgSpec.t)
-  | ByPath(Path.t);
+  | ByPath(Path.t)
+  | ByDirectoryPath(Path.t);
 
 let pp = fmt =>
   fun
   | ByPkgSpec(spec) => PkgSpec.pp(fmt, spec)
-  | ByPath(path) => Path.pp(fmt, path);
+  | ByPath(path) => Path.pp(fmt, path)
+  | ByDirectoryPath(path) => Fmt.pf(fmt, "from:%a", Path.pp, path);
 
 let parse = v =>
   Result.Syntax.(

--- a/bin/PkgArg.rei
+++ b/bin/PkgArg.rei
@@ -2,7 +2,8 @@ open EsyInstall;
 
 type t =
   | ByPkgSpec(PkgSpec.t)
-  | ByPath(Path.t);
+  | ByPath(Path.t)
+  | ByDirectoryPath(Path.t);
 
 let root: t;
 

--- a/bin/esy.re
+++ b/bin/esy.re
@@ -30,7 +30,7 @@ let chdirTerm =
 let pkgTerm =
   Cmdliner.Arg.(
     value
-    & opt(PkgArg.conv, PkgArg.root)
+    & opt(PkgArg.conv, PkgArg.ByDirectoryPath(Path.currentPath()))
     & info(["p", "package"], ~doc="Package to work on", ~docv="PACKAGE")
   );
 
@@ -51,8 +51,8 @@ let cmdAndPkgTerm = {
   let make = (pkg, cmd) =>
     switch (pkg, cmd) {
     | (None, None) => `Ok(None)
-    | (None, Some(cmd)) => `Ok(Some((PkgArg.root, cmd)))
-    | (Some(pkgarg), Some(cmd)) => `Ok(Some((pkgarg, cmd)))
+    | (None, Some(cmd)) => `Ok(Some((None, cmd)))
+    | (Some(pkgarg), Some(cmd)) => `Ok(Some((Some(pkgarg), cmd)))
     | (Some(_), None) =>
       `Error((
         false,
@@ -1341,18 +1341,21 @@ let default = (chdir, cmdAndPkg, proj: Project.t) => {
   | (Ok(_), None) =>
     let%lwt () = printHeader(~spec=proj.projcfg.spec, "esy");
     build(BuildDev, PkgArg.root, None, proj);
-  | (Ok(_), Some((PkgArg.ByPkgSpec(Root) as pkgarg, cmd))) =>
+  | (Ok(_), Some((None, cmd))) =>
     switch (Scripts.find(Cmd.getTool(cmd), proj.scripts)) {
     | Some(script) => runScript(proj, script, Cmd.getArgs(cmd), ())
-    | None => devExec(chdir, pkgarg, proj, cmd, ())
+    | None =>
+      let pkgarg = PkgArg.ByDirectoryPath(Path.currentPath());
+      devExec(chdir, pkgarg, proj, cmd, ());
     }
-  | (Ok(_), Some((pkgarg, cmd))) => devExec(chdir, pkgarg, proj, cmd, ())
+  | (Ok(_), Some((Some(pkgarg), cmd))) =>
+    devExec(chdir, pkgarg, proj, cmd, ())
   | (Error(_), None) =>
     let%lwt () = printHeader(~spec=proj.projcfg.spec, "esy");
     let%bind () = solveAndFetch(proj);
     let%bind (proj, _) = Project.make(proj.projcfg);
     build(BuildDev, PkgArg.root, None, proj);
-  | (Error(_) as err, Some((PkgArg.ByPkgSpec(Root), cmd))) =>
+  | (Error(_) as err, Some((None, cmd))) =>
     switch (Scripts.find(Cmd.getTool(cmd), proj.scripts)) {
     | Some(script) => runScript(proj, script, Cmd.getArgs(cmd), ())
     | None => Lwt.return(err)

--- a/bin/esy.re
+++ b/bin/esy.re
@@ -1968,7 +1968,7 @@ let () = {
 
       into
 
-        esy --project-path projectPath
+        esy --project projectPath
 
      which we can't parse with cmdliner
    */
@@ -1989,13 +1989,13 @@ let () = {
       | [prg, elem, maybeCommandName, ...rest] when elem.[0] == '@' =>
         let sandbox = String.sub(elem, 1, String.length(elem) - 1);
         if (StringSet.mem(maybeCommandName, commandNames)) {
-          [prg, maybeCommandName, "--project-path", sandbox, ...rest];
+          [prg, maybeCommandName, "--project", sandbox, ...rest];
         } else {
-          [prg, "--project-path", sandbox, maybeCommandName, ...rest];
+          [prg, "--project", sandbox, maybeCommandName, ...rest];
         };
       | [prg, elem] when elem.[0] == '@' =>
         let sandbox = String.sub(elem, 1, String.length(elem) - 1);
-        [prg, "--project-path", sandbox];
+        [prg, "--project", sandbox];
       | _ => argv
       };
 

--- a/test-e2e-slow/run-slow-tests.js
+++ b/test-e2e-slow/run-slow-tests.js
@@ -3,6 +3,10 @@
 const {execSync} = require('child_process');
 const os = require('os');
 
+// this is required so esy won't "attach" to the outer esy project (esy
+// itself)
+delete env.ESY__ROOT_PACKAGE_CONFIG_PATH
+
 const isTaggedCommit = () => {
   const TRAVIS_TAG = process.env['TRAVIS_TAG'];
   const APPVEYOR_REPO_TAG = process.env['APPVEYOR_REPO_TAG'];

--- a/test-e2e-slow/run-slow-tests.js
+++ b/test-e2e-slow/run-slow-tests.js
@@ -5,7 +5,7 @@ const os = require('os');
 
 // this is required so esy won't "attach" to the outer esy project (esy
 // itself)
-delete env.ESY__ROOT_PACKAGE_CONFIG_PATH
+delete process.env.ESY__ROOT_PACKAGE_CONFIG_PATH
 
 const isTaggedCommit = () => {
   const TRAVIS_TAG = process.env['TRAVIS_TAG'];

--- a/test-e2e/common/finding-project.test.js
+++ b/test-e2e/common/finding-project.test.js
@@ -1,0 +1,146 @@
+// @flow
+
+const path = require('path');
+const helpers = require('../test/helpers.js');
+
+describe('Finding project / package root', function() {
+  test('finding root with .esyproject', async function() {
+    const p = await helpers.createTestSandbox();
+    await p.fixture(
+      helpers.file('.esyproject', ''),
+      helpers.packageJson({
+        name: 'root',
+      }),
+      helpers.dir('subpackage',
+        helpers.packageJson({
+          name: 'subpackage',
+        }),
+      )
+    );
+    p.cd('./subpackage');
+
+    const {stdout} = await p.esy('status --json');
+    const status = JSON.parse(stdout);
+    expect(status).toMatchObject({
+      rootPackageConfigPath: path.join(p.projectPath, 'package.json')
+    });
+  });
+
+  test('finding root of a named project via @name', async function() {
+    const p = await helpers.createTestSandbox();
+    await p.fixture(
+      helpers.file('package.json', '{}'),
+      helpers.file('custom.json', '{}'),
+      helpers.dir('subdir')
+    );
+
+    {
+      const {stdout} = await p.esy('@custom status --json');
+      const status = JSON.parse(stdout);
+      expect(status).toMatchObject({
+        rootPackageConfigPath: path.join(p.projectPath, 'custom.json')
+      });
+    }
+
+    {
+      p.cd('./subdir')
+      const {stdout} = await p.esy('@custom status --json');
+      const status = JSON.parse(stdout);
+      expect(status).toMatchObject({
+        rootPackageConfigPath: path.join(p.projectPath, 'custom.json')
+      });
+    }
+  });
+
+  test('finding root of a named project via @name (ignoring package.json upwards)', async function() {
+    const p = await helpers.createTestSandbox();
+    await p.fixture(
+      helpers.file('package.json', '{}'),
+      helpers.dir('subdir',
+        helpers.file('custom.json', '{}'),
+      )
+    );
+
+    {
+      p.cd('./subdir')
+      const {stdout} = await p.esy('@custom status --json');
+      const status = JSON.parse(stdout);
+      expect(status).toMatchObject({
+        rootPackageConfigPath: path.join(p.projectPath, 'subdir', 'custom.json')
+      });
+    }
+  });
+
+  test('finding root of a named project via @name (ignoring .esyproject upwards)', async function() {
+    const p = await helpers.createTestSandbox();
+    await p.fixture(
+      helpers.file('.esyproject', ''),
+      helpers.file('package.json', '{}'),
+      helpers.dir('subdir',
+        helpers.file('custom.json', '{}'),
+      )
+    );
+
+    {
+      p.cd('./subdir')
+      const {stdout} = await p.esy('@custom status --json');
+      const status = JSON.parse(stdout);
+      expect(status).toMatchObject({
+        rootPackageConfigPath: path.join(p.projectPath, 'subdir', 'custom.json')
+      });
+    }
+  });
+
+  test('finding root of a named project via @name.json', async function() {
+    const p = await helpers.createTestSandbox();
+    await p.fixture(
+      helpers.file('package.json', '{}'),
+      helpers.file('custom.json', '{}'),
+      helpers.dir('subdir')
+    );
+
+    {
+      const {stdout} = await p.esy('@custom.json status --json');
+      const status = JSON.parse(stdout);
+      expect(status).toMatchObject({
+        rootPackageConfigPath: path.join(p.projectPath, 'custom.json')
+      });
+    }
+
+    {
+      p.cd('./subdir')
+      const {stdout} = await p.esy('@custom.json status --json');
+      const status = JSON.parse(stdout);
+      expect(status).toMatchObject({
+        rootPackageConfigPath: path.join(p.projectPath, 'custom.json')
+      });
+    }
+  });
+
+  test('finding root of a named project via @/path/name.json', async function() {
+    const p = await helpers.createTestSandbox();
+    await p.fixture(
+      helpers.file('package.json', '{}'),
+      helpers.file('custom.json', '{}'),
+      helpers.dir('subdir')
+    );
+
+    {
+      const {stdout} = await p.esy('@./custom.json status --json');
+      const status = JSON.parse(stdout);
+      expect(status).toMatchObject({
+        rootPackageConfigPath: path.join(p.projectPath, 'custom.json')
+      });
+    }
+
+    {
+      p.cd('./subdir')
+      const {stdout} = await p.esy('@../custom.json status --json');
+      const status = JSON.parse(stdout);
+      expect(status).toMatchObject({
+        rootPackageConfigPath: path.join(p.projectPath, 'custom.json')
+      });
+    }
+  });
+});
+

--- a/test-e2e/common/scripts.test.js
+++ b/test-e2e/common/scripts.test.js
@@ -121,16 +121,6 @@ it('executes scripts', async () => {
   );
 });
 
-it('executes scripts with -p root', async () => {
-  const p = await createTestSandbox(...fixture);
-  await p.esy('install');
-  await p.esy('build');
-
-  await expect(p.esy('-p root cmd1')).resolves.toEqual(
-    expect.objectContaining({stdout: 'cmd1_result' + os.EOL}),
-  );
-});
-
 it('executes scripts even if sandbox is not built', async () => {
   const p = await createTestSandbox(...fixture);
   await p.esy('install');

--- a/test-e2e/complete/monorepo-workflow.test.js
+++ b/test-e2e/complete/monorepo-workflow.test.js
@@ -16,7 +16,7 @@
 //
 
 const helpers = require('../test/helpers.js');
-const {test, isWindows, packageJson, dir, dummyExecutable} = helpers;
+const {test, isWindows, packageJson, file, dir, dummyExecutable} = helpers;
 
 async function createTestSandbox() {
   const p = await helpers.createTestSandbox();
@@ -80,6 +80,7 @@ async function createTestSandbox() {
         pkgc: 'link-dev:./pkgc',
       },
     }),
+    file('.esyproject', ''),
     dir(
       'pkga',
       ...createPackage({
@@ -156,6 +157,19 @@ describe('Monorepo workflow using low level commands', function() {
       // run commands in a specified package environment.
       const p = await createTestSandbox();
       const {stdout} = await p.esy(`-p pkga echo '#{self.name}'`);
+
+      expect(stdout.trim()).toBe('pkga');
+    },
+  );
+
+  test.disableIf(isWindows)(
+    'running command in monorepo package env (referring to a package by changing cwd)',
+    async function() {
+      // run commands in a specified package environment.
+      const p = await createTestSandbox();
+      p.cd('./pkga');
+      const {stdout} = await p.esy(`echo '#{self.name}'`);
+      p.cd('../');
 
       expect(stdout.trim()).toBe('pkga');
     },

--- a/test-e2e/esy-status.test.js
+++ b/test-e2e/esy-status.test.js
@@ -134,25 +134,4 @@ describe(`'esy status' command`, function() {
     expect(status.rootInstallPath).not.toBe(null);
   });
 
-  test('finding root with .esyproject', async function() {
-    const p = await helpers.createTestSandbox();
-    await p.fixture(
-      helpers.file('.esyproject', ''),
-      helpers.packageJson({
-        name: 'root',
-      }),
-      helpers.dir('subpackage',
-        helpers.packageJson({
-          name: 'subpackage',
-        }),
-      )
-    );
-    p.cd('./subpackage');
-
-    const {stdout} = await p.esy('status --json');
-    const status = JSON.parse(stdout);
-    expect(status).toMatchObject({
-      rootPackageConfigPath: path.join(p.projectPath, 'package.json')
-    });
-  });
 });


### PR DESCRIPTION
This PR improves on discovery of a project/package roots:

1. `esy @name` invocations now climb up to find closes `name.json` config.

2. `cd src/pkg && esy build/CMD/...` now executes in context of a package
   `src/pkg` (works only for `esy.json` or `package.json` configs).

   This might seen as a big breaking change but in fact it is not a breaking
   change mostly as it only affects setups with `.esyproject` (which was only
   introduced recently - released in `next` channel) b/c otherwise such
   invocations will select `src/pkg` as project root.