### PR TITLE
Try to fix release-postinstall.js for Windows

### DIFF
--- a/scripts/release-postinstall.js
+++ b/scripts/release-postinstall.js
@@ -124,7 +124,7 @@ switch (platform) {
     copyPlatformBinaries('win32');
 
     console.log('Installing native compiler toolchain for Windows...');
-    cp.execSync(`npm install esy-bash@0.3.16 --prefix ${__dirname}`);
+    cp.execSync(`npm install esy-bash@0.3.16 --prefix "${__dirname}"`);
     console.log('Native compiler toolchain installed successfully.');
     break;
   case 'linux':


### PR DESCRIPTION
Add quotes around the path used as the --prefix for esy-bash so that paths that contain spaces work as expected

This should fix #897 