### PR TITLE
Check pkg.installConfig.pnp to disable pnp

### DIFF
--- a/esy-install/Package.re
+++ b/esy-install/Package.re
@@ -8,6 +8,7 @@ type t = {
   overrides: Overrides.t,
   dependencies: PackageId.Set.t,
   devDependencies: PackageId.Set.t,
+  installConfig: InstallConfig.t,
 };
 
 let compare = (a, b) => PackageId.compare(a.id, b.id);

--- a/esy-install/Package.rei
+++ b/esy-install/Package.rei
@@ -8,6 +8,7 @@ type t = {
   overrides: Overrides.t,
   dependencies: PackageId.Set.t,
   devDependencies: PackageId.Set.t,
+  installConfig: InstallConfig.t,
 };
 
 let id: t => PackageId.t;

--- a/esy-install/SolutionLock.re
+++ b/esy-install/SolutionLock.re
@@ -48,6 +48,7 @@ and node = {
   overrides,
   dependencies: PackageId.Set.t,
   devDependencies: PackageId.Set.t,
+  installConfig: InstallConfig.t,
 };
 
 let indexFilename = "index.json";
@@ -216,6 +217,7 @@ let writePackage = (sandbox, pkg: Package.t) => {
     overrides,
     dependencies: pkg.dependencies,
     devDependencies: pkg.devDependencies,
+    installConfig: pkg.installConfig,
   });
 };
 
@@ -241,6 +243,7 @@ let readPackage = (sandbox, node: node) => {
     overrides,
     dependencies: node.dependencies,
     devDependencies: node.devDependencies,
+    installConfig: node.installConfig,
   });
 };
 

--- a/esy-package-config/InstallConfig.re
+++ b/esy-package-config/InstallConfig.re
@@ -1,0 +1,4 @@
+[@deriving (to_yojson, of_yojson({strict: false}))]
+type t = {pnp: [@default true] bool};
+
+let empty = {pnp: true};

--- a/esy-package-config/InstallConfig.rei
+++ b/esy-package-config/InstallConfig.rei
@@ -1,0 +1,6 @@
+type t = {pnp: bool};
+
+let empty: t;
+
+let to_yojson: Json.encoder(t);
+let of_yojson: Json.decoder(t);

--- a/esy-package-config/InstallManifest.re
+++ b/esy-package-config/InstallManifest.re
@@ -148,6 +148,7 @@ type t = {
   optDependencies: StringSet.t,
   resolutions: Resolutions.t,
   kind,
+  installConfig: InstallConfig.t,
 }
 and kind =
   | Esy

--- a/esy-package-config/InstallManifest.rei
+++ b/esy-package-config/InstallManifest.rei
@@ -41,6 +41,7 @@ type t = {
   optDependencies: StringSet.t,
   resolutions: Resolutions.t,
   kind,
+  installConfig: InstallConfig.t,
 }
 and kind =
   | Esy

--- a/esy-package-config/OfPackageJson.re
+++ b/esy-package-config/OfPackageJson.re
@@ -31,6 +31,8 @@ module InstallManifestV1 = {
       esy: option(EsyPackageJson.t),
       [@default None]
       dist: option(dist),
+      [@default InstallConfig.empty]
+      installConfig: InstallConfig.t,
     }
     and dist = {
       tarball: string,
@@ -180,6 +182,7 @@ module InstallManifestV1 = {
           } else {
             Npm;
           },
+        installConfig: pkgJson.installConfig,
       },
       warnings,
     ));

--- a/esy-solve/OpamManifest.re
+++ b/esy-solve/OpamManifest.re
@@ -376,6 +376,7 @@ let toInstallManifest = (~source=?, ~name, ~version, manifest) => {
         optDependencies,
         peerDependencies: NpmFormula.empty,
         resolutions: Resolutions.empty,
+        installConfig: InstallConfig.empty,
       }),
     );
   };

--- a/esy-solve/Resolver.re
+++ b/esy-solve/Resolver.re
@@ -94,6 +94,7 @@ let emptyLink = (~name, ~path, ~manifest, ~kind, ()) => {
   optDependencies: StringSet.empty,
   resolutions: Resolutions.empty,
   kind: Esy,
+  installConfig: InstallConfig.empty,
 };
 
 let emptyInstall = (~name, ~source, ()) => {
@@ -109,6 +110,7 @@ let emptyInstall = (~name, ~source, ()) => {
   optDependencies: StringSet.empty,
   resolutions: Resolutions.empty,
   kind: Esy,
+  installConfig: InstallConfig.empty,
 };
 
 let make = (~cfg, ~sandbox, ()) =>

--- a/esy-solve/Sandbox.re
+++ b/esy-solve/Sandbox.re
@@ -106,6 +106,7 @@ let make = (~cfg, spec: EsyInstall.SandboxSpec.t) => {
           optDependencies: StringSet.empty,
           resolutions,
           kind: Npm,
+          installConfig: InstallConfig.empty,
         };
         return({cfg, spec, root, resolutions: root.resolutions, resolver});
       };

--- a/esy-solve/Solver.re
+++ b/esy-solve/Solver.re
@@ -374,6 +374,7 @@ let lockPackage =
     optDependencies,
     resolutions: _,
     kind: _,
+    installConfig,
   } = pkg;
 
   let idsOfDependencies = dependencies =>
@@ -452,6 +453,7 @@ let lockPackage =
     overrides,
     dependencies,
     devDependencies,
+    installConfig,
   });
 };
 
@@ -626,6 +628,7 @@ let solveDependencies =
     optDependencies: StringSet.empty,
     resolutions: Resolutions.empty,
     kind: Esy,
+    installConfig: InstallConfig.empty,
   };
 
   let universe = Universe.add(~pkg=dummyRoot, solver.universe);


### PR DESCRIPTION
[Yarn uses](https://classic.yarnpkg.com/en/docs/pnp/getting-started/) the package.json key `installConfig.pnp` to enable PnP; however, I know that esy wants to default to plug-n-play, so I added the ability to *disable* PnP using the same key (when it is set to false).

The reason this is needed is that some projects (like [grain](https://github.com/grain-lang/grain/commits/organization)) use yarn workspaces to handle the linking of npm dependencies in a monorepo containing JS and OCaml code, but have esy as a separate phase of the build to manage the ocaml code. Right now, Grain needs to delete the node PnP bootstrap after it builds code—but it would be much nicer to always disable PnP.