### PR TITLE
fix note on refmterr in devDependencies

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -63,7 +63,7 @@ to call `dune build` command.
       "refmterr dune build --root . --only-packages #{self.name}",
     ]
   },
-  "dependencies": {
+  "devDependencies": {
     "refmterr": "*",
     ...
   }


### PR DESCRIPTION
The doc below says 

```Note that we use `refmterr` command which is declared in `"devDependencies"```

but the example has in in `dependencies`