### PR TITLE
Can select mode for export-dependencies and import-dependencies

### DIFF
--- a/bin/esy.re
+++ b/bin/esy.re
@@ -1239,12 +1239,15 @@ let exportDependencies = (mode: EsyBuild.BuildSpec.mode, proj: Project.t) => {
   let%bind configured = Project.configured(proj);
   let%bind plan = Project.plan(mode, proj);
 
-  let rootId =
-    configured.Project.root.EsyBuild.BuildSandbox.Task.pkg.Package.id;
   let%bind allProjectDependencies =
     BuildSandbox.Plan.all(plan)
     |> List.map(~f=task => task.BuildSandbox.Task.pkg)
-    |> List.filter(~f=pkg => pkg.Package.id != rootId)
+    |> List.filter(~f=pkg =>
+         switch (pkg.Package.source) {
+         | Link(_) => false
+         | Install(_) => true
+         }
+       )
     |> RunAsync.return;
 
   let exportBuild = pkg =>
@@ -1312,13 +1315,16 @@ let importDependencies =
   let%bind fetched = Project.fetched(proj);
   let%bind configured = Project.configured(proj);
 
-  let rootId =
-    configured.Project.root.EsyBuild.BuildSandbox.Task.pkg.Package.id;
   let%bind plan = Project.plan(mode, proj);
   let%bind allProjectDependencies =
     BuildSandbox.Plan.all(plan)
     |> List.map(~f=task => task.BuildSandbox.Task.pkg)
-    |> List.filter(~f=pkg => pkg.Package.id != rootId)
+    |> List.filter(~f=pkg =>
+         switch (pkg.Package.source) {
+         | Link(_) => false
+         | Install(_) => true
+         }
+       )
     |> RunAsync.return;
 
   let fromPath =

--- a/test-e2e/complete/export-import-basic-release.test.js
+++ b/test-e2e/complete/export-import-basic-release.test.js
@@ -1,0 +1,90 @@
+// @flow
+
+const path = require('path');
+const fs = require('fs-extra');
+
+const helpers = require('../test/helpers');
+const {packageJson, dir, file, dummyExecutable} = helpers;
+
+helpers.skipSuiteOnWindows('Needs investigation');
+
+it('basic export / import test', async () => {
+  const p = await helpers.createTestSandbox();
+  await p.fixture(
+    packageJson({
+      name: 'app',
+      version: '1.0.0',
+      license: 'MIT',
+      esy: {
+        build: ['ln -s #{dep.bin / dep.name}.cmd #{self.bin / self.name}.cmd'],
+      },
+      dependencies: {
+        dep: 'path:dep',
+      },
+      devDependencies: {
+        devdep: 'path:devdep',
+      }
+    }),
+    dir(
+      'dep',
+      packageJson({
+        name: 'dep',
+        version: '1.0.0',
+        license: 'MIT',
+        esy: {
+          build: ['ln -s #{subdep.bin / subdep.name}.cmd #{self.bin / self.name}.cmd'],
+        },
+        dependencies: {
+          subdep: 'path:../subdep',
+        },
+      }),
+    ),
+    dir(
+      'devdep',
+      packageJson({
+        name: 'devdep',
+        version: '1.0.0',
+        license: 'MIT',
+        esy: {
+          buildsInSource: true,
+          build: [helpers.buildCommand(p, '#{self.name}.js')],
+          install: [
+            'cp #{self.name}.cmd #{self.bin / self.name}.cmd',
+            'cp #{self.name}.js #{self.bin / self.name}.js',
+          ],
+        },
+      }),
+      dummyExecutable('devdep'),
+    ),
+    dir(
+      'subdep',
+      packageJson({
+        name: 'subdep',
+        version: '1.0.0',
+        license: 'MIT',
+        esy: {
+          buildsInSource: true,
+          build: [helpers.buildCommand(p, '#{self.name}.js')],
+          install: [
+            'cp #{self.name}.cmd #{self.bin / self.name}.cmd',
+            'cp #{self.name}.js #{self.bin / self.name}.js',
+          ],
+        },
+      }),
+      dummyExecutable('subdep'),
+    ),
+  );
+
+  await p.esy('install');
+  await p.esy('build');
+
+  let { stdout, stderr } = await p.esy('export-dependencies --release');
+  const exportPath = path.join(p.projectPath, '_export');
+
+  expect(await fs.exists(exportPath)).toBeTruthy();
+
+  const items = await fs.readdir(exportPath);
+
+  // make sure that devdep is not exported
+  items.forEach(v => expect(v).toEqual(expect.not.stringContaining('devdep')));
+});

--- a/test-e2e/complete/export-import-basic.test.js
+++ b/test-e2e/complete/export-import-basic.test.js
@@ -1,7 +1,6 @@
 // @flow
 
 const path = require('path');
-const del = require('del');
 const fs = require('fs-extra');
 
 const helpers = require('../test/helpers');
@@ -22,6 +21,9 @@ it('basic export / import test', async () => {
       dependencies: {
         dep: 'path:dep',
       },
+      devDependencies: {
+        devdep: 'path:devdep',
+      }
     }),
     dir(
       'dep',
@@ -36,6 +38,23 @@ it('basic export / import test', async () => {
           subdep: 'path:../subdep',
         },
       }),
+    ),
+    dir(
+      'devdep',
+      packageJson({
+        name: 'devdep',
+        version: '1.0.0',
+        license: 'MIT',
+        esy: {
+          buildsInSource: true,
+          build: [helpers.buildCommand(p, '#{self.name}.js')],
+          install: [
+            'cp #{self.name}.cmd #{self.bin / self.name}.cmd',
+            'cp #{self.name}.js #{self.bin / self.name}.js',
+          ],
+        },
+      }),
+      dummyExecutable('devdep'),
     ),
     dir(
       'subdep',
@@ -89,5 +108,9 @@ it('basic export / import test', async () => {
   {
     const {stdout} = await p.esy('x app.cmd');
     expect(stdout.trim()).toBe('__subdep__');
+  }
+  {
+    const {stdout} = await p.esy('devdep.cmd');
+    expect(stdout.trim()).toBe('__devdep__');
   }
 });


### PR DESCRIPTION
As discussed on discord, export-dependencies will now export dev dependencies, except if the --release flag is used.
The way I get all the dependencies is by getting the build plan depending on the mode and filtering the root from it, it feels a bit hacky but it works.

Add the tests to check that it works