### PR TITLE
Mark lock files as generated

### DIFF
--- a/esy-install/SolutionLock.re
+++ b/esy-install/SolutionLock.re
@@ -54,7 +54,7 @@ let indexFilename = "index.json";
 
 let gitAttributesContents = {|
 # Set eol to LF so files aren't converted to CRLF-eol on Windows.
-* text eol=lf
+* text eol=lf linguist-generated
 |};
 
 let gitIgnoreContents = {|


### PR DESCRIPTION
To reduce the size of the diff displayed by github, the files in `esy.lock` should be marked as generated.