### PR TITLE
Merge PATH in release

### DIFF
--- a/bin/NpmReleaseCommand.re
+++ b/bin/NpmReleaseCommand.re
@@ -163,6 +163,7 @@ let makeBinWrapper = (~destPrefix, ~bin, ~environment: Environment.Bindings.t) =
          switch (name) {
          | "cur__original_root"
          | "cur__root" => false
+         | "PATH" => false
          | _ => true
          }
        )
@@ -177,7 +178,6 @@ let makeBinWrapper = (~destPrefix, ~bin, ~environment: Environment.Bindings.t) =
 
   Printf.sprintf(
     {|
-
     let windows = Sys.os_type = "Win32";;
     let cwd = Sys.getcwd ();;
     let path_sep = if windows then '\\' else '/';;

--- a/bin/NpmReleaseCommand.re
+++ b/bin/NpmReleaseCommand.re
@@ -275,8 +275,8 @@ let makeBinWrapper = (~destPrefix, ~bin, ~environment: Environment.Bindings.t) =
       let findVarRe = Str.regexp "\\$\\([a-zA-Z0-9_]+\\)" in
       let replace v =
         let name = Str.matched_group 1 v in
-        let values = EnvHashtbl.find_all curEnvMap name in
-        String.concat ";" values
+        try EnvHashtbl.find curEnvMap name
+        with Not_found -> ""
       in
       let f (name, value) =
         let value = Str.global_substitute findVarRe replace value in

--- a/bin/NpmReleaseCommand.re
+++ b/bin/NpmReleaseCommand.re
@@ -180,10 +180,10 @@ let makeBinWrapper = (~destPrefix, ~bin, ~environment: Environment.Bindings.t) =
     let windows = Sys.os_type = "Win32";;
     let cwd = Sys.getcwd ();;
     let path_sep = if windows then '\\' else '/';;
-    let path_sep_str = String.make 1 path_sep
+    let path_sep_str = String.make 1 path_sep;;
 
-    let caseInsensitiveEqual i j = String.lowercase_ascii i = String.lowercase_ascii j;; 
-    let caseInsensitiveHash k = Hashtbl.hash (String.lowercase_ascii k)
+    let caseInsensitiveEqual i j = String.lowercase_ascii i = String.lowercase_ascii j;;
+    let caseInsensitiveHash k = Hashtbl.hash (String.lowercase_ascii k);;
 
     module EnvHash =
       struct

--- a/bin/NpmReleaseCommand.re
+++ b/bin/NpmReleaseCommand.re
@@ -163,7 +163,6 @@ let makeBinWrapper = (~destPrefix, ~bin, ~environment: Environment.Bindings.t) =
          switch (name) {
          | "cur__original_root"
          | "cur__root" => false
-         | "PATH" => false
          | _ => true
          }
        )
@@ -263,7 +262,11 @@ let makeBinWrapper = (~destPrefix, ~bin, ~environment: Environment.Bindings.t) =
     ;;
 
     let expandEnv env =
-      let findVarRe = Str.regexp "\\$\\([a-zA-Z0-9_]+\\)" in
+      let regexpString = "\\$\\([a-zA-Z0-9_]+\\)" in
+      let findVarRe = if windows
+      then Str.regexp_case_fold regexpString
+      else Str.regexp regexpString
+      in
       let replace v =
         let name = Str.matched_group 1 v in
         try Hashtbl.find curEnvMap name


### PR DESCRIPTION
This solves a issue where on Windows any released binary can't access its real path because this shadows it.

Current implementation puts `PATH` before `Path` (my actual system path) and that would only include
```
/usr/local/bin
/usr/bin
/bin
/usr/sbin
/sbin
C:/WINDOWS/System32
```
so anything that is in my path will never be found.

If there is a better way to implement this I'll be happy to change it.