### PR TITLE
[WIP] Support nvm-windows

### DIFF
--- a/esy-lib/NodeResolution.re
+++ b/esy-lib/NodeResolution.re
@@ -82,7 +82,14 @@ let rec realpath = (p: Fpath.t) => {
       };
     };
   };
-  _realpath(p);
+  let%bind p = _realpath(p);
+  let p = Path.show(p);
+  let len = String.length(p);
+  if (len >= 4 && String.sub(p, 0, 4) == "\\??\\") {
+    Ok(Path.v(String.sub(p, 4, len - 4)));
+  } else {
+    Ok(Path.v(p));
+  };
 };
 
 /** Try to resolve an absolute path */


### PR DESCRIPTION
Fix \??\ in the beginning of EsyBash.exe path
nvm-windows uses symlinks and they're interfering with path resolution
resulting in strange \??\ in the beginning of the global path
Let's workaround it

Fixes #840 
Fixes #720 