### PR TITLE
Keep .git folder on pining

### DIFF
--- a/esy-install/DistStorage.re
+++ b/esy-install/DistStorage.re
@@ -119,7 +119,6 @@ let fetch' = (sandbox, dist) => {
         let%bind () = Fs.createDir(stagePath);
         let%bind () = Git.clone(~dst=stagePath, ~remote=git.remote, ());
         let%bind () = Git.checkout(~ref=git.commit, ~repo=stagePath, ());
-        let%bind () = Fs.rmPath(Path.(stagePath / ".git"));
         let%bind () = Fs.rename(~src=stagePath, path);
         return(Path(path));
       },

--- a/esy-install/DistStorage.re
+++ b/esy-install/DistStorage.re
@@ -95,18 +95,16 @@ let fetch' = (sandbox, dist) => {
       ~tempPath,
       stagePath => {
         let%bind () = Fs.createDir(stagePath);
-        let tarballPath = Path.(stagePath / "archive.tgz");
-        let url =
+        let remote =
           Printf.sprintf(
-            "https://api.github.com/repos/%s/%s/tarball/%s",
+            "https://github.com/%s/%s.git",
             github.user,
             github.repo,
-            github.commit,
           );
-
-        let%bind () = Curl.download(~output=tarballPath, url);
-        let%bind () = Fs.rename(~src=tarballPath, path);
-        return(Tarball({tarballPath: path, stripComponents: 1}));
+        let%bind () = Git.clone(~dst=stagePath, ~remote, ());
+        let%bind () = Git.checkout(~ref=github.commit, ~repo=stagePath, ());
+        let%bind () = Fs.rename(~src=stagePath, path);
+        return(Path(path));
       },
     );
 


### PR DESCRIPTION
When using a github resolution / dependency, the `.git` folder is kept, as it is done by opam.
Fixes #902, but should only be merged if discussion concludes that it should be done

PS: I didn't really test this on ocamlformat that raised the issue in the first place, because somehow I can't get my dev version of `esy` to resolve the path to `esySolveCudfCommand.exe` anymore...