### PR TITLE
Fix double backslash paths in import/export workflow

### DIFF
--- a/esy-build/BuildSandbox.re
+++ b/esy-build/BuildSandbox.re
@@ -1399,7 +1399,17 @@ let exportBuild = (cfg, ~outputPrefixPath, buildPath) => {
   let%bind (origPrefix, destPrefix) = {
     let%bind prevStorePrefix =
       Fs.readFile(Path.(buildPath / "_esy" / "storePrefix"));
-    let nextStorePrefix = String.make(String.length(prevStorePrefix), '_');
+    let nextStorePrefix =
+      switch (System.Platform.host) {
+      | Windows =>
+        /* Keep the slashes segments in the path.  It's important for doing
+         * replacement of double backslashes in artifacts.  */
+        String.split_on_char('\\', prevStorePrefix)
+        |> List.map(~f=(seg => String.make(String.length(seg), '_')))
+        |> String.concat("\\");
+      | _ =>
+        String.make(String.length(prevStorePrefix), '_');
+      };
     return((Path.v(prevStorePrefix), Path.v(nextStorePrefix)));
   };
 


### PR DESCRIPTION
We start out with build artifacts like in the build directories of packages:
`cat /c/Users/myuser/.esy/3_/b/opam__s__ocamlfind-opam__c__1.8.1-ff386450/findlib.conf`
 
    path="C:\\Users\\myuser\\.esy\\3_\\s\\opam__s__ocamlfind-opam__c__1.8.1-ff386450\\lib"

Then import them into the installed store like this:
`cat /c/Users/myuser/.esy/3_/i/opam__s__ocamlfind-opam__c__1.8.1-ff386450/lib/findlib.conf`

    path="C:\\Users\\myuser\\.esy\\3_\\i\\opam__s__ocamlfind-opam__c__1.8.1-ff386450\\lib"

Then when exporting and reimporting they end up like:

    path="C:\Users\myname\.esy\3_\\i\\opam__s__ocamlfind-opam__c__1.8.1-ff386450\\lib"


- `esyRewritePrefixCommand.re` does:

      callRewriteProgram(
        orig,
        next
      )
      callRewriteProgram(
        replaceAllBackSlashesWithForwardSlashes(orig),
        replaceAllBackSlashesWithForwardSlashes(next)
      )
      callRewriteProgram(
        replaceAllForwardSlashesWithTwoBackSlashes(orig),
        replaceAllForwardSlashesWithTwoBackSlashes(next)
      )


So we start with some files containing exactly
  `C:\Users\myuser\.esy\3_\i\opam__s__ocamlfind-opam__c__1.8.1-ff386450`
and others containing exactly
  `C:\Users\myuser\.esy\3_\i\opam__s__ocamlfind-opam__c__1.8.1-ff386450`
  
To export:
- `esyRewritePrefixCommand.re` supplies the "ideal backslashed windows path" as inputs for rewriting.
- On export, it will replace the prefix with an underscore version:

      callRewriteProgram( C:\Users\myuser\.esy\3_\, _______________________\ )
      callRewriteProgram(
        replaceAllBackSlashesWithForwardSlashes(C:\Users\myuser\.esy\3_\,
        replaceAllBackSlashesWithForwardSlashes(_______________________\
      )
      THEN
      callRewriteProgram(
        replaceAllForwardSlashesWithTwoBackSlashes(C:/Users/myuser/.esy/3_/,
        replaceAllForwardSlashesWithTwoBackSlashes(_______________________/
      )
      
Which is:

      callRewriteProgram( C:\Users\myuser\.esy\3_\, _______________________\ )
      callRewriteProgram( C:/Users/myuser/.esy/3_/, _______________________/ )
      THEN
      callRewriteProgram( C:\\Users\\myuser\\.esy\\3_\\, callRewriteProgram\\ )

Then it does the same thing upon import, except now it flips the order of the
underscore path (it's the one being replaced now).

      callRewriteProgram( _______________________\, C:\Users\myuser\.esy\3_\ )
      callRewriteProgram(
        replaceAllBackSlashesWithForwardSlashes(_______________________\,
        replaceAllBackSlashesWithForwardSlashes(C:\Users\myuser\.esy\3_\
      )
      THEN
      callRewriteProgram(
        replaceAllForwardSlashesWithTwoBackSlashes(_______________________/,
        replaceAllForwardSlashesWithTwoBackSlashes(C:/Users/myuser/.esy/3_/
      )
      
Which is:

      callRewriteProgram( _______________________\, C:\Users\myuser\.esy\3_\ )
      callRewriteProgram( _______________________/, C:/Users/myuser/.esy/3_/ )
      THEN
      callRewriteProgram( _______________________\\, C:\\Users\\myuser\\.esy\\3_\\ )

Let's consider what happens on export/import to files containing
`C:\Users\myuser\.esy\3_\i\opam__s__ocamlfind-opam__c__1.8.1-ff386450`:


Upon export:
    
    
      callRewriteProgram( C:\Users\myuser\.esy\3_\, _______________________\ )
        # Our original C:\Users\myuser\.esy\3_\i\opam__s__ocamlfind-opam__c__1.8.1-ff386450
        # was replaced with _______________________\i\opam__s__ocamlfind-opam__c__1.8.1-ff386450
      
      callRewriteProgram( C:/Users/myuser/.esy/3_/, _______________________/ )
      THEN
      callRewriteProgram( C:\\Users\\myuser\\.esy\\3_\\, _______________________\\ )
        # still _______________________\i\opam__s__ocamlfind-opam__c__1.8.1-ff386450 in the files

Now the path is  `_______________________/i/opam__s__ocamlfind-opam__c__1.8.1-ff386450` in our exported files.
Upon import:


      callRewriteProgram( _______________________\, C:\Users\myuser\.esy\3_\ )
        # Now we're back to C:\Users\myuser\.esy\3_\i\opam__s__ocamlfind-opam__c__1.8.1-ff386450
      
      callRewriteProgram( _______________________/, C:/Users/myuser/.esy/3_/
        # Our paths remain as was
      THEN
      callRewriteProgram( _______________________\\, C:\\Users\\myuser\\.esy\\3_\\)
        # Our paths remain as was

So we got back to what we started with `C:\Users\myuser\.esy\3_\i\opam__s__ocamlfind-opam__c__1.8.1-ff386450`

But some artifacts have double backslashed text files:
Let's consider what happens on export/import to files containing
`C:\\Users\\myuser\\.esy\\3_\\i\\opam__s__ocamlfind-opam__c__1.8.1-ff386450`:



Upon export:
    
      callRewriteProgram( C:\Users\myuser\.esy\3_\, _______________________\)
        # Nothing replaced
      callRewriteProgram( C:/Users/myuser/.esy/3_/, _______________________/)
        # Still nothing
      THEN
      callRewriteProgram( C:\\Users\\myuser\\.esy\\3_\\, _______________________\\)
        # Our original C:\\Users\\myuser\\.esy\\3_\\i\\opam__s__ocamlfind-opam__c__1.8.1-ff386450
        # becomes _______________________\\i\\opam__s__ocamlfind-opam__c__1.8.1-ff386450 in the files

Now the path is  `_______________________\\i\\opam__s__ocamlfind-opam__c__1.8.1-ff386450` in our exported files.
Upon import:

      callRewriteProgram( _______________________\, C:\Users\myuser\.esy\3_\)
        # becomes C:\Users\myuser\.esy\3_\\\i\\opam__s__ocamlfind-opam__c__1.8.1-ff386450 in the files!!
        # THIS IS WRONG!!
      callRewriteProgram( _______________________/, C:/Users/myuser/.esy/3_/)
      # Nothing
      THEN
      callRewriteProgram( _______________________\\, C:\\Users\\myuser\\.esy\\3_\\)


But does it work when the source/dest paths are differently slashed?
-------------------

Recall we had paths like this in artifacts:
`C:\\Users\\myuser\\.esy\\3_\\i\\opam__s__ocamlfind-opam__c__1.8.1-ff386450`:

Upon export:

      callRewriteProgram( C:\Users\myuser\.esy\3_\, __\_____\______\_______\)
        # Nothing replaced
      callRewriteProgram( C:/Users/myuser/.esy/3_/, __\_____\______\_______\)
        # Still nothing
      THEN
      callRewriteProgram( C:\\Users\\myuser\\.esy\\3_\\, __\\_____\\______\\____\\__\\)
        # Our original C:\\Users\\myuser\\.esy\\3_\\i\\opam__s__ocamlfind-opam__c__1.8.1-ff386450
        # becomes __\\_____\\______\\____\\__\\i\\opam__s__ocamlfind-opam__c__1.8.1-ff386450 in the files

Now the path is  `__\\_____\\______\\____\\__\\i\\opam__s__ocamlfind-opam__c__1.8.1-ff386450` in our exported files.
Upon import:
- Let's import to `C:\fewerslashes\.esy\3_\`

      callRewriteProgram( __\_____\______\_______\, C:\fewerslashes\.esy\3_\)
        # No change
      callRewriteProgram( __/_____/______/_______/, C:/fewerslashes/.esy/3_/)
        # Nothing
      THEN
      callRewriteProgram( __\\_____\\______\\____\\__\\, C:\\fewerslashes\\.esy\\3_\\)
        # Our path becomes C:\\Users\\myuser\\.esy\\3_\\i\\opam__s__ocamlfind-opam__c__1.8.1-ff386450


This is not exactly correct if these paths were in binaries, since the lenghts
are different but double backslash tend to only appear in config files.
This is more correct than what was there before.
