### PR TITLE
Prefix rewriting fix for Windows

### DIFF
--- a/esy-build-package/bin/esyRewritePrefixCommand.re
+++ b/esy-build-package/bin/esyRewritePrefixCommand.re
@@ -8,7 +8,7 @@ let rewritePrefixInFile' = (~origPrefix, ~destPrefix, path) =>
   };
 
 let replaceAllButFirstForwardSlashWithBack = s =>
-  switch(String.split_on_char('/', s)) {
+  switch (String.split_on_char('/', s)) {
   | [hd, ...tl] => hd ++ "/" ++ String.concat("\\", tl)
   | [] => s
   };
@@ -62,11 +62,13 @@ let rewritePrefixesInFile = (~origPrefix, ~destPrefix, path) => {
       );
 
       rewritePrefixInFile'(
-        ~origPrefix=replaceAllButFirstForwardSlashWithBack(Path.normalizePathSepOfFilename(origPrefixString)),
+        ~origPrefix=
+          replaceAllButFirstForwardSlashWithBack(
+            Path.normalizePathSepOfFilename(origPrefixString),
+          ),
         ~destPrefix=escapedDestPrefix,
-        path
+        path,
       );
-
     };
 
     return();

--- a/esy-build-package/bin/esyRewritePrefixCommand.re
+++ b/esy-build-package/bin/esyRewritePrefixCommand.re
@@ -7,6 +7,12 @@ let rewritePrefixInFile' = (~origPrefix, ~destPrefix, path) =>
   | Error(msg) => Error(`Msg(msg))
   };
 
+let replaceAllButFirstForwardSlashWithBack = s =>
+  switch(String.split_on_char('/', s)) {
+  | [hd, ...tl] => hd ++ "/" ++ String.concat("\\", tl)
+  | [] => s
+  };
+
 let rewritePrefixesInFile = (~origPrefix, ~destPrefix, path) => {
   open Result.Syntax;
 
@@ -54,6 +60,13 @@ let rewritePrefixesInFile = (~origPrefix, ~destPrefix, path) => {
         ~destPrefix=escapedDestPrefix,
         path,
       );
+
+      rewritePrefixInFile'(
+        ~origPrefix=replaceAllButFirstForwardSlashWithBack(Path.normalizePathSepOfFilename(origPrefixString)),
+        ~destPrefix=escapedDestPrefix,
+        path
+      );
+
     };
 
     return();


### PR DESCRIPTION
This PR adds another search candidate for prefix rewriting. Along with the ideal `C:\foo\bar`, `C:/foo/bar`, we noticed some paths were of the form `C:/foo\bar\baz..` 

Ideally, all three searches could be unified into a single pass