### PR TITLE
Allow configuring Esy's sandbox global lookup paths

### DIFF
--- a/bin/Project.re
+++ b/bin/Project.re
@@ -162,6 +162,7 @@ let makeProject = (makeSolved, projcfg: ProjectConfig.t) => {
         ~storePath,
         ~localStorePath=EsyInstall.SandboxSpec.storePath(projcfg.spec),
         ~projectPath=projcfg.spec.path,
+        ~globalPathVariable=projcfg.globalPathVariable,
         (),
       ),
     );

--- a/bin/ProjectConfig.re
+++ b/bin/ProjectConfig.re
@@ -201,6 +201,7 @@ type t = {
   solveTimeout: option(float),
   skipRepositoryUpdate: bool,
   solveCudfCommand: option(Cmd.t),
+  globalPathVariable: option(string),
 };
 
 let storePath = cfg => {
@@ -279,6 +280,16 @@ let esyOpamOverrideArg = {
   );
 };
 
+let globalPathVariableArg = {
+  let doc = "Specifies the PATH variable to look for global utils in the build env.";
+  let env = Arg.env_var("ESY__GLOBAL_PATH", ~doc);
+  Arg.(
+    value
+    & opt(some(string), None)
+    & info(["global-path"], ~env, ~docs=commonOptionsSection, ~doc)
+  );
+};
+
 let cacheTarballsPath = {
   let doc = "Specifies tarballs cache directory.";
   Arg.(
@@ -338,6 +349,7 @@ let make =
       solveTimeout,
       skipRepositoryUpdate,
       solveCudfCommand,
+      globalPathVariable,
     ) => {
   open RunAsync.Syntax;
 
@@ -365,6 +377,7 @@ let make =
     solveTimeout,
     skipRepositoryUpdate,
     solveCudfCommand,
+    globalPathVariable,
   });
 };
 
@@ -381,6 +394,7 @@ let promiseTerm = {
         solveTimeout,
         skipRepositoryUpdate,
         solveCudfCommand,
+        globalPathVariable,
         (),
       ) =>
     make(
@@ -394,6 +408,7 @@ let promiseTerm = {
       solveTimeout,
       skipRepositoryUpdate,
       solveCudfCommand,
+      globalPathVariable,
     );
 
   Cmdliner.Term.(
@@ -408,6 +423,7 @@ let promiseTerm = {
     $ solveTimeoutArg
     $ skipRepositoryUpdateArg
     $ solveCudfCommandArg
+    $ globalPathVariableArg
     $ Cli.setupLogTerm
   );
 };
@@ -428,6 +444,7 @@ let promiseTermForMultiplePaths = resolvedPathTerm => {
         solveTimeout,
         skipRepositoryUpdate,
         solveCudfCommand,
+        globalPathVariable,
         (),
       ) =>
     paths
@@ -443,6 +460,7 @@ let promiseTermForMultiplePaths = resolvedPathTerm => {
            solveTimeout,
            skipRepositoryUpdate,
            solveCudfCommand,
+           globalPathVariable,
          )
        )
     |> RunAsync.List.joinAll;
@@ -467,6 +485,7 @@ let promiseTermForMultiplePaths = resolvedPathTerm => {
     $ solveTimeoutArg
     $ skipRepositoryUpdateArg
     $ solveCudfCommandArg
+    $ globalPathVariableArg
     $ Cli.setupLogTerm
   );
 };

--- a/bin/ProjectConfig.rei
+++ b/bin/ProjectConfig.rei
@@ -18,6 +18,7 @@ type t = {
   solveTimeout: option(float),
   skipRepositoryUpdate: bool,
   solveCudfCommand: option(Cmd.t),
+  globalPathVariable: option(string),
 };
 
 let storePath: t => Run.t(Path.t);

--- a/esy-build-package/Config.re
+++ b/esy-build-package/Config.re
@@ -7,6 +7,7 @@ type t = {
   storePath: EsyLib.Path.t,
   localStorePath: EsyLib.Path.t,
   disableSandbox: bool,
+  globalPathVariable: option(string),
 };
 
 type config = t;
@@ -54,6 +55,7 @@ let make =
       ~storePath,
       ~projectPath,
       ~localStorePath,
+      ~globalPathVariable,
       (),
     ) => {
   open Run;
@@ -71,6 +73,7 @@ let make =
     storePath,
     localStorePath,
     disableSandbox,
+    globalPathVariable,
   });
 };
 

--- a/esy-build-package/Config.rei
+++ b/esy-build-package/Config.rei
@@ -5,6 +5,7 @@ type t =
     storePath: Fpath.t,
     localStorePath: Fpath.t,
     disableSandbox: bool,
