### PR TITLE
Improve local tests-e2e-re

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,6 +166,12 @@ test-unit::
 test-e2e:: ./bin/esy
 	@./node_modules/.bin/jest test-e2e
 
+verdaccio::
+	cd test-e2e-re/lib/verdaccio && npm install
+
+test-e2e-re:: ./bin/esy verdaccio
+	esy test:e2e-re
+
 test-e2e-slow:: ./bin/esy
 	@./node_modules/.bin/jest test-e2e-slow
 
@@ -174,6 +180,8 @@ test::
 	@$(MAKE) test-unit
 	@echo "Running test suite: e2e"
 	@$(MAKE) test-e2e
+	@echo "Running test suite: e2e-re"
+	@$(MAKE) test-e2e-re
 
 ci::
 	@$(MAKE) test

--- a/esy.json
+++ b/esy.json
@@ -28,7 +28,7 @@
     "release:platform-release": "node ./scripts/make-platform-release.js",
     "test:unit": "esy b dune runtest",
     "test:e2e": "npm run jest test-e2e",
-    "test:e2e-re": "esy b dune exec ./test-e2e-re/lib/RunTests.exe",
+    "test:e2e-re": "sh -c 'esy b; esy dune exec ./test-e2e-re/lib/RunTests.exe'",
     "test:e2e-slow": "node test-e2e-slow/run-slow-tests.js"
   },
   "resolutions": {


### PR DESCRIPTION
## Problems

- by using `esy b dune exec` if the user installed node locally like when using `n` or `nvm` it fails
- test-e2e-re wasn't documented how to use neither was being run at `make test`

## How it was solved
To solve the problem of node local only, replaces it with a shell script inlined.

To solve the test-e2e-re not being run at `make test` it was added to the Makefile and also added an `npm install` on verdaccio which is needed