### PR TITLE
Update Fs.re to handle EXDEV and degrade to using "mv" if encountered.

### DIFF
--- a/esy-lib/Fs.re
+++ b/esy-lib/Fs.re
@@ -165,6 +165,17 @@ let rename = (~skipIfExists=false, ~src, target) => {
     } else {
       RunAsync.errorf("destination already exists: %s", filename);
     }
+  | Unix.Unix_error(Unix.EXDEV, "rename", filename) =>
+    let%lwt () =
+      Logs_lwt.debug(m =>
+        m("rename of %s failed with EXDEV, trying `mv`", filename)
+      );
+    let cmd = Printf.sprintf("mv %s %s", src, target);
+    if (Sys.command(cmd) == 0) {
+      RunAsync.return();
+    } else {
+      RunAsync.errorf("Unable to rename %s to %s", src, target);
+    };
   };
 };
 

--- a/test/Fs.re
+++ b/test/Fs.re
@@ -71,3 +71,24 @@ let%test "rmPathLwt - delete read only file" = {
 
   TestHarness.runRunAsyncTest(test);
 };
+
+let%test "rename - can rename a directory" = {
+  let test = () => {
+    let f = (srcTempPath, dstTempPath) => {
+      open RunAsync.Syntax;
+      let src = Path.(srcTempPath / "test.txt");
+      let dst = Path.(dstTempPath / "");
+      let data = "test";
+      let%bind () = Fs.writeFile(~data, src);
+      let src = Path.(srcTempPath / "");
+      let%bind () = Fs.rename(~src, dst);
+      return(true);
+    };
+
+    Fs.withTempDir(srcTempPath => {
+      Fs.withTempDir(dstTempPath => {f(srcTempPath, dstTempPath)})
+    });
+  };
+
+  TestHarness.runRunAsyncTest(test);
+};


### PR DESCRIPTION
This should help handle use-cases where the `.esy` cache is on a different filesystem than the `_esy` build cache and a rename is required. My specific scenario is a decent size OCaml system (~35 deps, C stubs, etc.) inside of a Docker BuildKit build with different caches mounted at `~/.esy` and `_esy`. The `Lwt_unix.rename` command was raising `Unix.EXDEV` and terminating the build.

I got the idea for this patch from a fix for a similar issue described here https://bugzilla.redhat.com/show_bug.cgi?id=1670210 with this commit https://github.com/libguestfs/supermin/commit/6579cf5f72d5de345ae1cc97d0344dfa1771460a which simply used the local `mv` command. I felt it would be better to only degrade to `mv` in case `Unix.EXDEV` is raised.

Regarding Windows support: I am not sure if `Unix.EXDEV` will ever get raised in Windows, and if it does, this will still fail in approximately the same way, since `mv` will likely either work or not exist. I could potentially test this at a later date but I don't have access to my Windows development machine (it's stuck at the office).

I have a "minimum" test case here: https://github.com/pm-mck/demo-esy-docker. It appears the `pkg-config` `devDependency` is required to trigger the behavior. 

To fully test this fix I mounted my customized esy build inside of that docker build and it was able to `mv` the cache correctly.

