### PR TITLE
Fix use PATH variable to run required executables

### DIFF
--- a/esy-build/Scope.re
+++ b/esy-build/Scope.re
@@ -375,7 +375,7 @@ let make =
           let windir = Sys.getenv("WINDIR") ++ "/System32";
           let windir = Path.normalizePathSepOfFilename(windir);
           "$PATH;/usr/local/bin;/usr/bin;/bin;/usr/sbin;/sbin;" ++ windir;
-        | _ => "$PATH:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+        | _ => Sys.getenv("PATH") ++ ":/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
         };
 
       SandboxEnvironment.[


### PR DESCRIPTION
esy builds on NixOS failed without it with the following error:

    esy-build-package: unable to resolve command: cp