### PR TITLE
Add a Nix derivation

### DIFF
--- a/nix/esy/default.nix
+++ b/nix/esy/default.nix
@@ -1,0 +1,251 @@
+# nix-build -E 'with import <nixpkgs> { }; import ./esy pkgs'
+pkgs: with pkgs;
+
+let
+  esyVersion = "0.5.8";
+
+  ocamlPackages = pkgs.ocamlPackages.overrideScope' (self: super: rec {
+    cmdliner = pkgs.ocamlPackages.cmdliner.overrideDerivation (old: {
+      src = builtins.fetchurl {
+        url = https://github.com/esy-ocaml/cmdliner/archive/8500634a96019c4d29b1751628025b693f2b97d6.tar.gz;
+        sha256 = "094s12xzlywglfjs95gam47bq3is72zkaz3082zq8s4gi1w2irva";
+      };
+      createFindlibDestdir = true;
+    });
+  });
+
+  opam-lib = { pname, deps }: stdenv.mkDerivation rec {
+    name = pname;
+    version = "2.0.5";
+    buildInputs = with ocamlPackages; [
+      ocaml
+      findlib
+      dune
+    ];
+    propagatedBuildInputs = deps;
+    src = fetchFromGitHub {
+      owner  = "ocaml";
+      repo   = "opam";
+      rev    = "${version}";
+      sha256 = "0pf2smq2sdcxryq5i87hz3dv05pb3zasb1is3kxq1pi1s4cn55mx";
+    };
+    configurePhase = ''
+      ./configure --disable-checks
+    '';
+    buildPhase = ''
+      make ${name}.install
+    '';
+    installPhase = ''
+      runHook preInstall
+      ${opaline}/bin/opaline -prefix $out -libdir $OCAMLFIND_DESTDIR
+      runHook postInstall
+    '';
+  };
+
+  opam-core = opam-lib {
+    pname= "opam-core";
+    deps = with ocamlPackages; [
+      ocamlgraph
+      re
+      cppo
+    ];
+  };
+
+  opam-format = opam-lib {
+    pname = "opam-format";
+    deps = with ocamlPackages; [
+      opam-file-format
+      opam-core
+    ];
+  };
+
+  opam-repository = opam-lib {
+    pname = "opam-repository";
+    deps = with ocamlPackages; [
+      opam-format
+    ];
+  };
+
+  opam-state = opam-lib {
+    pname = "opam-state";
+    deps = with ocamlPackages; [
+      opam-repository
+    ];
+  };
+
+  cudf = stdenv.mkDerivation rec {
+    name = "cudf";
+    buildInputs = with ocamlPackages; [
+      ocaml
+      ocamlbuild
+      # for pod2man
+      perl
+      findlib
+    ];
+    propagatedBuildInputs = with ocamlPackages; [ ocaml_extlib ];
+    src = builtins.fetchTarball {
+      url = https://gforge.inria.fr/frs/download.php/36602/cudf-0.9.tar.gz;
+      sha256 = "12p8aap34qsg1hcjkm79ak3n4b8fm79iwapi1jzjpw32jhwn6863";
+    };
+    buildPhase = ''
+      make all opt
+    '';
+    patchPhase = "sed -i s@/usr/@$out/@ Makefile.config";
+    createFindlibDestdir = true;
+  };
+
+  dose3 = stdenv.mkDerivation {
+    name = "dose";
+    src = builtins.fetchurl {
+      url = "http://gforge.inria.fr/frs/download.php/file/36063/dose3-5.0.1.tar.gz";
+      sha256 = "00yvyfm4j423zqndvgc1ycnmiffaa2l9ab40cyg23pf51qmzk2jm";
+    };
+    buildInputs = with ocamlPackages; [
+      ocaml
+      findlib
+      ocamlbuild
+      ocaml_extlib
+      cudf
+      ocamlgraph
+      cppo
+      re
+      perl
+    ];
+    createFindlibDestdir = true;
+    patches = [
+      ./patches/0001-Install-mli-cmx-etc.patch
+      ./patches/0002-dont-make-printconf.patch
+      ./patches/0003-Fix-for-ocaml-4.06.patch
+      ./patches/0004-Add-unix-as-dependency-to-dose3.common-in-META.in.patch
+      ./patches/dose.diff
+    ];
+  };
+
+  esy-solve-cudf = ocamlPackages.buildDunePackage rec {
+    pname = "esy-solve-cudf";
+    version = "0.1.10";
+    buildInputs = with ocamlPackages; [
+      ocaml
+      findlib
+      dune
+      ocaml_extlib
+    ];
+    propagatedBuildInputs = with ocamlPackages; [ cmdliner cudf ];
+    src = fetchFromGitHub {
+      owner  = "andreypopp";
+      repo   = pname;
+      rev    = "v${version}";
+      sha256 = "174q1wkr31dn8vsvnlj4hzfgvbamqq74n7wxhbccriqmv8lz5a3g";
+      fetchSubmodules = true;
+    };
+
+    buildPhase = ''
+      runHook preBuild
+      dune build -p ${pname},mccs
+      runHook postBuild
+    '';
+
+    meta = {
+      homepage = https://github.com/andreypopp/esy-solve-cudf;
+      description = "package.json workflow for native development with Reason/OCaml";
+      license = stdenv.lib.licenses.gpl3;
+    };
+  };
+
+  esyNpm = builtins.fetchurl {
+    url = "https://registry.npmjs.org/esy/${esyVersion}";
+    sha256 = "0rhbbg7rav68z5xwppx1ni8gjm6pcqf564nn1z6yrag3wgjgs63c";
+  };
+
+  esySolveCudfNpm = builtins.fetchurl {
+    url = "https://registry.npmjs.org/esy-solve-cudf/${esy-solve-cudf.version}";
+    sha256 = "19m793mydd8gcgw1mbn7pd8fw2rhnd00k5wpa4qkx8a3zn6crjjf";
+  };
+
+in
+  ocamlPackages.buildDunePackage rec {
+    pname = "esy";
+    version = "0.5.8";
+
+    minimumOCamlVersion = "4.06";
+
+    src = fetchFromGitHub {
+      owner  = "esy";
+      repo   = pname;
+      rev    = "v${version}";
+      sha256 = "0n2606ci86vqs7sm8icf6077h5k6638909rxyj43lh55ah33l382";
+    };
+
+    propagatedBuildInputs = with ocamlPackages; [
+      angstrom
+      cmdliner
+      reason
+      bos
+      fmt
+      fpath
+      lambdaTerm
+      logs
+      lwt4
+      lwt_ppx
+      menhir
+      opam-file-format
+      ppx_deriving
+      ppx_deriving_yojson
+      ppx_expect
+      ppx_inline_test
+      ppx_let
+      ppx_sexp_conv
+      re
+      yojson
+      cudf
+      dose3
+      opam-format
+      opam-core
+      opam-state
+  ];
+  doCheck = false;
+
+  buildPhase = ''
+    runHook preBuild
+    dune build -p ${pname},esy-build-package
+    runHook postBuild
+  '';
+
+  # |- bin
+  #   |- esy
+  # |- lib
+  #   |- default
+  #     |- bin
+  #       |- esy.exe
+  #       |- esyInstallRelease.js
+  #     |- esy-build-package
+  #       |- bin
+  #       |- esyBuildPackageCommand.exe
+  #       |- esyRewritePrefixCommand.exe
+  #   |- node_modules
+  #     |- esy-solve-cudf
+  #       |- package.json
+  #       |- esySolveCudfCommand.exe
+  fixupPhase = ''
+    mkdir -p $out/lib/default/bin
+    mkdir -p $out/lib/default/esy-build-package/bin
+    mkdir -p $out/lib/node_modules/esy-solve-cudf
+    mv $out/bin/esy $out/lib/default/bin/esy.exe
+    mv $out/bin/esyInstallRelease.js $out/lib/default/bin/
+    mv $out/bin/esy-build-package $out/lib/default/esy-build-package/bin/esyBuildPackageCommand.exe
+    mv $out/bin/esy-rewrite-prefix $out/lib/default/esy-build-package/bin/esyRewritePrefixCommand.exe
+    ln -s $out/lib/default/bin/esy.exe $out/bin/esy
+    cp ${esyNpm} $out/package.json
+    cp ${esySolveCudfNpm} $out/lib/node_modules/esy-solve-cudf/package.json
+    cp ${esy-solve-cudf}/bin/esy-solve-cudf $out/lib/node_modules/esy-solve-cudf/esySolveCudfCommand.exe
+
+  '';
+  postBuild = "true";
+
+  meta = {
+    homepage = https://github.com/esy/esy;
+    description = "package.json workflow for native development with Reason/OCaml";
+    license = stdenv.lib.licenses.bsd2;
+    # maintainers = with stdenv.lib.maintainers; [ sternenseemann ];
+  };
+}