+    globalPathVariable: option(string),
   };
 
 let pp: Fmt.t(t);
@@ -26,6 +27,7 @@ let make:
     ~storePath: storePathConfig,
     ~projectPath: Fpath.t,
     ~localStorePath: Fpath.t,
+    ~globalPathVariable: option(string),
     unit
   ) =>
   Run.t(t, _);

--- a/esy-build-package/bin/esyBuildPackageCommand.re
+++ b/esy-build-package/bin/esyBuildPackageCommand.re
@@ -15,6 +15,7 @@ type commonOpts = {
   projectPath: option(Fpath.t),
   logLevel: option(Logs.level),
   disableSandbox: bool,
+  globalPathVariable: option(string),
 };
 
 let setupLog = (style_renderer, level) => {
@@ -27,7 +28,14 @@ let setupLog = (style_renderer, level) => {
 
 let createConfig = (copts: commonOpts) => {
   open Run;
-  let {globalStorePrefix, localStorePath, projectPath, disableSandbox, _} = copts;
+  let {
+    globalStorePrefix,
+    localStorePath,
+    projectPath,
+    disableSandbox,
+    globalPathVariable,
+    _,
+  } = copts;
   let%bind currentPath = Bos.OS.Dir.current();
   let projectPath = Option.orDefault(~default=currentPath, projectPath);
   let storePath =
@@ -47,6 +55,7 @@ let createConfig = (copts: commonOpts) => {
     ~localStorePath=
       Option.orDefault(~default=projectPath / "_store", localStorePath),
     ~projectPath,
+    ~globalPathVariable,
     (),
   );
 };
@@ -248,6 +257,15 @@ let () = {
       let doc = "Disables sandboxing and builds the package without. CAUTION: this can be dangerous";
       Arg.(value & flag & info(["disable-sandbox"], ~docs, ~doc));
     };
+    let globalPathVariable = {
+      let doc = "Specifies the PATH variable to look for global utils in the build env.";
+      let env = Arg.env_var("ESY__GLOBAL_PATH", ~doc);
+      Arg.(
+        value
+        & opt(some(string), None)
+        & info(["global-path"], ~env, ~docs, ~doc)
+      );
+    };
     let setupLogT =
       Term.(
         const(setupLog)
@@ -262,6 +280,7 @@ let () = {
           planPath,
           logLevel,
           disableSandbox,
+          globalPathVariable,
         ) => {
       {
         projectPath,
@@ -270,6 +289,7 @@ let () = {
         planPath,
         logLevel,
         disableSandbox,
+        globalPathVariable,
       };
     };
     Term.(
@@ -280,6 +300,7 @@ let () = {
       $ planPath
       $ setupLogT
       $ disableSandbox
+      $ globalPathVariable
     );
   };
   /* Command terms */

--- a/esy-build/BuildSandbox.re
+++ b/esy-build/BuildSandbox.re
@@ -554,6 +554,7 @@ let makeScope =
         ~sourcePath,
         ~mode,
         ~depspec,
+        ~globalPathVariable=sandbox.cfg.globalPathVariable,
         pkg,
         buildManifest,
       );

--- a/esy-build/Scope.re
+++ b/esy-build/Scope.re
@@ -352,6 +352,7 @@ let make =
       ~depspec,
       ~sourceType,
       ~sourcePath,
+      ~globalPathVariable,
       pkg,
       buildManifest,
     ) => {
@@ -382,7 +383,13 @@ let make =
           let windir = Sys.getenv("WINDIR") ++ "/System32";
           let windir = Path.normalizePathSepOfFilename(windir);
           "$PATH;/usr/local/bin;/usr/bin;/bin;/usr/sbin;/sbin;" ++ windir;
-        | _ => "$PATH:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+        | _ =>
+          let esyGlobalPath =
+            switch (globalPathVariable) {
+            | Some(path) => path
+            | None => "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+            };
+          "$PATH:" ++ esyGlobalPath;
         };
 
       SandboxEnvironment.[

--- a/esy-build/Scope.rei
+++ b/esy-build/Scope.rei
@@ -19,6 +19,7 @@ let make:
     ~depspec: EsyInstall.Solution.DepSpec.t,
     ~sourceType: SourceType.t,
     ~sourcePath: SandboxPath.t,
+    ~globalPathVariable: option(string),
     EsyInstall.Package.t,
     BuildManifest.t
   ) =>


### PR DESCRIPTION
This allows environments where binaries don't live in standard locations
to use Esy.