### PR TITLE
increase RLIMIT_NOFILE locally on Linux and macOS

### DIFF
--- a/bin/esy.re
+++ b/bin/esy.re
@@ -2120,6 +2120,8 @@ let commandsConfig = {
 };
 
 let () = {
+  EsyLib.System.ensureMinimumFileDescriptors();
+
   let (defaultCommand, commands) = commandsConfig;
 
   /*

--- a/esy-lib/System.re
+++ b/esy-lib/System.re
@@ -121,6 +121,9 @@ module Arch = {
 external checkLongPathRegistryKey: unit => bool =
   "esy_win32_check_long_path_regkey";
 
+external ensureMinimumFileDescriptors: unit => unit =
+  "esy_ensure_minimum_file_descriptors";
+
 let supportsLongPaths = () =>
   switch (Sys.win32) {
   | false => true

--- a/esy-lib/System.rei
+++ b/esy-lib/System.rei
@@ -46,6 +46,8 @@ module Arch: {
 
 let supportsLongPaths: unit => bool;
 
+let ensureMinimumFileDescriptors: unit => unit;
+
 module Environment: {
   /** Environment variable separator which is used for $PATH and etc */
 

--- a/esy-lib/dune
+++ b/esy-lib/dune
@@ -9,7 +9,7 @@
    EsyShellExpansion)
  (foreign_stubs
   (language c)
-  (names win32_path))
+  (names unix_rlimit_patch win32_path))
  (preprocess
   (pps lwt_ppx ppx_let ppx_deriving_yojson ppx_deriving.std ppx_expect
     ppx_inline_test ppx_sexp_conv)))

--- a/esy-lib/unix_rlimit_patch.c
+++ b/esy-lib/unix_rlimit_patch.c
@@ -1,0 +1,20 @@
+#include <caml/mlvalues.h>
+
+#if __APPLE__ || __linux__
+#include <sys/resource.h>
+#endif
+
+#define MIN_NOFILE 4096
+
+CAMLprim value
+esy_ensure_minimum_file_descriptors(value unit) {
+#if __APPLE__ || __linux__
+    struct rlimit limits;
+    getrlimit(RLIMIT_NOFILE, &limits);
+    if (limits.rlim_cur < MIN_NOFILE) {
+        limits.rlim_cur = MIN_NOFILE;
+        setrlimit(RLIMIT_NOFILE, &limits);
+    }
+#endif
+    return Val_unit; 
+}

--- a/test-e2e/esy-CMD.test.js
+++ b/test-e2e/esy-CMD.test.js
@@ -92,6 +92,17 @@ describe(`'esy CMD' invocation`, () => {
     await p.esy('devDep.cmd');
   });
 
+  test.disableIf(isWindows)('ensures the RLIMIT_NOFILE was set', async () => {
+    const p = await createTestSandbox();
+    await p.esy('install');
+    const { stdout } = await p.run([
+      "ulimit -Sn 2048",
+      `${helpers.ESY} sh -c "ulimit -Sn"`,
+    ].join('\n'));
+    const result = stdout.trim();
+    expect(result).toEqual("4096");
+  })
+
   test('inherits the outside environment', async () => {
     process.env.X = '1';
     const p = await createTestSandbox();


### PR DESCRIPTION
This PR closes #1057

Revery is working with this patch without using `ulimit`

## How it works

It uses `setrlimit` to increase RLIMIT_NOFILE to 4096 if it isn't big enough, this should be completely safe as `setrlimit` applies only to the current process and his children.
