### PR TITLE
fix concurrency on windows

### DIFF
--- a/bin/NpmReleaseCommand.re
+++ b/bin/NpmReleaseCommand.re
@@ -751,7 +751,8 @@ let run = (proj: Project.t) => {
   make(
     ~ocamlopt,
     ~outputPath,
-    ~concurrency=EsyRuntime.concurrency,
+    ~concurrency=
+      EsyRuntime.concurrency(proj.projcfg.ProjectConfig.buildConcurrency),
     proj.buildCfg,
     proj.projcfg.ProjectConfig.spec,
     fetched.Project.sandbox,

--- a/bin/Project.re
+++ b/bin/Project.re
@@ -716,7 +716,8 @@ let buildDependencies =
       Solution.dependenciesByDepSpec(solved.solution, depspec, task.pkg);
     BuildSandbox.build(
       ~skipStalenessCheck,
-      ~concurrency=EsyRuntime.concurrency,
+      ~concurrency=
+        EsyRuntime.concurrency(proj.projcfg.ProjectConfig.buildConcurrency),
       ~buildLinked,
       fetched.sandbox,
       plan,

--- a/bin/ProjectConfig.re
+++ b/bin/ProjectConfig.re
@@ -204,6 +204,7 @@ type t = {
   prefixPath: option(Path.t),
   cacheTarballsPath: option(Path.t),
   fetchConcurrency: option(int),
+  buildConcurrency: option(int),
   opamRepository: option(EsySolve.Config.checkoutCfg),
   esyOpamOverride: option(EsySolve.Config.checkoutCfg),
   opamRepositoryLocal: option(Path.t),
@@ -391,6 +392,16 @@ let fetchConcurrencyArg = {
   );
 };
 
+let buildConcurrencyArg = {
+  let doc = "Specifies number of concurrent build tasks";
+  let env = Arg.env_var("ESY__BUILD_CONCURRENCY", ~doc);
+  Arg.(
+    value
+    & opt(some(int), None)
+    & info(["build-concurrency"], ~env, ~doc, ~docs=commonOptionsSection)
+  );
+};
+
 let solveCudfCommandArg = {
   let doc = "Set command which is used for solving CUDF problems.";
   let env = Arg.env_var("ESY__SOLVE_CUDF_COMMAND", ~doc);
@@ -408,6 +419,7 @@ let make =
       prefixPath,
       cacheTarballsPath,
       fetchConcurrency,
+      buildConcurrency,
       opamRepository,
       esyOpamOverride,
       opamRepositoryLocal,
@@ -440,6 +452,7 @@ let make =
     prefixPath,
     cacheTarballsPath,
     fetchConcurrency,
+    buildConcurrency,
     opamRepository,
     esyOpamOverride,
     opamRepositoryLocal,
@@ -461,6 +474,7 @@ let promiseTerm = {
         prefixPath,
         cacheTarballsPath,
         fetchConcurrency,
+        buildConcurrency,
         opamRepository,
         esyOpamOverride,
         opamRepositoryLocal,
@@ -479,6 +493,7 @@ let promiseTerm = {
       prefixPath,
       cacheTarballsPath,
       fetchConcurrency,
+      buildConcurrency,
       opamRepository,
       esyOpamOverride,
       opamRepositoryLocal,
@@ -498,6 +513,7 @@ let promiseTerm = {
     $ prefixPath
     $ cacheTarballsPath
     $ fetchConcurrencyArg
+    $ buildConcurrencyArg
     $ opamRepositoryArg
     $ esyOpamOverrideArg
     $ opamRepositoryLocalArg
@@ -523,6 +539,7 @@ let promiseTermForMultiplePaths = resolvedPathTerm => {
         prefixPath,
         cacheTarballsPath,
         fetchConcurrency,
+        buildConcurrency,
         opamRepository,
         esyOpamOverride,
         opamRepositoryLocal,
@@ -543,6 +560,7 @@ let promiseTermForMultiplePaths = resolvedPathTerm => {
            prefixPath,
            cacheTarballsPath,
            fetchConcurrency,
+           buildConcurrency,
            opamRepository,
            esyOpamOverride,
            opamRepositoryLocal,
@@ -572,6 +590,7 @@ let promiseTermForMultiplePaths = resolvedPathTerm => {
     $ prefixPath
     $ cacheTarballsPath
     $ fetchConcurrencyArg
+    $ buildConcurrencyArg
     $ opamRepositoryArg
     $ esyOpamOverrideArg
     $ opamRepositoryLocalArg

--- a/bin/ProjectConfig.re
+++ b/bin/ProjectConfig.re
@@ -385,10 +385,11 @@ let skipRepositoryUpdateArg = {
 
 let fetchConcurrencyArg = {
   let doc = "Specifies number of concurrent fetch tasks.";
+  let env = Arg.env_var("ESY__FETCH_CONCURRENCY", ~doc);
   Arg.(
     value
     & opt(some(int), None)
-    & info(["fetch-concurrency"], ~doc, ~docs=commonOptionsSection)
+    & info(["fetch-concurrency"], ~env, ~doc, ~docs=commonOptionsSection)
   );
 };
 

--- a/bin/ProjectConfig.rei
+++ b/bin/ProjectConfig.rei
@@ -13,6 +13,7 @@ type t = {
   prefixPath: option(Path.t),
   cacheTarballsPath: option(Path.t),
   fetchConcurrency: option(int),
+  buildConcurrency: option(int),
   opamRepository: option(EsySolve.Config.checkoutCfg),
   esyOpamOverride: option(EsySolve.Config.checkoutCfg),
   opamRepositoryLocal: option(Path.t),


### PR DESCRIPTION
## Problems

- Windows doesn't support `getconf` on powershell,
- There is no way to limit the number of parallel processes during build

## Solutions

- Windows has an env variable called `NUMBER_OF_PROCESSORS` for that
- added the env variable called `ESY_BUILD_CONCURRENCY`