### PR TITLE
Dependency: Update esy-bash to 0.3.19

### DIFF
--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "b48c633036870360a03e775a68303498",
+  "checksum": "3f8c5b4d67450459013654844ae75cab",
   "root": "esy@link-dev:./package.json",
   "node": {
     "yargs-parser@9.0.2@d41d8cd9": {
@@ -538,14 +538,14 @@
       ],
       "devDependencies": []
     },
-    "uglify-js@3.5.10@d41d8cd9": {
-      "id": "uglify-js@3.5.10@d41d8cd9",
+    "uglify-js@3.5.11@d41d8cd9": {
+      "id": "uglify-js@3.5.11@d41d8cd9",
       "name": "uglify-js",
-      "version": "3.5.10",
+      "version": "3.5.11",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.10.tgz#sha1:652bef39f86d9dbfd6674407ee05a5e2d372cf2d"
+          "archive:https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.11.tgz#sha1:833442c0aa29b3a7d34344c7c63adaa3f3504f6a"
         ]
       },
       "overrides": [],
@@ -1603,7 +1603,7 @@
         ]
       },
       "overrides": [],
-      "dependencies": [ "glob@7.1.3@d41d8cd9" ],
+      "dependencies": [ "glob@7.1.4@d41d8cd9" ],
       "devDependencies": []
     },
     "ret@0.1.15@d41d8cd9": {
@@ -4308,7 +4308,7 @@
         "jest-resolve@23.6.0@d41d8cd9", "jest-regex-util@23.3.0@d41d8cd9",
         "jest-jasmine2@23.6.0@d41d8cd9", "jest-get-type@22.4.3@d41d8cd9",
         "jest-environment-node@23.4.0@d41d8cd9",
-        "jest-environment-jsdom@23.4.0@d41d8cd9", "glob@7.1.3@d41d8cd9",
+        "jest-environment-jsdom@23.4.0@d41d8cd9", "glob@7.1.4@d41d8cd9",
         "chalk@2.4.2@d41d8cd9", "babel-jest@23.6.0@d41d8cd9",
         "babel-core@6.26.3@d41d8cd9"
       ],
@@ -4346,7 +4346,7 @@
         "istanbul-lib-coverage@1.2.1@d41d8cd9",
         "istanbul-api@1.3.7@d41d8cd9", "is-ci@1.2.1@d41d8cd9",
         "import-local@1.0.0@d41d8cd9", "graceful-fs@4.1.15@d41d8cd9",
-        "glob@7.1.3@d41d8cd9", "exit@0.1.2@d41d8cd9", "chalk@2.4.2@d41d8cd9",
+        "glob@7.1.4@d41d8cd9", "exit@0.1.2@d41d8cd9", "chalk@2.4.2@d41d8cd9",
         "ansi-escapes@3.2.0@d41d8cd9"
       ],
       "devDependencies": []
@@ -5469,7 +5469,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "uglify-js@3.5.10@d41d8cd9", "source-map@0.6.1@d41d8cd9",
+        "uglify-js@3.5.11@d41d8cd9", "source-map@0.6.1@d41d8cd9",
         "optimist@0.6.1@d41d8cd9", "neo-async@2.6.0@d41d8cd9"
       ],
       "devDependencies": []
@@ -5515,7 +5515,7 @@
       "overrides": [],
       "dependencies": [
         "pinkie-promise@2.0.1@d41d8cd9", "pify@2.3.0@d41d8cd9",
-        "object-assign@4.1.1@d41d8cd9", "glob@7.1.3@d41d8cd9",
+        "object-assign@4.1.1@d41d8cd9", "glob@7.1.4@d41d8cd9",
         "array-union@1.0.2@d41d8cd9"
       ],
       "devDependencies": []
@@ -5564,14 +5564,14 @@
       ],
       "devDependencies": []
     },
-    "glob@7.1.3@d41d8cd9": {
-      "id": "glob@7.1.3@d41d8cd9",
+    "glob@7.1.4@d41d8cd9": {
+      "id": "glob@7.1.4@d41d8cd9",
       "name": "glob",
-      "version": "7.1.3",
+      "version": "7.1.4",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/glob/-/glob-7.1.3.tgz#sha1:3960832d3f1574108342dafd3a67b332c0969df1"
+          "archive:https://registry.npmjs.org/glob/-/glob-7.1.4.tgz#sha1:aa608a2f6c577ad357e1ae5a5c26d9a8d1969255"
         ]
       },
       "overrides": [],
@@ -5909,7 +5909,7 @@
         ]
       },
       "overrides": [],
