### PR TITLE
Expand PATH environment variable

### DIFF
--- a/esy-build/Scope.re
+++ b/esy-build/Scope.re
@@ -384,7 +384,9 @@ let make =
           let windir = Sys.getenv("WINDIR") ++ "\\System32";
           let windir = Path.normalizePathSepOfFilename(windir);
           Sys.getenv("PATH") ++ ";" ++ windir;
-        | _ => Sys.getenv("PATH") ++ ":/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+        | _ =>
+          Sys.getenv("PATH")
+          ++ ":/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
         };
 
       SandboxEnvironment.[

--- a/esy-build/Scope.re
+++ b/esy-build/Scope.re
@@ -381,10 +381,10 @@ let make =
       let defaultPath =
         switch (platform) {
         | Windows =>
-          let windir = Sys.getenv("WINDIR") ++ "/System32";
+          let windir = Sys.getenv("WINDIR") ++ "\\System32";
           let windir = Path.normalizePathSepOfFilename(windir);
-          "$PATH;/usr/local/bin;/usr/bin;/bin;/usr/sbin;/sbin;" ++ windir;
-        | _ => "$PATH:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+          Sys.getenv("PATH") ++ ";" ++ windir;
+        | _ => Sys.getenv("PATH") ++ ":/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
         };
 
       SandboxEnvironment.[


### PR DESCRIPTION
This PR will resolve two issues:

- On Windows, parent `PATH` environment variable is not interpolated properly. According to the Windows environment variable specification, interpolation syntax is `%PATH%` for `PATH` and it is not automatic unless interpreted by a shell. In addition, path separator is `"\\"` and Unix-related paths such as `/usr/bin` and `/sbin` do not exist in a typical Windows system.

- In Unix-like environment, `$PATH` interpolation only takes effect when it is interpreted in a shell. It has to be manually interpolated on our end.

Related to kamilchm/nix-esy#1

@kamilchm