### PR TITLE
Stronger check for installation.json validness

### DIFF
--- a/bin/Project.re
+++ b/bin/Project.re
@@ -530,17 +530,25 @@ module OfTerm = {
           );
           let v = {...v, projcfg};
           if%bind (checkStaleness(files)) {
+            let%lwt () = Logs_lwt.debug(m => m("cache is stale, discarding"));
             return(None);
           } else {
+            let%lwt () = Logs_lwt.debug(m => m("using cache"));
             return(Some(v));
           };
         }
       ) {
-      | Failure(_) => return(None)
+      | Failure(_) =>
+        let%lwt () =
+          Logs_lwt.debug(m => m("unable to read the cache, skipping..."));
+        return(None);
       };
 
     try%lwt (Lwt_io.with_file(~mode=Lwt_io.Input, Path.show(cachePath), f)) {
-    | Unix.Unix_error(_) => return(None)
+    | Unix.Unix_error(_) =>
+      let%lwt () =
+        Logs_lwt.debug(m => m("unable to find the cache, skipping..."));
+      return(None);
     };
   };
 

--- a/bin/esy.re
+++ b/bin/esy.re
@@ -986,14 +986,15 @@ let solveAndFetch = (proj: Project.t) => {
     EsySolve.Sandbox.digest(proj.workflow.solvespec, proj.solveSandbox);
   switch%bind (SolutionLock.ofPath(~digest, proj.installSandbox, lockPath)) {
   | Some(solution) =>
-    if%bind (EsyInstall.Fetch.isInstalled(
-               proj.workflow.installspec,
-               proj.installSandbox,
-               solution,
-             )) {
-      return();
-    } else {
-      fetch(proj);
+    switch%bind (
+      EsyInstall.Fetch.maybeInstallationOfSolution(
+        proj.workflow.installspec,
+        proj.installSandbox,
+        solution,
+      )
+    ) {
+    | Some(_installation) => return()
+    | None => fetch(proj)
     }
   | None =>
     let%bind () = solve(false, proj);

--- a/esy-build/ReadBuildManifest.re
+++ b/esy-build/ReadBuildManifest.re
@@ -202,7 +202,7 @@ let ofPath = (~manifest=?, path: Path.t) => {
   let%lwt () =
     Logs_lwt.debug(m =>
       m(
-        "BuildManifest.ofPath %a %a",
+        "ReadBuildManifest.ofPath %a %a",
         Fmt.(option(ManifestSpec.pp)),
         manifest,
         Path.pp,

--- a/esy-install/Fetch.rei
+++ b/esy-install/Fetch.rei
@@ -15,7 +15,9 @@ let fetch: (Solution.Spec.t, Sandbox.t, Solution.t) => RunAsync.t(unit);
 
 /** Check if the solution is installed. */
 
-let isInstalled: (Solution.Spec.t, Sandbox.t, Solution.t) => RunAsync.t(bool);
+let maybeInstallationOfSolution:
+  (Solution.Spec.t, Sandbox.t, Solution.t) =>
+  RunAsync.t(option(Installation.t));
 
 let fetchOverrideFiles:
   (Config.t, SandboxSpec.t, Override.t) => RunAsync.t(list(File.t));

--- a/esy-install/Solution.re
+++ b/esy-install/Solution.re
@@ -53,6 +53,7 @@ let allDependenciesBFS = Graph.allDependenciesBFS;
 let findBy = Graph.findBy;
 let getExn = Graph.getExn;
 let get = Graph.get;
+let mem = Graph.mem;
 let isRoot = Graph.isRoot;
 let root = Graph.root;
 let nodes = Graph.nodes;

--- a/esy-install/Solution.rei
+++ b/esy-install/Solution.rei
@@ -66,6 +66,7 @@ let isRoot: (t, pkg) => bool;
 let dependenciesBySpec: (t, Spec.t, pkg) => list(pkg);
 let dependenciesByDepSpec: (t, DepSpec.t, pkg) => list(pkg);
 
+let mem: (t, id) => bool;
 let get: (t, id) => option(pkg);
 let getExn: (t, id) => pkg;
 let findBy: (t, (id, pkg) => bool) => option((id, pkg));


### PR DESCRIPTION
This makes check for stake installation.json stronger.

In some cases we use installation to loop over each packages and then join
it with metadata from solution. If there are some packages in installation
which do not exist in solution - we fail.

This makes sure we invalidate installation if it contains some packages 
which are not in solution.

Also this dedupes the logic for installation staleness check by providing a
single function `Fetch.maybeInstallationOfSolution` which returns
`option(Installation.t)`.

Fixes #834