### PR TITLE
Encode constraints for the CUDF solver

### DIFF
--- a/esy-package-config/VersionBase.re
+++ b/esy-package-config/VersionBase.re
@@ -22,7 +22,6 @@ module type CONSTRAINT = {
     | GTE(version)
     | LT(version)
     | LTE(version)
-    | NONE
     | ANY;
 
   include S.COMMON with type t := t;
@@ -91,7 +90,6 @@ module Constraint = {
       | GTE(Version.t)
       | LT(Version.t)
       | LTE(Version.t)
-      | NONE
       | ANY;
 
     let pp = fmt =>
@@ -102,7 +100,6 @@ module Constraint = {
       | GTE(v) => Fmt.pf(fmt, ">=%a", Version.pp, v)
       | LT(v) => Fmt.pf(fmt, "<%a", Version.pp, v)
       | LTE(v) => Fmt.pf(fmt, "<=%a", Version.pp, v)
-      | NONE => Fmt.pf(fmt, "NONE")
       | ANY => Fmt.pf(fmt, "*");
 
     let matchesSimple = (~version, constr) =>
@@ -110,7 +107,6 @@ module Constraint = {
       | EQ(a) => Version.compare(a, version) == 0
       | NEQ(a) => Version.compare(a, version) !== 0
       | ANY => true
-      | NONE => false
 
       | GT(a) => Version.compare(a, version) < 0
       | GTE(a) => Version.compare(a, version) <= 0
@@ -122,7 +118,6 @@ module Constraint = {
       switch (Version.prerelease(version), constr) {
       | (_, EQ(_))
       | (_, NEQ(_))
-      | (_, NONE)
       | (false, ANY)
       | (false, GT(_))
       | (false, GTE(_))
@@ -148,7 +143,6 @@ module Constraint = {
       | EQ(a) => EQ(f(a))
       | NEQ(a) => NEQ(f(a))
       | ANY => ANY
-      | NONE => NONE
       | GT(a) => GT(f(a))
       | GTE(a) => GTE(f(a))
       | LT(a) => LT(f(a))
@@ -199,7 +193,6 @@ module Formula = {
           let matchPrerelease = {
             let f = vs =>
               fun
-              | Constraint.NONE
               | Constraint.ANY => vs
               | Constraint.EQ(v)
               | Constraint.NEQ(v)
@@ -308,7 +301,6 @@ module Formula = {
           let matchPrerelease = {
             let f = vs =>
               fun
-              | Constraint.NONE
               | Constraint.ANY => vs
               | Constraint.EQ(v)
               | Constraint.NEQ(v)

--- a/esy-package-config/VersionBase.rei
+++ b/esy-package-config/VersionBase.rei
@@ -35,7 +35,6 @@ module type CONSTRAINT = {
     | GTE(version)
     | LT(version)
     | LTE(version)
-    | NONE
     | ANY;
 
   include S.COMMON with type t := t;

--- a/esy-solve/Resolver.re
+++ b/esy-solve/Resolver.re
@@ -165,6 +165,15 @@ let sourceMatchesSpec = (resolver, spec, source) =>
   | None => false
   };
 
+let versionByNpmDistTag = (resolver: t, package: string, tag: string) =>
+  switch (Hashtbl.find_opt(resolver.npmDistTags, package)) {
+  | None => None
+  | Some(tags) => StringMap.find_opt(tag, tags)
+  };
+
+let sourceBySpec = (resolver: t, spec: SourceSpec.t) =>
+  Hashtbl.find_opt(resolver.sourceSpecToSource, spec);
+
 let versionMatchesReq = (resolver: t, req: Req.t, name, version: Version.t) => {
   let checkVersion = () =>
     switch (req.spec, version) {

--- a/esy-solve/Resolver.rei
+++ b/esy-solve/Resolver.rei
@@ -32,5 +32,9 @@ let package:
   (~resolution: Resolution.t, t) =>
   RunAsync.t(result(InstallManifest.t, string));
 
+let versionByNpmDistTag:
+  (t, string, string) => option(SemverVersion.Version.t);
+let sourceBySpec: (t, SourceSpec.t) => option(Source.t);
+
 let versionMatchesReq: (t, Req.t, string, Version.t) => bool;
 let versionMatchesDep: (t, InstallManifest.Dep.t, string, Version.t) => bool;

--- a/esy-solve/Resolver.rei
+++ b/esy-solve/Resolver.rei
@@ -35,6 +35,8 @@ let package:
 let versionByNpmDistTag:
   (t, string, string) => option(SemverVersion.Version.t);
 let sourceBySpec: (t, SourceSpec.t) => option(Source.t);
+let getResolutions: t => Resolutions.t;
+let getVersionByResolutions: (t, string) => option(Version.t);
 
 let versionMatchesReq: (t, Req.t, string, Version.t) => bool;
 let versionMatchesDep: (t, InstallManifest.Dep.t, string, Version.t) => bool;

--- a/esy-solve/Universe.re
+++ b/esy-solve/Universe.re
@@ -225,34 +225,6 @@ module CudfMapping = {
     Cudf.lookup_package(cudfUniv, (CudfName.show(cudfName), cudfVersion));
   };
 
-  let _encodeDepExn = (~name, ~matches, (univ, _cudfUniv, vmap)) => {
-    let versions = findVersions(~name, univ);
-
-    let versionsMatched = List.filter(~f=matches, versions);
-
-    switch (versionsMatched) {
-    | [] => [
-        (CudfName.show(CudfName.encode(name)), Some((`Eq, 100000000))),
-      ]
-    | versionsMatched =>
-      let pkgToConstraint = pkg => {
-        let cudfVersion =
-          CudfVersionMap.findCudfVersionExn(
-            ~name=pkg.InstallManifest.name,
-            ~version=pkg.InstallManifest.version,
-            vmap,
-          );
-
-        (
-          CudfName.show(CudfName.encode(pkg.InstallManifest.name)),
-          Some((`Eq, cudfVersion)),
-        );
-      };
-
-      List.map(~f=pkgToConstraint, versionsMatched);
-    };
-  };
-
   let univ = ((univ, _, _)) => univ;
   let cudfUniv = ((_, cudfUniv, _)) => cudfUniv;
 };

--- a/esy-solve/Universe.re
+++ b/esy-solve/Universe.re
@@ -263,15 +263,78 @@ let toCudf = (~installed=InstallManifest.Set.empty, solvespec, univ) => {
 
   let buildVersionMap = () => {
     let allVersions = ref(StringMap.empty);
+    let sourceVersions = ref(StringMap.empty);
+
     let addVersion = (name, version) => {
       let versions =
         switch (StringMap.find_opt(name, allVersions^)) {
         | Some(versions) => versions
         | None => Version.Set.empty
         };
-      allVersions :=
-        StringMap.add(name, Version.Set.add(version, versions), allVersions^);
+      switch (StringMap.find_opt(name, sourceVersions^)) {
+      | Some(_) =>
+        failwith("Conflict: source & normal version. TODO: better reporting")
+      | None =>
+        allVersions :=
+          StringMap.add(
+            name,
+            Version.Set.add(version, versions),
+            allVersions^,
+          )
+      };
     };
+
+    let addSourceVersion = (name, source: Source.t) =>
+      switch (StringMap.find_opt(name, allVersions^)) {
+      | Some(_) =>
+        failwith("Conflict: source & normal version. TODO: better reporting")
+      | None =>
+        switch (StringMap.find_opt(name, sourceVersions^)) {
+        | Some(source') =>
+          if (Source.compare(source, source') != 0) {
+            failwith(
+              "different source versions for one package. TODO: better reporting",
+            );
+          }
+        | None =>
+          sourceVersions := StringMap.add(name, source, sourceVersions^)
+        }
+      };
+
+    let addNpmConstraint = (name, constr: SemverVersion.Constraint.t) =>
+      switch (constr) {
+      | EQ(version)
+      | NEQ(version)
+      | GT(version)
+      | GTE(version)
+      | LT(version)
+      | LTE(version) => addVersion(name, Version.Npm(version))
+      | ANY => ()
+      };
+
+    let addOpamConstraint = (name, constr: OpamPackageVersion.Constraint.t) =>
+      switch (constr) {
+      | EQ(version)
+      | NEQ(version)
+      | GT(version)
+      | GTE(version)
+      | LT(version)
+      | LTE(version) => addVersion(name, Version.Opam(version))
+      | ANY => ()
+      };
+
+    let addNpmDistTag = (name, tag) =>
+      switch (Resolver.versionByNpmDistTag(univ.resolver, name, tag)) {
+      | None => failwith("invalid npm-dist-tag, TODO: better error reporting")
+      | Some(version) => addNpmConstraint(name, EQ(version))
+      };
+
+    let addSourcePackage = (name, spec: SourceSpec.t) =>
+      switch (Resolver.sourceBySpec(univ.resolver, spec)) {
+      | None =>
+        failwith("cannot find source by spec, TODO: better error reporting")
+      | Some(source) => addSourceVersion(name, source)
+      };
 
     StringMap.iter(
       (name, versions) =>
@@ -285,41 +348,36 @@ let toCudf = (~installed=InstallManifest.Set.empty, solvespec, univ) => {
               | Ok(dependencies) => dependencies
               };
             switch (dependencies) {
-            | Dependencies.OpamFormula(_) => ()
+            | Dependencies.OpamFormula(deps) =>
+              List.flatten(deps)
+              |> List.iter(~f=(dep: InstallManifest.Dep.t) =>
+                   switch (dep.req) {
+                   | Npm(constr) => addNpmConstraint(dep.name, constr)
+                   | NpmDistTag(tag) => addNpmDistTag(dep.name, tag)
+                   | Opam(constr) => addOpamConstraint(dep.name, constr)
+                   | Source(spec) => addSourcePackage(dep.name, spec)
+                   }
+                 )
             | Dependencies.NpmFormula(reqs) =>
               List.iter(
                 ~f=
                   (req: Req.t) =>
                     switch (req.spec) {
-                    | VersionSpec.Npm(_) => failwith("npm!")
-                    | VersionSpec.NpmDistTag(_) =>
-                      /* TODO: use Resolver to get version */
-                      failwith("npm-dist-tag!")
+                    | VersionSpec.Npm(dep) =>
+                      List.flatten(dep)
+                      |> List.iter(~f=addNpmConstraint(req.name))
+                    | VersionSpec.NpmDistTag(tag) =>
+                      addNpmDistTag(req.name, tag)
                     | VersionSpec.Opam(dep) =>
-                      List.iter(
-                        ~f=
-                          constr =>
-                            switch (constr) {
-                            | OpamPackageVersion.Constraint.EQ(version)
-                            | NEQ(version)
-                            | GT(version)
-                            | GTE(version)
-                            | LT(version)
-                            | LTE(version) =>
-                              addVersion(req.name, Version.Opam(version))
-                            | ANY
-                            | NONE => ()
-                            },
-                        List.flatten(dep),
-                      )
-                    | VersionSpec.Source(_) =>
-                      /* TODO: use Resolver to map to Source.t */
-                      /* TODO: map (package_name, Source.t) to 1 version */
-                      failwith("source!")
+                      List.flatten(dep)
+                      |> List.iter(~f=addOpamConstraint(req.name))
+                    | VersionSpec.Source(spec) =>
+                      addSourcePackage(req.name, spec)
                     },
                 reqs,
               )
             };
+            ();
           },
           versions,
         ),
@@ -340,68 +398,90 @@ let toCudf = (~installed=InstallManifest.Set.empty, solvespec, univ) => {
       },
       allVersions^,
     );
+
+    StringMap.iter(
+      (name, source) =>
+        CudfVersionMap.update(
+          cudfVersionMap,
+          name,
+          Version.Source(source),
+          1,
+        ),
+      sourceVersions^,
+    );
   };
 
   let encodeOpamDep = (dep: InstallManifest.Dep.t) => {
-    let _getCudfVersion = (name, version) =>
-      CudfVersionMap.findCudfVersionExn(
-        ~name,
-        ~version=Version.Opam(version),
-        cudfVersionMap,
-      );
+    let v = (constr, version) => (
+      dep.name,
+      Some((
+        constr,
+        CudfVersionMap.findCudfVersionExn(
+          ~name=dep.name,
+          ~version,
+          cudfVersionMap,
+        ),
+      )),
+    );
     switch (dep.req) {
-    | InstallManifest.Dep.Npm(req) =>
+    | Npm(req) =>
       switch (req) {
-      | SemverVersion.Constraint.EQ(_) => failwith("npm:eq!")
-      | NEQ(_) => failwith("npm:neq!")
-      | GT(_) => failwith("npm:gt!")
-      | GTE(_) => failwith("npm:gte!")
-      | LT(_) => failwith("npm:lt!")
-      | LTE(_) => failwith("npm:lte!")
-      | NONE => failwith("npm:remove NONE!")
-      | ANY => [(dep.name, None)]
+      | EQ(version) => v(`Eq, Npm(version))
+      | NEQ(version) => v(`Neq, Npm(version))
+      | GT(version) => v(`Gt, Npm(version))
+      | GTE(version) => v(`Geq, Npm(version))
+      | LT(version) => v(`Lt, Npm(version))
+      | LTE(version) => v(`Leq, Npm(version))
+      | ANY => (dep.name, None)
       }
-    | InstallManifest.Dep.NpmDistTag(_) => failwith("npm-dist-tag!")
-    | InstallManifest.Dep.Opam(dep) =>
-      switch (dep) {
-      | OpamPackageVersion.Constraint.EQ(_version) => failwith("eq!")
-      | OpamPackageVersion.Constraint.NEQ(_version) => failwith("neq!")
-      | OpamPackageVersion.Constraint.GT(_version) => failwith("gt!")
-      | OpamPackageVersion.Constraint.GTE(_version) => failwith("gte!")
-      | OpamPackageVersion.Constraint.LT(_version) => failwith("lt!")
-      | OpamPackageVersion.Constraint.LTE(_version) => failwith("lte!")
-      | _ => failwith("other")
+    | NpmDistTag(tag) =>
+      switch (Resolver.versionByNpmDistTag(univ.resolver, dep.name, tag)) {
+      | None =>
+        failwith("cannot resolve npm-dist-tag, TODO: better reporting")
+      | Some(version) => v(`Eq, Npm(version))
       }
-    | InstallManifest.Dep.Source(_) => failwith("source!")
+    | Opam(odep) =>
+      switch (odep) {
+      | EQ(version) => v(`Eq, Opam(version))
+      | NEQ(version) => v(`Neq, Opam(version))
+      | GT(version) => v(`Gt, Opam(version))
+      | GTE(version) => v(`Geq, Opam(version))
+      | LT(version) => v(`Lt, Opam(version))
+      | LTE(version) => v(`Leq, Opam(version))
+      | ANY => (dep.name, None)
+      }
+    | Source(spec) =>
+      switch (Resolver.sourceBySpec(univ.resolver, spec)) {
+      | None =>
+        failwith("Cannot locate source by spec, TODO: better reporting")
+      | Some(source) => v(`Eq, Source(source))
+      }
     };
   };
 
   let encodeNpmReq = (req: Req.t) => {
     switch (req.spec) {
-    | VersionSpec.Npm(_) => failwith("npm!")
-    | VersionSpec.NpmDistTag(_) => failwith("npm-dist-tag!")
-    | VersionSpec.Opam(dep) =>
+    | Npm(dep) =>
       let v = (constr, version) => (
         req.name,
         Some((
           constr,
           CudfVersionMap.findCudfVersionExn(
             ~name=req.name,
-            ~version=Version.Opam(version),
+            ~version=Version.Npm(version),
             cudfVersionMap,
           ),
         )),
       );
-      let encConstr = constr =>
+      let encConstr = (constr: SemverVersion.Constraint.t) =>
         switch (constr) {
-        | OpamPackageVersion.Constraint.EQ(version) => v(`Eq, version)
+        | EQ(version) => v(`Eq, version)
         | NEQ(version) => v(`Neq, version)
         | GT(version) => v(`Gt, version)
         | GTE(version) => v(`Geq, version)
         | LT(version) => v(`Lt, version)
         | LTE(version) => v(`Leq, version)
         | ANY => (req.name, None)
-        | NONE => failwith("remove NONE!")
         };
       let rec encOr = ands =>
         switch (ands) {
@@ -419,7 +499,72 @@ let toCudf = (~installed=InstallManifest.Set.empty, solvespec, univ) => {
           );
         };
       encOr(dep);
-    | VersionSpec.Source(_) => failwith("source!")
+
+    | NpmDistTag(tag) =>
+      switch (Resolver.versionByNpmDistTag(univ.resolver, req.name, tag)) {
+      | None =>
+        failwith("cannot resolve npm-dist-tag, TODO: better reporting")
+      | Some(version) =>
+        let version =
+          CudfVersionMap.findCudfVersionExn(
+            ~name=req.name,
+            ~version=Version.Npm(version),
+            cudfVersionMap,
+          );
+        [[(req.name, Some((`Eq, version)))]];
+      }
+
+    | Opam(dep) =>
+      let v = (constr, version) => (
+        req.name,
+        Some((
+          constr,
+          CudfVersionMap.findCudfVersionExn(
+            ~name=req.name,
+            ~version=Version.Opam(version),
+            cudfVersionMap,
+          ),
+        )),
+      );
+      let encConstr = (constr: OpamPackageVersion.Constraint.t) =>
+        switch (constr) {
+        | EQ(version) => v(`Eq, version)
+        | NEQ(version) => v(`Neq, version)
+        | GT(version) => v(`Gt, version)
+        | GTE(version) => v(`Geq, version)
+        | LT(version) => v(`Lt, version)
+        | LTE(version) => v(`Leq, version)
+        | ANY => (req.name, None)
+        };
+      let rec encOr = ands =>
+        switch (ands) {
+        | [] => [[]]
+        | [[], ...rest] => encOr(rest)
+        | [expr, ...rest] =>
+          let rest = encOr(rest);
+          List.fold_left(
+            ~f=
+              (acc, constr) =>
+                acc
+                @ List.map(~f=expr => [encConstr(constr), ...expr], rest),
+            ~init=[],
+            expr,
+          );
+        };
+      encOr(dep);
+    | Source(spec) =>
+      switch (Resolver.sourceBySpec(univ.resolver, spec)) {
+      | None =>
+        failwith("Cannot locate source by spec, TODO: better reporting")
+      | Some(source) =>
+        let version =
+          CudfVersionMap.findCudfVersionExn(
+            ~name=req.name,
+            ~version=Version.Source(source),
+            cudfVersionMap,
+          );
+        [[(req.name, Some((`Eq, version)))]];
+      }
     };
   };
 
@@ -428,22 +573,20 @@ let toCudf = (~installed=InstallManifest.Set.empty, solvespec, univ) => {
   // - outer lists are AND-ed
   let encodeDeps = (deps: Dependencies.t) =>
     switch (deps) {
-    // deps is CNF
-    | InstallManifest.Dependencies.OpamFormula(deps) =>
-      let f = deps => {
-        let f = (deps, dep) => deps @ encodeOpamDep(dep);
-        List.fold_left(~f, ~init=[], deps);
-      };
-
+    | OpamFormula(deps) =>
+      // deps is CNF
+      let f = List.map(~f=encodeOpamDep);
       List.map(~f, deps);
-    // reqs is CNF
-    | InstallManifest.Dependencies.NpmFormula(reqs) =>
+    | NpmFormula(reqs) =>
+      // reqs is CNF
+
       /* Only considering packages which have esy.json / esy config */
       let reqs = {
         let f = (req: Req.t) => StringMap.mem(req.name, univ.pkgs);
         List.filter(~f, reqs);
       };
 
+      // one req is DNF
       List.fold_left(
         ~f=(acc, req) => acc @ encodeNpmReq(req),
         ~init=[],

--- a/test-e2e/common/__snapshots__/solve.test.js.snap
+++ b/test-e2e/common/__snapshots__/solve.test.js.snap
@@ -1,0 +1,183 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`esy solve LE "<1.5.0" for: 1.0.0, 1.5.0 1`] = `
+"preamble: 
+property: staleness: int, original-version: string
+
+package: @esy-ocaml/substs
+version: 1
+conflicts: @esy-ocaml/substs
+staleness: 0
+original-version: 1.0.0
+
+package: @opam/pkg
+version: 1
+depends: @esy-ocaml/substs
+conflicts: @opam/pkg
+staleness: 1
+original-version: opam:1.0.0
+
+package: root
+version: 1
+depends: @opam/pkg < 2
+conflicts: root
+staleness: 0
+original-version: 0.0.0
+
+request: 
+install: root = 1"
+`;
+
+exports[`esy solve LE "<2.0.0" for: 1.0.0, 1.5.0 1`] = `
+"preamble: 
+property: staleness: int, original-version: string
+
+package: @esy-ocaml/substs
+version: 1
+conflicts: @esy-ocaml/substs
+staleness: 0
+original-version: 1.0.0
+
+package: @opam/pkg
+version: 1
+depends: @esy-ocaml/substs
+conflicts: @opam/pkg
+staleness: 2
+original-version: opam:1.0.0
+
+package: @opam/pkg
+version: 2
+depends: @esy-ocaml/substs
+conflicts: @opam/pkg
+staleness: 1
+original-version: opam:1.5.0
+
+package: root
+version: 1
+depends: @opam/pkg < 3
+conflicts: root
+staleness: 0
+original-version: 0.0.0
+
+request: 
+install: root = 1"
+`;
+
+exports[`esy solve LE "1-3 || 6 - 9" 1`] = `
+"preamble: 
+property: staleness: int, original-version: string
+
+package: @esy-ocaml/substs
+version: 1
+conflicts: @esy-ocaml/substs
+staleness: 0
+original-version: 1.0.0
+
+package: @opam/pkg
+version: 1
+depends: @esy-ocaml/substs
+conflicts: @opam/pkg
+staleness: 8
+original-version: opam:1.0.0
+
+package: @opam/pkg
+version: 2
+depends: @esy-ocaml/substs
+conflicts: @opam/pkg
+staleness: 7
+original-version: opam:2.0.0
+
+package: @opam/pkg
+version: 3
+depends: @esy-ocaml/substs
+conflicts: @opam/pkg
+staleness: 6
+original-version: opam:3.0.0
+
+package: @opam/pkg
+version: 5
+depends: @esy-ocaml/substs
+conflicts: @opam/pkg
+staleness: 4
+original-version: opam:6.0.0
+
+package: @opam/pkg
+version: 6
+depends: @esy-ocaml/substs
+conflicts: @opam/pkg
+staleness: 3
+original-version: opam:7.0.0
+
+package: @opam/pkg
+version: 7
+depends: @esy-ocaml/substs
+conflicts: @opam/pkg
+staleness: 2
+original-version: opam:8.0.0
+
+package: @opam/pkg
+version: 8
+depends: @esy-ocaml/substs
+conflicts: @opam/pkg
+staleness: 1
+original-version: opam:9.0.0
+
+package: root
+version: 1
+depends: @opam/pkg >= 1 | @opam/pkg > 4 , @opam/pkg >= 1 | @opam/pkg < 9 , @opam/pkg <= 3 | @opam/pkg > 4 , @opam/pkg <= 3 | @opam/pkg < 9
+conflicts: root
+staleness: 0
+original-version: 0.0.0
+
+request: 
+install: root = 1"
+`;
+
+exports[`esy solve dumps CUDF input & output to files on disk 1`] = `
+"preamble: 
+property: staleness: int, original-version: string
+
+package: root
+version: 1
+conflicts: root
+staleness: 0
+original-version: 0.0.0
+
+request: 
+install: root = 1"
+`;
+
+exports[`esy solve dumps CUDF input & output to files on disk 2`] = `
+"preamble: 
+property: staleness: int, original-version: string
+
+package: root
+version: 1
+conflicts: root
+installed: true
+original-version: 0.0.0
+staleness: 0"
+`;
+
+exports[`esy solve dumps CUDF input & output to stdout 1`] = `
+"preamble: 
+property: staleness: int, original-version: string
+
+package: root
+version: 1
+conflicts: root
+staleness: 0
+original-version: 0.0.0
+
+request: 
+install: root = 1
+preamble: 
+property: staleness: int, original-version: string
+
+package: root
+version: 1
+conflicts: root
+installed: true
+original-version: 0.0.0
+staleness: 0"
+`;

--- a/test-e2e/common/__snapshots__/solve.test.js.snap
+++ b/test-e2e/common/__snapshots__/solve.test.js.snap
@@ -1,6 +1,112 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`esy solve LE "<1.5.0" for: 1.0.0, 1.5.0 1`] = `
+exports[`Dumps CUDF ...to files on disk 1`] = `
+"preamble: 
+property: staleness: int, original-version: string
+
+package: root
+version: 1
+conflicts: root
+staleness: 0
+original-version: 0.0.0
+
+request: 
+install: root = 1"
+`;
+
+exports[`Dumps CUDF ...to files on disk 2`] = `
+"preamble: 
+property: staleness: int, original-version: string
+
+package: root
+version: 1
+conflicts: root
+installed: true
+original-version: 0.0.0
+staleness: 0"
+`;
+
+exports[`Dumps CUDF ...to stdout 1`] = `
+"preamble: 
+property: staleness: int, original-version: string
+
+package: root
+version: 1
+conflicts: root
+staleness: 0
+original-version: 0.0.0
+
+request: 
+install: root = 1
+preamble: 
+property: staleness: int, original-version: string
+
+package: root
+version: 1
+conflicts: root
+installed: true
+original-version: 0.0.0
+staleness: 0"
+`;
+
+exports[`NPM depends on NPM "1 - 3 || 6 - 9" for 1 - 10 1`] = `
+"preamble: 
+property: staleness: int, original-version: string
+
+package: pkg
+version: 1
+conflicts: pkg
+staleness: 8
+original-version: 1.0.0
+
+package: pkg
+version: 2
+conflicts: pkg
+staleness: 7
+original-version: 2.0.0
+
+package: pkg
+version: 3
+conflicts: pkg
+staleness: 6
+original-version: 3.0.0
+
+package: pkg
+version: 5
+conflicts: pkg
+staleness: 4
+original-version: 6.0.0
+
+package: pkg
+version: 6
+conflicts: pkg
+staleness: 3
+original-version: 7.0.0
+
+package: pkg
+version: 7
+conflicts: pkg
+staleness: 2
+original-version: 8.0.0
+
+package: pkg
+version: 8
+conflicts: pkg
+staleness: 1
+original-version: 9.0.0
+
+package: root
+version: 1
+depends: pkg >= 1 | pkg > 4 , pkg >= 1 | pkg < 9 , pkg <= 3 | pkg > 4 , pkg <= 3 | pkg < 9
+conflicts: root
+staleness: 0
+original-version: 0.0.0
+
+request: 
+install: root = 1"
+`;
+
+exports[`NPM depends on OPAM "<2" for: 1, 2 1`] = `
 "preamble: 
 property: staleness: int, original-version: string
 
@@ -28,7 +134,7 @@ request:
 install: root = 1"
 `;
 
-exports[`esy solve LE "<2.0.0" for: 1.0.0, 1.5.0 1`] = `
+exports[`NPM depends on OPAM "<3" for: 1, 2 1`] = `
 "preamble: 
 property: staleness: int, original-version: string
 
@@ -50,7 +156,7 @@ version: 2
 depends: @esy-ocaml/substs
 conflicts: @opam/pkg
 staleness: 1
-original-version: opam:1.5.0
+original-version: opam:2.0.0
 
 package: root
 version: 1
@@ -63,7 +169,7 @@ request:
 install: root = 1"
 `;
 
-exports[`esy solve LE "1-3 || 6 - 9" 1`] = `
+exports[`NPM depends on OPAM "1 - 3 || 6 - 9" for 1 - 10 1`] = `
 "preamble: 
 property: staleness: int, original-version: string
 
@@ -133,51 +239,100 @@ request:
 install: root = 1"
 `;
 
-exports[`esy solve dumps CUDF input & output to files on disk 1`] = `
+exports[`OPAM depends on OPAM 2 - 8 for 1 - 10 1`] = `
 "preamble: 
 property: staleness: int, original-version: string
 
+package: @esy-ocaml/substs
+version: 1
+conflicts: @esy-ocaml/substs
+staleness: 0
+original-version: 1.0.0
+
+package: @opam/pkg
+version: 1
+depends: @esy-ocaml/substs
+conflicts: @opam/pkg
+staleness: 11
+original-version: opam:1.0.0
+
+package: @opam/pkg
+version: 3
+depends: @esy-ocaml/substs
+conflicts: @opam/pkg
+staleness: 9
+original-version: opam:2.0.0
+
+package: @opam/pkg
+version: 4
+depends: @esy-ocaml/substs
+conflicts: @opam/pkg
+staleness: 8
+original-version: opam:3.0.0
+
+package: @opam/pkg
+version: 5
+depends: @esy-ocaml/substs
+conflicts: @opam/pkg
+staleness: 7
+original-version: opam:4.0.0
+
+package: @opam/pkg
+version: 6
+depends: @esy-ocaml/substs
+conflicts: @opam/pkg
+staleness: 6
+original-version: opam:5.0.0
+
+package: @opam/pkg
+version: 7
+depends: @esy-ocaml/substs
+conflicts: @opam/pkg
+staleness: 5
+original-version: opam:6.0.0
+
+package: @opam/pkg
+version: 8
+depends: @esy-ocaml/substs
+conflicts: @opam/pkg
+staleness: 4
+original-version: opam:7.0.0
+
+package: @opam/pkg
+version: 10
+depends: @esy-ocaml/substs
+conflicts: @opam/pkg
+staleness: 2
+original-version: opam:8.0.0
+
+package: @opam/pkg
+version: 11
+depends: @esy-ocaml/substs
+conflicts: @opam/pkg
+staleness: 1
+original-version: opam:9.0.0
+
+package: @opam/pkg
+version: 12
+depends: @esy-ocaml/substs
+conflicts: @opam/pkg
+staleness: 0
+original-version: opam:10.0.0
+
+package: @opam/x
+version: 1
+depends: @opam/pkg >= 2 , @opam/pkg <= 9 , @esy-ocaml/substs
+conflicts: @opam/x
+staleness: 0
+original-version: opam:1.0.0
+
 package: root
 version: 1
+depends: @opam/x
 conflicts: root
 staleness: 0
 original-version: 0.0.0
 
 request: 
 install: root = 1"
-`;
-
-exports[`esy solve dumps CUDF input & output to files on disk 2`] = `
-"preamble: 
-property: staleness: int, original-version: string
-
-package: root
-version: 1
-conflicts: root
-installed: true
-original-version: 0.0.0
-staleness: 0"
-`;
-
-exports[`esy solve dumps CUDF input & output to stdout 1`] = `
-"preamble: 
-property: staleness: int, original-version: string
-
-package: root
-version: 1
-conflicts: root
-staleness: 0
-original-version: 0.0.0
-
-request: 
-install: root = 1
-preamble: 
-property: staleness: int, original-version: string
-
-package: root
-version: 1
-conflicts: root
-installed: true
-original-version: 0.0.0
-staleness: 0"
 `;

--- a/test-e2e/common/solve.test.js
+++ b/test-e2e/common/solve.test.js
@@ -7,6 +7,38 @@ const {version} = require('../../package.json');
 
 helpers.skipSuiteOnWindows('needs fixes for path pretty printing');
 
+async function createSandbox(config) {
+  const p = await helpers.createTestSandbox();
+
+  await p.defineNpmPackage({
+    name: '@esy-ocaml/substs',
+    version: '1.0.0',
+    esy: {},
+  });
+
+  let opamTemplate = {
+    opam: outdent`
+        opam-version: "2.0"
+      `,
+    url: null,
+  };
+
+  for (let i = 0, l = config.opam.length; i < l; i++) {
+    await p.defineOpamPackage({...opamTemplate, ...config.opam[i]});
+  }
+
+  await p.fixture(
+    packageJson({
+      name: 'root',
+      version: '1.0.0',
+      esy: {},
+      ...config.root,
+    }),
+  );
+
+  return Promise.resolve(p);
+}
+
 describe('esy solve', function() {
   it('dumps CUDF input & output to stdout', async () => {
     const p = await helpers.createTestSandbox();
@@ -23,28 +55,7 @@ describe('esy solve', function() {
     const res = await p.esy(
       'solve --dump-cudf-request=- --dump-cudf-solution=- --skip-repository-update',
     );
-    expect(res.stdout.trim()).toEqual(outdent`
-    preamble: 
-    property: staleness: int, original-version: string
-
-    package: root
-    version: 1
-    conflicts: root
-    staleness: 0
-    original-version: 0.0.0
-
-    request: 
-    install: root = 1
-    preamble: 
-    property: staleness: int, original-version: string
-
-    package: root
-    version: 1
-    conflicts: root
-    installed: true
-    original-version: 0.0.0
-    staleness: 0
-    `);
+    expect(res.stdout.trim()).toMatchSnapshot();
   });
 
   it('dumps CUDF input & output to files on disk', async () => {
@@ -67,34 +78,68 @@ describe('esy solve', function() {
       .readFileSync(path.join(p.projectPath, 'cudf.in'))
       .toString()
       .trim();
-    expect(cudfIn).toEqual(outdent`
-    preamble: 
-    property: staleness: int, original-version: string
-
-    package: root
-    version: 1
-    conflicts: root
-    staleness: 0
-    original-version: 0.0.0
-
-    request: 
-    install: root = 1
-    `);
+    expect(cudfIn).toMatchSnapshot();
 
     const cudfOut = fs
       .readFileSync(path.join(p.projectPath, 'cudf.out'))
       .toString()
       .trim();
-    expect(cudfOut).toEqual(outdent`
-    preamble: 
-    property: staleness: int, original-version: string
+    expect(cudfOut).toMatchSnapshot();
+  });
 
-    package: root
-    version: 1
-    conflicts: root
-    installed: true
-    original-version: 0.0.0
-    staleness: 0
-    `);
+  describe('LE', function() {
+    it('"<2.0.0" for: 1.0.0, 1.5.0', async () => {
+      const p = await createSandbox({
+        opam: [{name: 'pkg', version: '1.0.0'}, {name: 'pkg', version: '1.5.0'}],
+        root: {
+          dependencies: {
+            '@opam/pkg': '<2.0.0',
+          },
+        },
+      });
+
+      const res = await p.esy('solve --dump-cudf-request=- --skip-repository-update');
+      expect(res.stdout.trim()).toMatchSnapshot();
+      // console.log(res.stdout.trim())
+    });
+
+    it('"<1.5.0" for: 1.0.0, 1.5.0', async () => {
+      const p = await createSandbox({
+        opam: [{name: 'pkg', version: '1.0.0'}, {name: 'pkg', version: '1.5.0'}],
+        root: {
+          dependencies: {
+            '@opam/pkg': '<1.5.0',
+          },
+        },
+      });
+
+      const res = await p.esy('solve --dump-cudf-request=- --skip-repository-update');
+      expect(res.stdout.trim()).toMatchSnapshot();
+    });
+
+    it('"1-3 || 6 - 9"', async () => {
+      const p = await createSandbox({
+        opam: [
+          {name: 'pkg', version: '1.0.0'},
+          {name: 'pkg', version: '2.0.0'},
+          {name: 'pkg', version: '3.0.0'},
+          {name: 'pkg', version: '4.0.0'},
+          {name: 'pkg', version: '5.0.0'},
+          {name: 'pkg', version: '6.0.0'},
+          {name: 'pkg', version: '7.0.0'},
+          {name: 'pkg', version: '8.0.0'},
+          {name: 'pkg', version: '9.0.0'},
+          {name: 'pkg', version: '10.0.0'},
+        ],
+        root: {
+          dependencies: {
+            '@opam/pkg': '>=1.0.0 <=3.0.0 || >5.0.0 <10.0.0',
+          },
+        },
+      });
+
+      const res = await p.esy('solve --dump-cudf-request=- --skip-repository-update');
+      expect(res.stdout.trim()).toMatchSnapshot();
+    });
   });
 });


### PR DESCRIPTION
This PR fixes the #888. It should be functionally equivalent to the `master` version.
Few details on the implementation:
- First, we build the mapping (real version => CUDF version).
- While doing so, we consider all the versions mentioned in all the fields of interest (`version`, `dependencies`, `depends` in OPAM files).
- Then, we encode the `dependencies` rules using the mapping above and all the available CUDF operators.
- `Source` packages are encoded in a specific way by adding the `10_000_000` to the CUDF version
- Because of the rule above we have to make sure that source package will not be accidentally selected based on a *regular* constraint. Specifically, say the `pkg` is known to be `source` and we have the following *regular* constraint somewhere: `pkg > 1 | otherpkg = 1`. This case will be encoded as following (CNF): `(pkg > 1 | otherpkg = 1) & (pkg < 10_000_000 | otherpkg = 1)`
- Global *resolutions* are applied post factum to all the formulas. I.e. say that we have the CUDF formula `pkg > 1 | otherpkg = 1` and we have the *resolution* setting saying `pkg` should always be 10. In this case the formula submitted to CUDF solver is turned into: `pkg = 10 | otherpkg = 1`.

Overall, this framework unblocks the implementation of the `conflict` field handling in OPAM files.