### PR TITLE
feat: add init command

### DIFF
--- a/bin/esy.re
+++ b/bin/esy.re
@@ -1415,7 +1415,16 @@ let initCommand = shouldForce => {
       |> Yojson.Safe.to_string
       |> Yojson.Safe.prettify;
 
-    Fs.writeFile(~data=manifestScaffold, manifestTarget);
+    let%bind _ignore = Fs.writeFile(~data=manifestScaffold, manifestTarget);
+
+    let succesfulMessage =
+      "Wrote to "
+      ++ Path.show(manifestTarget)
+      ++ " with the following content: \n\n"
+      ++ manifestScaffold;
+
+    print_endline(succesfulMessage);
+    RunAsync.return();
   };
 
   let esyManifestTarget =
@@ -1432,9 +1441,8 @@ let initCommand = shouldForce => {
       ~manifestTarget=esyManifestTarget,
     )
   | (false, true) =>
-    print_endline(
-      "An esy-manifest already exists. Use with `-f` to overwrite it.",
-    );
+    let manifestExistsMessage = "An esy-manifest already exists. Use with `-f` or `--force` to overwrite it.";
+    print_endline(manifestExistsMessage);
     RunAsync.return();
   };
 };

--- a/test-e2e-re/lib/Fixture.re
+++ b/test-e2e-re/lib/Fixture.re
@@ -79,8 +79,8 @@ and layoutMany = p =>
       };
     };
 
-let packageJson = entry => {
-  FixtureFile({name: "package.json", data: PackageJson.toString(entry)});
+let packageJson = (~manifestName="package.json", entry) => {
+  FixtureFile({name: manifestName, data: PackageJson.toString(entry)});
 };
 
 let defaultProject = () => {

--- a/test-e2e/esy-install/init.test.js
+++ b/test-e2e/esy-install/init.test.js
@@ -1,0 +1,83 @@
+// @flow
+
+const path = require('path');
+const helpers = require('../test/helpers.js');
+
+describe('init esy-project', function() {
+  test(`creates an esy.json skeleton`, async () => {
+    const p = await helpers.createTestSandbox();
+
+    await p.esy(`init`);
+    const packageJsonData = await helpers.readFile(
+      path.join(p.projectPath, 'esy.json'),
+      'utf8',
+    );
+    const packageJson = JSON.parse(packageJsonData);
+
+    expect(packageJson).toMatchObject({
+      name: 'project',
+      version: '0.1.0',
+      esy: {},
+      scripts: {},
+      dependencies: {},
+      devDependencies: {},
+    });
+  });
+
+  test(`does not overwrite existing esy.json without -f`, async () => {
+    const fixture = [
+      helpers.packageJson(
+        {
+          already: 'created',
+        },
+        'esy.json',
+      ),
+    ];
+
+    const p = await helpers.createTestSandbox(...fixture);
+
+    await p.esy(`init`);
+
+    const packageJsonData = await helpers.readFile(
+      path.join(p.projectPath, 'esy.json'),
+      'utf8',
+    );
+
+    const packageJson = JSON.parse(packageJsonData);
+
+    expect(packageJson).toMatchObject({
+      already: 'created',
+    });
+  });
+
+  test(`should overwrite existing esy.json with -f`, async () => {
+    const fixture = [
+      helpers.packageJson(
+        {
+          already: 'created',
+        },
+        'esy.json',
+      ),
+    ];
+
+    const p = await helpers.createTestSandbox(...fixture);
+
+    await p.esy(`init -f`);
+
+    const packageJsonData = await helpers.readFile(
+      path.join(p.projectPath, 'esy.json'),
+      'utf8',
+    );
+
+    const packageJson = JSON.parse(packageJsonData);
+
+    expect(packageJson).toMatchObject({
+      name: 'project',
+      version: '0.1.0',
+      esy: {},
+      scripts: {},
+      dependencies: {},
+      devDependencies: {},
+    });
+  });
+});

--- a/test-e2e/test/FixtureUtils.js
+++ b/test-e2e/test/FixtureUtils.js
@@ -62,8 +62,8 @@ function symlink(name /*: string*/, path /*: string*/) /*: FixtureSymlink*/ {
   return {type: 'symlink', name, path};
 }
 
-function packageJson(json /*: Object*/) {
-  return file('package.json', JSON.stringify(json, null, 2));
+function packageJson(json /*: Object*/, manifestName = 'package.json') {
+  return file(manifestName, JSON.stringify(json, null, 2));
 }
 
 async function layout(p /*: string*/, fixture /*: FixtureItem*/) {


### PR DESCRIPTION
Discussed in #371, this PR adds a basic `esy init`-command which generates the following JSON:

```json
{
  "name": "current-directory-name",
  "version": "0.1.0",
  "esy": {},
  "scripts": {},
  "dependencies": {},
  "devDependencies": {}
}
```

I know there are probably bigger plans for the `init`-command, but this might be a good start!

**Code comments:**

I was unsure on how the `FixtureUtils.js` was generated, so that might need another look!