### PR TITLE
test-e2e-re: Don't build the tests as part of the production binary

### DIFF
--- a/esy.json
+++ b/esy.json
@@ -18,7 +18,7 @@
     "release:platform-release": "node ./scripts/make-platform-release.js",
     "test:unit": "esy b dune runtest",
     "test:e2e": "npm run jest test-e2e",
-    "test:e2e-re": "esy x RunTests.exe",
+    "test:e2e-re": "esy b dune exec ./test-e2e-re/lib/RunTests.exe",
     "test:e2e-slow": "node test-e2e-slow/run-slow-tests.js"
   },
   "resolutions": {

--- a/test-e2e-re/lib/dune
+++ b/test-e2e-re/lib/dune
@@ -29,9 +29,6 @@
    (modules (:standard \ RunTests))
 )
 (executable
-  (package esy)
-  (name RunTests)
-  (public_name RunTests.exe)
-  (libraries TestE2E)
-  (modules RunTests)
-)
+ (name RunTests)
+ (libraries TestE2E)
+ (modules RunTests))


### PR DESCRIPTION
This diff makes it possible to build esy without having to install all the extra test dependencies.

I stumbled upon this when trying to build a nightly binary for Nix as part of #994.

It doesn't really make sense to ship the `RunTests.exe` executable as part of the esy package, and it would introduce a lot more deps in the Nix derivation too.