### PR TITLE
Check if publicName already includes .exe

### DIFF
--- a/bin/NpmReleaseCommand.re
+++ b/bin/NpmReleaseCommand.re
@@ -623,7 +623,12 @@ let make =
                 let f = ((publicName, _innerName)) => {
                   let binName =
                     switch (System.Platform.host) {
-                    | Windows => publicName ++ ".exe"
+                    | Windows =>
+                      if (Path.hasExt("exe", Path.v(publicName))) {
+                        publicName;
+                      } else {
+                        publicName ++ ".exe";
+                      }
                     | _ => publicName
                     };
 


### PR DESCRIPTION
This PR fixes the double .exe issue we had before on Windows.