### PR TITLE
Tests: add devDependencies to PackageGraph.read

### DIFF
--- a/test-e2e/complete/lock-invalidation.test.js
+++ b/test-e2e/complete/lock-invalidation.test.js
@@ -40,8 +40,9 @@ describe('lock invalidation', () => {
       name: 'root',
       version: 'link-dev:./package.json',
       dependencies: {
-        a: {name: 'a', version: '1.0.0', dependencies: {}},
+        a: {name: 'a', version: '1.0.0', dependencies: {}, devDependencies: {}},
       },
+      devDependencies: {},
     });
 
     // wait, on macOS sometimes it doesn't pick up changes
@@ -60,9 +61,10 @@ describe('lock invalidation', () => {
       name: 'root',
       version: 'link-dev:./package.json',
       dependencies: {
-        a: {name: 'a', version: '1.0.0', dependencies: {}},
-        b: {name: 'b', version: '1.0.0', dependencies: {}},
+        a: {name: 'a', version: '1.0.0', dependencies: {}, devDependencies: {}},
+        b: {name: 'b', version: '1.0.0', dependencies: {}, devDependencies: {}},
       },
+      devDependencies: {},
     });
 
     // wait, on macOS sometimes it doesn't pick up changes
@@ -81,8 +83,9 @@ describe('lock invalidation', () => {
       name: 'root',
       version: 'link-dev:./package.json',
       dependencies: {
-        a: {name: 'a', version: '1.0.0', dependencies: {}},
+        a: {name: 'a', version: '1.0.0', dependencies: {}, devDependencies: {}},
       },
+      devDependencies: {},
     });
   });
 
@@ -126,10 +129,12 @@ describe('lock invalidation', () => {
           name: 'dep',
           version: 'link:dep',
           dependencies: {
-            a: {name: 'a', version: '1.0.0', dependencies: {}},
+            a: {name: 'a', version: '1.0.0', dependencies: {}, devDependencies: {}},
           },
+          devDependencies: {},
         },
       },
+      devDependencies: {},
     });
 
     // wait, on macOS sometimes it doesn't pick up changes
@@ -152,11 +157,13 @@ describe('lock invalidation', () => {
           name: 'dep',
           version: 'link:dep',
           dependencies: {
-            a: {name: 'a', version: '1.0.0', dependencies: {}},
-            b: {name: 'b', version: '1.0.0', dependencies: {}},
+            a: {name: 'a', version: '1.0.0', dependencies: {}, devDependencies: {}},
+            b: {name: 'b', version: '1.0.0', dependencies: {}, devDependencies: {}},
           },
+          devDependencies: {},
         },
       },
+      devDependencies: {},
     });
 
     // wait, on macOS sometimes it doesn't pick up changes
@@ -179,10 +186,12 @@ describe('lock invalidation', () => {
           name: 'dep',
           version: 'link:dep',
           dependencies: {
-            a: {name: 'a', version: '1.0.0', dependencies: {}},
+            a: {name: 'a', version: '1.0.0', dependencies: {}, devDependencies: {}},
           },
+          devDependencies: {},
         },
       },
+      devDependencies: {},
     });
   });
 
@@ -227,13 +236,15 @@ describe('lock invalidation', () => {
       name: 'root',
       version: 'link-dev:./package.json',
       dependencies: {
-        a: {name: 'a', version: '1.0.0', dependencies: {}},
+        a: {name: 'a', version: '1.0.0', dependencies: {}, devDependencies: {}},
         dep: {
           name: 'dep',
           version: 'link:dep',
           dependencies: {},
+          devDependencies: {},
         },
       },
+      devDependencies: {},
     });
 
     // wait, on macOS sometimes it doesn't pick up changes
@@ -252,15 +263,17 @@ describe('lock invalidation', () => {
       name: 'root',
       version: 'link-dev:./package.json',
       dependencies: {
-        a: {name: 'a', version: '1.0.0', dependencies: {}},
+        a: {name: 'a', version: '1.0.0', dependencies: {}, devDependencies: {}},
         dep: {
           name: 'dep',
           version: 'link:dep',
           dependencies: {
-            b: {name: 'b', version: '1.0.0', dependencies: {}},
+            b: {name: 'b', version: '1.0.0', dependencies: {}, devDependencies: {}},
           },
+          devDependencies: {},
         },
       },
+      devDependencies: {},
     });
 
     // wait, on macOS sometimes it doesn't pick up changes
