### PR TITLE
[WIP] Support manifests with path

### DIFF
--- a/esy-package-config/Dist.re
+++ b/esy-package-config/Dist.re
@@ -545,6 +545,15 @@ module Parse = {
          |};
        };
 
+       let%expect_test "git+ssh://git@github.com:esy/esy.git:path/to/opam#abcdef" = {
+         testRelaxed("git+ssh://git@github.com:esy/esy.git:path/to/opam#abcdef");
+         %expect
+         {|
+           (Git (remote git@github.com:esy/esy.git) (commit abcdef)
+            (manifest ((Opam opam))))
+         |};
+       };
+
        /* Testing parser: errors */
 
        let%expect_test "github:user/repo#ref" = {

--- a/esy-package-config/ManifestSpec.re
+++ b/esy-package-config/ManifestSpec.re
@@ -12,7 +12,7 @@ let pp = (fmt, (_, fname)) => Fmt.string(fmt, fname);
 
 let ofString = fname =>
   Result.Syntax.(
-    switch (fname) {
+    switch (Path.(basename(v(fname)))) {
     | "" => errorf("empty filename")
     | "opam" => return((Opam, "opam"))
     | fname =>

--- a/esy-package-config/SourceSpec.re
+++ b/esy-package-config/SourceSpec.re
@@ -277,6 +277,22 @@ let%test_module "parsing" =
        (manifest ((Opam lwt.opam)))) |};
      };
 
+     let%expect_test "git+https://example.com/repo.git:path/to/lwt.opam#ref" = {
+       parse("git+https://example.com/repo.git:path/to/lwt.opam#ref");
+       %expect
+       {|
+      (Git (remote https://example.com/repo.git) (ref (ref))
+       (manifest ((Opam lwt.opam)))) |};
+     };
+
+     let%expect_test "git+https://example.com/repo.git:path/to/opam#ref" = {
+       parse("git+https://example.com/repo.git:path/to/opam#ref");
+       %expect
+       {|
+      (Git (remote https://example.com/repo.git) (ref (ref))
+       (manifest ((Opam opam)))) |};
+     };
+
      let%expect_test "git+https://example.com/repo.git:lwt.opam" = {
        parse("git+https://example.com/repo.git:lwt.opam");
        %expect


### PR DESCRIPTION
Issue: #872 

This PR adds an additional check to `ManifestSpec.ofString` to see whether the `fname` has a `basename` that matches "opam".