### PR TITLE
Fix broken `esy x` command in getting-started.md

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -55,7 +55,7 @@ Use `esy x COMMAND` invocation to run project's built executable as if they are
 installed:
 
 ```shell
-esy x Hello.exe
+esy x Hello
 ```
 
 ## Rebuild the project


### PR DESCRIPTION
Looks like the hello-reason repo changed the command to run the example (likely [here](https://github.com/esy-ocaml/hello-reason/commit/766583c8761b110c8cdd94686af7d4bf74c78b5e)), so this page needs a minor update.

<img width="554" alt="Screen Shot 2019-04-26 at 8 12 17 PM" src="https://user-images.githubusercontent.com/25241/56844114-129dee80-6860-11e9-9747-1a3142b15472.png">
