### PR TITLE
Add --release to `esy export-dependencies`

### DIFF
--- a/bin/esy.re
+++ b/bin/esy.re
@@ -1694,10 +1694,7 @@ let commandsConfig = {
         ~name="export-dependencies",
         ~doc="Export sandbox dependendencies as prebuilt artifacts",
         ~docs=otherSection,
-        Term.(
-          const(exportDependencies)
-          $ modeTerm
-        ),
+        Term.(const(exportDependencies) $ modeTerm),
       ),
       makeProjectCommand(
         ~name="import-dependencies",


### PR DESCRIPTION
This makes it possible to export dependencies using the release mode.  Before this, exported dependencies would come from the sandbox containing all the dev dependencies (if you are using `link-dev` for example).