### PR TITLE
add --retry and --retry-delay options to curl commands

### DIFF
--- a/esy-lib/Curl.re
+++ b/esy-lib/Curl.re
@@ -82,6 +82,10 @@ let getOrNotFound = (~accept=?, url) => {
       % "--silent"
       % "--connect-timeout"
       % "60"
+      % "--retry"
+      % "3"
+      % "--retry-delay"
+      % "5"
       % "--fail"
       % "--location"
       % url
@@ -121,6 +125,10 @@ let head = url => {
       % "--silent"
       % "--connect-timeout"
       % "60"
+      % "--retry"
+      % "3"
+      % "--retry-delay"
+      % "5"
       % "--fail"
       % "--location"
       % url
@@ -148,6 +156,10 @@ let download = (~output, url) => {
       % "--silent"
       % "--connect-timeout"
       % "60"
+      % "--retry"
+      % "3"
+      % "--retry-delay"
+      % "5"
       % "--fail"
       % "--location"
       % url


### PR DESCRIPTION
It's very annoying to run `esy install` on a device with an unstable internet connection because it fails for getting a single package out of many others. I think adding a retry will help