### PR TITLE
Executes scripts from the project's root

### DIFF
--- a/bin/esy.re
+++ b/bin/esy.re
@@ -639,14 +639,15 @@ let runScript = (proj: Project.t, script, args, ()) => {
             |> addArgs(args)
           );
 
-          let cwd = Some(
+        let cwd =
+          Some(
             Scope.(
               rootPath(scope)
               |> SandboxPath.toValue
               |> SandboxValue.render(proj.buildCfg)
-            )
+            ),
           );
-        
+
         return((cmd, cwd));
       },
     );

--- a/bin/esy.re
+++ b/bin/esy.re
@@ -593,7 +593,7 @@ let runScript = (proj: Project.t, script, args, ()) => {
     };
   };
 
-  let%bind cmd =
+  let%bind (cmd, cwd) =
     RunAsync.ofRun(
       {
         open Run.Syntax;
@@ -638,13 +638,23 @@ let runScript = (proj: Project.t, script, args, ()) => {
             |> addArgs(scriptArgs)
             |> addArgs(args)
           );
-        return(cmd);
+
+          let cwd = Some(
+            Scope.(
+              rootPath(scope)
+              |> SandboxPath.toValue
+              |> SandboxValue.render(proj.buildCfg)
+            )
+          );
+        
+        return((cmd, cwd));
       },
     );
 
   let%bind status =
     ChildProcess.runToStatus(
       ~resolveProgramInEnv=true,
+      ~cwd?,
       ~stderr=`FD_copy(Unix.stderr),
       ~stdout=`FD_copy(Unix.stdout),
       ~stdin=`FD_copy(Unix.stdin),

--- a/esy-lib/ChildProcess.re
+++ b/esy-lib/ChildProcess.re
@@ -155,7 +155,7 @@ let run =
 };
 
 let runToStatus =
-    (~env=?, ~resolveProgramInEnv=?, ~stdin=?, ~stdout=?, ~stderr=?, cmd) => {
+    (~env=?, ~resolveProgramInEnv=?, ~cwd=?, ~stdin=?, ~stdout=?, ~stderr=?, cmd) => {
   open RunAsync.Syntax;
   let f = process => {
     let%lwt status = process#status;
@@ -165,6 +165,7 @@ let runToStatus =
   withProcess(
     ~env?,
     ~resolveProgramInEnv?,
+    ~cwd?,
     ~stdin?,
     ~stdout?,
     ~stderr?,

--- a/esy-lib/ChildProcess.re
+++ b/esy-lib/ChildProcess.re
@@ -155,7 +155,15 @@ let run =
 };
 
 let runToStatus =
-    (~env=?, ~resolveProgramInEnv=?, ~cwd=?, ~stdin=?, ~stdout=?, ~stderr=?, cmd) => {
+    (
+      ~env=?,
+      ~resolveProgramInEnv=?,
+      ~cwd=?,
+      ~stdin=?,
+      ~stdout=?,
+      ~stderr=?,
+      cmd,
+    ) => {
   open RunAsync.Syntax;
   let f = process => {
     let%lwt status = process#status;

--- a/esy-lib/ChildProcess.rei
+++ b/esy-lib/ChildProcess.rei
@@ -42,6 +42,7 @@ let runToStatus:
   (
     ~env: env=?,
     ~resolveProgramInEnv: bool=?,
+    ~cwd: string=?,
     ~stdin: Lwt_process.redirection=?,
     ~stdout: Lwt_process.redirection=?,
     ~stderr: Lwt_process.redirection=?,

--- a/test-e2e/common/scripts.test.js
+++ b/test-e2e/common/scripts.test.js
@@ -30,6 +30,7 @@ const fixture = [
       build_cmd4: "esy build bash -c 'echo 'build_cmd_result''",
       build_cmd5: 'esy build echo #{self.name}',
       build_cmd6: [['esy', 'build', 'echo', '#{self.name}']],
+      printpwd: "pwd",
     },
     esy: {
       build: [
@@ -61,7 +62,8 @@ const fixture = [
         build: 'true'
       }
     })
-  )
+  ),
+  dir('foo')
 ];
 
 it('executes scripts', async () => {
@@ -139,3 +141,14 @@ it('does execute scripts in a non-root package scope', async () => {
     message: expect.stringMatching('error: unable to resolve command: cmd1')
   });
 });
+
+it('executes script in the package\'s root', async () => {
+  const p = await createTestSandbox(...fixture);
+  await p.esy('install');
+  await p.esy('build');
+  p.cd("foo");
+  const cmd = await p.esy('printpwd');
+  const splitPath = cmd.stdout.split("/");
+  const folderName = splitPath[splitPath.length - 1];
+  expect(folderName).toEqual(expect.not.stringMatching(/foo/));
+})


### PR DESCRIPTION
Fixes #879, scripts should be always executed from the package's root.

I checked that the test passes in after the modification, but not before.