### PR TITLE
Bump esy-bash version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "babel-preset-env": "^1.7.0",
     "babel-preset-flow": "^6.23.0",
     "del": "^3.0.0",
-    "esy-bash": "0.3.19",
+    "esy-bash": "0.3.20",
     "flow-bin": "^0.77.0",
     "fs-extra": "^7.0.0",
     "jest-cli": "^23.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1337,10 +1337,10 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
   integrity sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=
 
-esy-bash@0.3.19:
-  version "0.3.19"
-  resolved "https://registry.yarnpkg.com/esy-bash/-/esy-bash-0.3.19.tgz#67f3ebeccea738f15153a628432ca50344913a3d"
-  integrity sha512-+Duv8M+ZWM+MSY30ypqJrj40y5trPHrXpORTGVimPXUl7+6sj9bJLbRR/Pp0QHHYhANZzCTJAEjpu2dV6zl5UQ==
+esy-bash@0.3.20:
+  version "0.3.20"
+  resolved "https://registry.yarnpkg.com/esy-bash/-/esy-bash-0.3.20.tgz#c2f8227bd047e73e661bd89e0bfe2c09fd1193c2"
+  integrity sha512-VeQY7AgpwmgDgeR/2yFRM3QyIYjnGF6SC6PHh8gOU8Tz3S2OA1wAFCgDS4sFGwqjK6VY4EfKERrxOpMojbi+7w==
 
 esy-solve-cudf@^0.1.10:
   version "0.1.10"


### PR DESCRIPTION
Just bumps the `esy-bash` version to pick up https://github.com/bryphe/esy-bash/pull/52.

Quick local test (installed version then this fixed version):

![image](https://user-images.githubusercontent.com/10038688/72005858-6d3c7680-3246-11ea-8501-072b2c13c062.png)

As an aside, there is a patched file from `esy-bash` [floating around in this repo](https://github.com/esy/esy/blob/master/scripts/build/patched-bash-exec.js), that doesn't contain the fixes that were applied upstream in `esy-bash` of quoting the `cd` command.

As far as I can tell, the only reference to it is from a stale AppVeyor `yml` file that isn't used. If thats the case, that is fine (well, it should probably be deleted if its not used and the relevant issue is fixed). If its used elsewhere, should probably apply the same quote fix here too.