### PR TITLE
fix checkout string parsing to allow remote url

### DIFF
--- a/esy-lib/Cli.re
+++ b/esy-lib/Cli.re
@@ -108,17 +108,23 @@ let cmdConv = {
 
 let checkoutConv = {
   open Cmdliner;
-  let parse = v =>
-    switch (Astring.String.cut(~rev=true, ~sep=":", v)) {
-    | Some(("", local)) => Ok(`Local(Path.v(local)))
-    | Some((remote, local)) =>
-      switch (remote) {
-      | "http"
-      | "https" => Ok(`Remote(v))
-      | _ => Ok(`RemoteLocal((remote, Path.v(local))))
+  let parse = v => {
+    switch (String.split_on_char(':', v)) {
+    | ["", ...tail] =>
+      let local = String.concat(":", tail);
+      Ok(`Local(Path.v(local)));
+    | ["http" as p, snd, ...tail]
+    | ["https" as p, snd, ...tail] =>
+      if (List.length(tail) == 0) {
+        Ok(`Remote(v));
+      } else {
+        let remote = String.concat(":", [p, snd]);
+        let local = String.concat(":", [p, snd]);
+        Ok(`RemoteLocal((remote, Path.v(local))));
       }
-    | None => Ok(`Remote(v))
+    | _ => Ok(`Remote(v))
     };
+  };
 
   let print = (fmt: Format.formatter, v) =>
     switch (v) {

--- a/esy-lib/Cli.re
+++ b/esy-lib/Cli.re
@@ -119,7 +119,7 @@ let checkoutConv = {
         Ok(`Remote(v));
       } else {
         let remote = String.concat(":", [p, snd]);
-        let local = String.concat(":", [p, snd]);
+        let local = String.concat(":", tail);
         Ok(`RemoteLocal((remote, Path.v(local))));
       }
     | _ => Ok(`Remote(v))

--- a/esy-lib/Cli.re
+++ b/esy-lib/Cli.re
@@ -109,10 +109,14 @@ let cmdConv = {
 let checkoutConv = {
   open Cmdliner;
   let parse = v =>
-    switch (Astring.String.cut(~sep=":", v)) {
-    | Some((remote, "")) => Ok(`Remote(remote))
+    switch (Astring.String.cut(~rev=true, ~sep=":", v)) {
     | Some(("", local)) => Ok(`Local(Path.v(local)))
-    | Some((remote, local)) => Ok(`RemoteLocal((remote, Path.v(local))))
+    | Some((remote, local)) =>
+      switch (remote) {
+      | "http"
+      | "https" => Ok(`Remote(v))
+      | _ => Ok(`RemoteLocal((remote, Path.v(local))))
+      }
     | None => Ok(`Remote(v))
     };
 


### PR DESCRIPTION
Should fix the string parsing issue when using a remote URL for `--opam-repository` or `--opam-override-repository` options.