--- a/nix/esy/patches/0001-Install-mli-cmx-etc.patch
+++ b/nix/esy/patches/0001-Install-mli-cmx-etc.patch
@@ -1,0 +1,133 @@
+From b5314c20d8e3caf62fe0dc96ad937a2950158b23 Mon Sep 17 00:00:00 2001
+From: Louis Gesbert <louis.gesbert@ocamlpro.com>
+Date: Thu, 2 Mar 2017 12:19:56 +0100
+Subject: [PATCH] Install mli, cmx, etc.
+
+---
+ Makefile | 26 +++++++++++++-------------
+ 1 file changed, 13 insertions(+), 13 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 09464ff..5044d7f 100644
+--- a/Makefile
++++ b/Makefile
+@@ -56,7 +56,7 @@ $(DOSELIBS)/cudf.%:
+ 	@for i in _build/cudf/cudf.*; do \
+ 	  if [ -e $$i ]; then \
+ 	  cp $$i $(DOSELIBS) ; \
+-	  rm -f $(DOSELIBS)/*.mlpack $(DOSELIBS)/*.cmx ; \
++	  rm -f $(DOSELIBS)/*.mlpack ; \
+ 	  fi ; \
+ 	done
+ 
+@@ -67,7 +67,7 @@ $(DOSELIBS)/common.%: common/*.ml common/*.mli
+ 	  if [ -e $$i ]; then \
+ 	  cp $$i $(DOSELIBS) ; \
+ 		rm $$i ;\
+-	  rm -f $(DOSELIBS)/*.mlpack $(DOSELIBS)/*.cmx ; \
++	  rm -f $(DOSELIBS)/*.mlpack ; \
+ 	  fi ; \
+ 	done
+ 
+@@ -78,7 +78,7 @@ $(DOSELIBS)/versioning.%: versioning/*.ml versioning/*.mli
+ 	  if [ -e $$i ]; then \
+ 	  cp $$i $(DOSELIBS) ; \
+ 		rm $$i ;\
+-	  rm -f $(DOSELIBS)/*.mlpack $(DOSELIBS)/*.cmx ; \
++	  rm -f $(DOSELIBS)/*.mlpack ; \
+ 	  fi ; \
+ 	done
+ 
+@@ -88,7 +88,7 @@ $(DOSELIBS)/algo.%: algo/*.ml algo/*.mli $(DOSELIBS)/common.%
+ 	  if [ -e $$i ]; then \
+ 	  cp $$i $(DOSELIBS) ; \
+ 		rm $$i ;\
+-	  rm -f $(DOSELIBS)/*.mlpack $(DOSELIBS)/*.cmx ; \
++	  rm -f $(DOSELIBS)/*.mlpack ; \
+ 	  fi ; \
+ 	done
+ 
+@@ -98,7 +98,7 @@ $(DOSELIBS)/debian.%: deb/*.ml deb/*.mli $(DOSELIBS)/pef.%
+ 	  if [ -e $$i ]; then \
+ 	  cp $$i $(DOSELIBS) ; \
+ 		rm $$i ;\
+-	  rm -f $(DOSELIBS)/*.mlpack $(DOSELIBS)/*.cmx ; \
++	  rm -f $(DOSELIBS)/*.mlpack ; \
+ 	  fi ; \
+ 	done
+ 
+@@ -108,7 +108,7 @@ $(DOSELIBS)/opam.%: opam/*.ml opam/*.mli $(DOSELIBS)/pef.%
+ 	  if [ -e $$i ]; then \
+ 	  cp $$i $(DOSELIBS) ; \
+ 		rm $$i ;\
+-	  rm -f $(DOSELIBS)/*.mlpack $(DOSELIBS)/*.cmx ; \
++	  rm -f $(DOSELIBS)/*.mlpack ; \
+ 	  fi ; \
+ 	done
+ 
+@@ -118,7 +118,7 @@ $(DOSELIBS)/npm.%: npm/*.ml npm/*.mli $(DOSELIBS)/versioning.% $(DOSELIBS)/pef.%
+ 	  if [ -e $$i ]; then \
+ 	  cp $$i $(DOSELIBS) ; \
+ 		rm $$i ;\
+-	  rm -f $(DOSELIBS)/*.mlpack $(DOSELIBS)/*.cmx ; \
++	  rm -f $(DOSELIBS)/*.mlpack ; \
+ 	  fi ; \
+ 	done
+ 
+@@ -128,7 +128,7 @@ $(DOSELIBS)/rpm.%: rpm/*.ml $(DOSELIBS)/algo.%
+ 	  if [ -e $$i ]; then \
+ 	  cp $$i $(DOSELIBS) ; \
+ 		rm $$i ;\
+-	  rm -f $(DOSELIBS)/*.mlpack $(DOSELIBS)/*.cmx ; \
++	  rm -f $(DOSELIBS)/*.mlpack ; \
+ 	  fi ; \
+ 	done
+ 
+@@ -138,7 +138,7 @@ $(DOSELIBS)/pef.%: pef/*.ml pef/*.mli
+ 	  if [ -e $$i ]; then \
+ 	  cp $$i $(DOSELIBS) ; \
+ 		rm $$i ;\
+-	  rm -f $(DOSELIBS)/*.mlpack $(DOSELIBS)/*.cmx ; \
++	  rm -f $(DOSELIBS)/*.mlpack ; \
+ 	  fi ; \
+ 	done
+ 
+@@ -148,7 +148,7 @@ $(DOSELIBS)/csw.%: opencsw/*.ml $(DOSELIBS)/versioning.%
+ 	  if [ -e $$i ]; then \
+ 	  cp $$i $(DOSELIBS) ; \
+ 		rm $$i ;\
+-	  rm -f $(DOSELIBS)/*.mlpack $(DOSELIBS)/*.cmx ; \
++	  rm -f $(DOSELIBS)/*.mlpack ; \
+ 	  fi ; \
+ 	done
+ 
+@@ -158,7 +158,7 @@ $(DOSELIBS)/doseparse.%: $(DOSELIBS)/pef.% $(DOSELIBS)/debian.%
+ 	  if [ -e $$i ]; then \
+ 	  cp $$i $(DOSELIBS) ; \
+ 		rm $$i ;\
+-	  rm -f $(DOSELIBS)/*.mlpack $(DOSELIBS)/*.cmx $(DOSELIBS)/*.ml ; \
++	  rm -f $(DOSELIBS)/*.mlpack $(DOSELIBS)/*.ml ; \
+ 	  fi ; \
+ 	done
+ 
+@@ -168,7 +168,7 @@ $(DOSELIBS)/doseparseNoRpm.%: $(DOSELIBS)/pef.% $(DOSELIBS)/debian.%
+ 	  if [ -e $$i ]; then \
+ 			cp $$i $(DOSELIBS) ;\
+ 			rm $$i ;\
+-			rm -f $(DOSELIBS)/*.mlpack $(DOSELIBS)/*.cmx ;\
++			rm -f $(DOSELIBS)/*.mlpack ;\
+ 	  fi ; \
+ 	done
+ 
+@@ -223,7 +223,7 @@ INSTALL_STUFF_ = META
+ INSTALL_STUFF_ += $(wildcard _build/doselibs/*.cma _build/doselibs/*.cmi)
+ INSTALL_STUFF_ += $(wildcard _build/doselibs/*.cmxa _build/doselibs/*.cmxs)
+ INSTALL_STUFF_ += $(wildcard _build/doselibs/*.a)
+-#INSTALL_STUFF_ += $(wildcard _build/*/*.mli)
++INSTALL_STUFF_ += $(wildcard _build/doselibs/*.mli) $(wildcard _build/doselibs/*.cmti) $(wildcard _build/doselibs/*.cmx)
+ INSTALL_STUFF_ += $(wildcard _build/rpm/*.so)
+ 
+ exclude_cudf = $(wildcard _build/doselibs/*cudf* _build/cudf/*)
+-- 
+2.11.0
+

--- a/nix/esy/patches/0002-dont-make-printconf.patch
+++ b/nix/esy/patches/0002-dont-make-printconf.patch
@@ -1,0 +1,9 @@
+--- a/configure
++++ b/configure
+@@ -6552,6 +6552,3 @@ if test -n "$ac_unrecognized_opts" && test "$enable_option_checking" != no; then
+   { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: unrecognized options: $ac_unrecognized_opts" >&5
+ $as_echo "$as_me: WARNING: unrecognized options: $ac_unrecognized_opts" >&2;}
+ fi
+-
+-
+-make printconf

--- a/nix/esy/patches/0003-Fix-for-ocaml-4.06.patch
+++ b/nix/esy/patches/0003-Fix-for-ocaml-4.06.patch
@@ -1,0 +1,52 @@
+From aeca7656f499d7f4595319858f242276920e31bb Mon Sep 17 00:00:00 2001
+From: Louis Gesbert <louis.gesbert@ocamlpro.com>
+Date: Sat, 2 Dec 2017 12:51:01 +0100
+Subject: [PATCH] Fix for ocaml 4.06
+
+---
+ common/criteria_lexer.mll | 8 ++++----
+ common/util.ml            | 2 +-
+ 2 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/common/criteria_lexer.mll b/common/criteria_lexer.mll
+index 71f9178..fc4eae3 100644
+--- a/common/criteria_lexer.mll
++++ b/common/criteria_lexer.mll
+@@ -18,7 +18,7 @@
+     let c = Lexing.lexeme_char lexbuf 2 in (* the delimiter can be any character *)
+     (* find the terminating delimiter *)
+     let endpos =
+-      try String.index_from lexbuf.lex_buffer (lexbuf.lex_start_pos + 3) c with
++      try Bytes.index_from lexbuf.lex_buffer (lexbuf.lex_start_pos + 3) c with
+       |Invalid_argument _ ->
+           raise (Format822.Syntax_error (
+             Format822.error lexbuf "String too short"))
+@@ -27,9 +27,9 @@
+             Format822.error lexbuf (Printf.sprintf "cannot find: %c" c)))
+     in
+     let len = endpos - (lexbuf.lex_start_pos + 3) in
+-    let s = String.sub lexbuf.lex_buffer (lexbuf.lex_start_pos + 3) len in
+-    lexbuf.Lexing.lex_curr_pos <- lexbuf.Lexing.lex_start_pos + ((String.length s)+4);
+-    s
++    let s = Bytes.sub lexbuf.lex_buffer (lexbuf.lex_start_pos + 3) len in
++    lexbuf.Lexing.lex_curr_pos <- lexbuf.Lexing.lex_start_pos + ((Bytes.length s)+4);
++    Bytes.to_string s
+ 
+ }
+ 
+diff --git a/common/util.ml b/common/util.ml
+index 598f266..36ca3d1 100644
+--- a/common/util.ml
++++ b/common/util.ml
+@@ -87,7 +87,7 @@ module MakeMessages(X : sig val label : string end) = struct
+   let clean label =
+     try 
+       let s = Filename.chop_extension (Filename.basename label) in
+-      String.capitalize s
++      String.capitalize_ascii s
+     with Invalid_argument _ -> label
+ 
+   let create ?(enabled=false) label =
+-- 
+2.11.0
+

--- a/nix/esy/patches/0004-Add-unix-as-dependency-to-dose3.common-in-META.in.patch
+++ b/nix/esy/patches/0004-Add-unix-as-dependency-to-dose3.common-in-META.in.patch
@@ -1,0 +1,25 @@
+From b94cf24739818e5aff397e0a83b19ea32dc81f42 Mon Sep 17 00:00:00 2001
+From: Louis Gesbert <louis.gesbert@ocamlpro.com>
+Date: Tue, 6 Feb 2018 10:15:45 +0100
+Subject: [PATCH 3/3] Add "unix" as dependency to dose3.common in META.in
+
+---
+ META.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/META.in b/META.in
+index aa2cd8d..0f9d337 100644
+--- a/META.in
++++ b/META.in
+@@ -8,7 +8,7 @@ package "common" (
+ version = "@PACKAGE_VERSION@"
+ archive(byte) = "common.cma"
+ archive(native) = "common.cmxa"
+-requires = "extlib, re.pcre, cudf, @ZIP@, @BZ2@"
++requires = "extlib, re.pcre, cudf, unix, @ZIP@, @BZ2@"
+ )
+ 
+ package "algo" (
+-- 
+2.11.0
+

--- a/nix/esy/patches/dose.diff
+++ b/nix/esy/patches/dose.diff
@@ -1,0 +1,24 @@
+diff --git a/Makefile.config.in b/Makefile.config.in
+index 155a77a..a9b8bc2 100644
+--- a/Makefile.config.in
++++ b/Makefile.config.in
+@@ -29,8 +29,8 @@ ifneq ($(DESTDIR),)
+   LIBDIR = $(DESTDIR)@libdir@/ocaml
+ endif
+
+-INSTALL=$(OCAMLFIND) install -destdir $(LIBDIR)
+-UNINSTALL=$(OCAMLFIND) remove -destdir $(LIBDIR)
++INSTALL=$(OCAMLFIND) install -destdir $(OCAMLFIND_DESTDIR)
++UNINSTALL=$(OCAMLFIND) remove -destdir $(OCAMLFIND_DESTDIR)
+
+ printconf:
+ 	@echo
+@@ -41,7 +41,7 @@ printconf:
+ 	@echo "DESTDIR: $(DESTDIR)"
+ 	@echo "OCAMLFIND_DESTDIR: $(OCAMLFIND_DESTDIR)"
+ 	@echo "Prefix: @prefix@"
+-	@echo "Libdir: $(LIBDIR)"
++	@echo "Libdir: $(OCAMLFIND_DESTDIR)"
+ 	@echo "Bindir: $(BINDIR)"
+ 	@echo "OCAML_OS_TYPE: @OCAML_OS_TYPE@"
+ 	@echo "OCAML_SYSTEM: @OCAML_SYSTEM@"


### PR DESCRIPTION
This is a WIP derivation that currently allows installing esy 0.5.8.

We should extend this to generate derivations for nightly releases too and add it to a CI step.

Fixes https://github.com/esy/esy/issues/652