@@ -288,10 +301,12 @@ describe('lock invalidation', () => {
           name: 'dep',
           version: 'link:dep',
           dependencies: {
-            b: {name: 'b', version: '1.0.0', dependencies: {}},
+            b: {name: 'b', version: '1.0.0', dependencies: {}, devDependencies: {}},
           },
+          devDependencies: {},
         },
       },
+      devDependencies: {},
     });
   });
 });

--- a/test-e2e/complete/sandbox-overrides.test.js
+++ b/test-e2e/complete/sandbox-overrides.test.js
@@ -99,13 +99,13 @@ describe('Sandbox overrides', function() {
     await p.esy('@another install');
 
     expect(await helpers.readInstalledPackages(p.projectPath, 'default')).toMatchObject({
-      dependencies: {
+      devDependencies: {
         dep: {name: 'dep', version: '1.0.0'},
       },
     });
 
     expect(await helpers.readInstalledPackages(p.projectPath, 'another')).toMatchObject({
-      dependencies: {
+      devDependencies: {
         dep: {name: 'dep', version: '2.0.0'},
       },
     });
@@ -309,8 +309,10 @@ describe('Sandbox overrides', function() {
     await p.esy('install');
     expect(await helpers.readInstalledPackages(p.projectPath)).toMatchObject({
       dependencies: {
-        devDep: {name: 'devDep'},
         '@esy-ocaml/substs': {name: '@esy-ocaml/substs'},
+      },
+      devDependencies: {
+        devDep: {name: 'devDep'},
       },
     });
   });

--- a/test-e2e/esy-install/devDependencies.test.js
+++ b/test-e2e/esy-install/devDependencies.test.js
@@ -34,7 +34,7 @@ describe('Installing devDependencies', function() {
     });
 
     await expect(helpers.readInstalledPackages(p.projectPath)).resolves.toMatchObject({
-      dependencies: {
+      devDependencies: {
         devDep: {
           name: 'devDep',
         },
@@ -76,7 +76,7 @@ describe('Installing devDependencies', function() {
     });
 
     await expect(helpers.readInstalledPackages(p.projectPath)).resolves.toMatchObject({
-      dependencies: {
+      devDependencies: {
         devDep: {
           name: 'devDep',
           dependencies: {
@@ -132,6 +132,8 @@ describe('Installing devDependencies', function() {
           name: 'ok',
           version: '1.0.0',
         },
+      },
+      devDependencies: {
         devDep: {
           name: 'devDep',
           dependencies: {
@@ -183,7 +185,7 @@ describe('Installing devDependencies', function() {
 
     const layout = await helpers.readInstalledPackages(p.projectPath);
     await expect(layout).toMatchObject({
-      dependencies: {
+      devDependencies: {
         devDep: {
           name: 'devDep',
           dependencies: {

--- a/test-e2e/test/PackageGraph.js
+++ b/test-e2e/test/PackageGraph.js
@@ -191,9 +191,10 @@ async function read(directory: string, sandbox?: string = 'default'): Promise<?P
       dependencies[name] = make(dep);
     }
 
+    const devDependencies = {};
     for (const dep of item.devDependencies) {
       const {name} = parseId(dep);
-      dependencies[name] = make(dep);
+      devDependencies[name] = make(dep);
     }
 
     return {
@@ -201,6 +202,7 @@ async function read(directory: string, sandbox?: string = 'default'): Promise<?P
       version: item.version,
       path: installation[id].path,
       dependencies,
+      devDependencies,
     };
   }
 


### PR DESCRIPTION
## Why?

#980 is blocked because of the test failing, currently we use a single `dependencies` entry on `PackageGraph.read` and devDeps are inside of it, but having explicitly `devDependencies` and `dependencies` seems to make more sense as it cover more problems.

By merging this PR #980 can be rebased and probably also merged

## What this PR does?
Change the mentioned behavior on `PackageGraph.read` and fix the tests which rely on it.

## Use or not use `toEqual` vs `toMatchObject`?

`lock-invalidation.test.js` needed so many changes because it is using `toEqual` on the comparison instead of `toMatchObject` like in the other tests, which is more strict but also it's a weird choice here.