-      "dependencies": [ "minimatch@3.0.4@d41d8cd9", "glob@7.1.3@d41d8cd9" ],
+      "dependencies": [ "minimatch@3.0.4@d41d8cd9", "glob@7.1.4@d41d8cd9" ],
       "devDependencies": []
     },
     "filename-regex@2.0.1@d41d8cd9": {
@@ -6201,14 +6201,14 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "esy-bash@0.3.18@d41d8cd9": {
-      "id": "esy-bash@0.3.18@d41d8cd9",
+    "esy-bash@0.3.19@d41d8cd9": {
+      "id": "esy-bash@0.3.19@d41d8cd9",
       "name": "esy-bash",
-      "version": "0.3.18",
+      "version": "0.3.19",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/esy-bash/-/esy-bash-0.3.18.tgz#sha1:d4cf1cd7cfece6e15386bc820f0633b7f5e30364"
+          "archive:https://registry.npmjs.org/esy-bash/-/esy-bash-0.3.19.tgz#sha1:67f3ebeccea738f15153a628432ca50344913a3d"
         ]
       },
       "overrides": [],
@@ -6261,7 +6261,7 @@
         "klaw@2.1.1@d41d8cd9", "jest-pnp-resolver@1.2.1@d41d8cd9",
         "jest-junit@5.2.0@d41d8cd9", "jest-cli@23.6.0@d41d8cd9",
         "invariant@2.2.4@d41d8cd9", "fs-extra@7.0.1@d41d8cd9",
-        "flow-bin@0.77.0@d41d8cd9", "esy-bash@0.3.18@d41d8cd9",
+        "flow-bin@0.77.0@d41d8cd9", "esy-bash@0.3.19@d41d8cd9",
         "del@3.0.0@d41d8cd9", "babel-preset-flow@6.23.0@d41d8cd9",
         "babel-preset-env@1.7.0@d41d8cd9",
         "@opam/utop@github:ocaml-community/utop:utop.opam#5637c67@d41d8cd9",
@@ -6419,14 +6419,14 @@
       "dependencies": [ "once@1.4.0@d41d8cd9" ],
       "devDependencies": []
     },
-    "electron-to-chromium@1.3.131@d41d8cd9": {
-      "id": "electron-to-chromium@1.3.131@d41d8cd9",
+    "electron-to-chromium@1.3.133@d41d8cd9": {
+      "id": "electron-to-chromium@1.3.133@d41d8cd9",
       "name": "electron-to-chromium",
-      "version": "1.3.131",
+      "version": "1.3.133",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.131.tgz#sha1:205a0b7a276b3f56bc056f19178909243054252a"
+          "archive:https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.133.tgz#sha1:c47639c19b91feee3e22fad69f5556142007008c"
         ]
       },
       "overrides": [],
@@ -7134,14 +7134,14 @@
       "dependencies": [ "rsvp@3.6.2@d41d8cd9" ],
       "devDependencies": []
     },
-    "caniuse-lite@1.0.30000966@d41d8cd9": {
-      "id": "caniuse-lite@1.0.30000966@d41d8cd9",
+    "caniuse-lite@1.0.30000967@d41d8cd9": {
+      "id": "caniuse-lite@1.0.30000967@d41d8cd9",
       "name": "caniuse-lite",
-      "version": "1.0.30000966",
+      "version": "1.0.30000967",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000966.tgz#sha1:f3c6fefacfbfbfb981df6dfa68f2aae7bff41b64"
+          "archive:https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000967.tgz#sha1:a5039577806fccee80a04aaafb2c0890b1ee2f73"
         ]
       },
       "overrides": [],
@@ -7280,8 +7280,8 @@
       },
       "overrides": [],
       "dependencies": [
-        "electron-to-chromium@1.3.131@d41d8cd9",
-        "caniuse-lite@1.0.30000966@d41d8cd9"
+        "electron-to-chromium@1.3.133@d41d8cd9",
+        "caniuse-lite@1.0.30000967@d41d8cd9"
       ],
       "devDependencies": []
     },

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "babel-preset-env": "^1.7.0",
     "babel-preset-flow": "^6.23.0",
     "del": "^3.0.0",
-    "esy-bash": "0.3.18",
+    "esy-bash": "0.3.19",
     "flow-bin": "^0.77.0",
     "fs-extra": "^7.0.0",
     "jest-cli": "^23.4.1",

--- a/scripts/release-postinstall.js
+++ b/scripts/release-postinstall.js
@@ -124,7 +124,7 @@ switch (platform) {
     copyPlatformBinaries('win32');
 
     console.log('Installing native compiler toolchain for Windows...');
-    cp.execSync(`npm install esy-bash@0.3.18 --prefix "${__dirname}"`);
+    cp.execSync(`npm install esy-bash@0.3.19 --prefix "${__dirname}"`);
     console.log('Native compiler toolchain installed successfully.');
     break;
   case 'linux':


### PR DESCRIPTION
This picks up @manuhornung 's fix for esy-bash, for paths with spaces: https://github.com/bryphe/esy-bash/pull/51 (in `esy-bash@0.3.19`)