### PR TITLE
Fixes copying of symlinks in sources

### DIFF
--- a/esy-build-package/Run.re
+++ b/esy-build-package/Run.re
@@ -257,6 +257,11 @@ let copyContents = (~from, ~ignore=[], dest) => {
           let%bind {st_atime: atime, st_mtime: mtime, _}: Unix.stats =
             Bos.OS.Path.stat(path);
           let%bind () = Bos.OS.File.write(nextPath, data);
+
+          let oc = open_out(nextPath |> Path.show); /* create or truncate file, return channel */
+          Printf.fprintf(oc, "%s\n", data); /* write something */
+          close_out(oc);
+
           Unix.utimes(Fpath.to_string(nextPath), atime, mtime);
           Bos.OS.Path.Mode.set(nextPath, stats.Unix.st_perm);
         | Unix.S_LNK =>

--- a/esy-build-package/Run.re
+++ b/esy-build-package/Run.re
@@ -246,7 +246,7 @@ let copyContents = (~from, ~ignore=[], dest) => {
                  )) {
         Ok();
       } else {
-        let%bind stats = Bos.OS.Path.symlink_stat(path);
+        let%bind stats = Bos.OS.Path.stat(path);
         let nextPath = rebasePath(path);
         switch (stats.Unix.st_kind) {
         | Unix.S_DIR =>
@@ -257,11 +257,6 @@ let copyContents = (~from, ~ignore=[], dest) => {
           let%bind {st_atime: atime, st_mtime: mtime, _}: Unix.stats =
             Bos.OS.Path.stat(path);
           let%bind () = Bos.OS.File.write(nextPath, data);
-
-          let oc = open_out(nextPath |> Path.show); /* create or truncate file, return channel */
-          Printf.fprintf(oc, "%s\n", data); /* write something */
-          close_out(oc);
-
           Unix.utimes(Fpath.to_string(nextPath), atime, mtime);
           Bos.OS.Path.Mode.set(nextPath, stats.Unix.st_perm);
         | Unix.S_LNK =>


### PR DESCRIPTION
We encountered issues with packages that have `buildsInSource: true` with symlinks in the source tree. This ignore symlink redirects during the `stat` as the path was anyways found to not be a symlink

Closes #855 