### PR TITLE
Allow configuring global lookup paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,3 +271,4 @@ The release workflow is the following:
 [ocamlbuild]: https://github.com/ocaml/ocamlbuild/blob/master/manual/manual.adoc
 [pjc]: https://github.com/jordwalke/PackageJsonForCompilers
 [esy.sh]: http://esy.sh
+

--- a/bin/Project.re
+++ b/bin/Project.re
@@ -167,6 +167,7 @@ let makeProject = (makeSolved, projcfg: ProjectConfig.t) => {
         ~storePath,
         ~localStorePath=EsyInstall.SandboxSpec.storePath(projcfg.spec),
         ~projectPath=projcfg.spec.path,
+        ~globalPathVariable=projcfg.globalPathVariable,
         (),
       ),
     );

--- a/bin/ProjectConfig.re
+++ b/bin/ProjectConfig.re
@@ -215,6 +215,7 @@ type t = {
   solveTimeout: option(float),
   skipRepositoryUpdate: bool,
   solveCudfCommand: option(Cmd.t),
+  globalPathVariable: option(string),
 };
 
 let storePath = cfg => {
@@ -346,6 +347,16 @@ let esyOpamOverrideRemoteArg = {
   );
 };
 
+let globalPathVariableArg = {
+  let doc = "Specifies the PATH variable to look for global utils in the build env.";
+  let env = Arg.env_var("ESY__GLOBAL_PATH", ~doc);
+  Arg.(
+    value
+    & opt(some(string), None)
+    & info(["global-path"], ~env, ~docs=commonOptionsSection, ~doc)
+  );
+};
+
 let cacheTarballsPath = {
   let doc = "Specifies tarballs cache directory.";
   Arg.(
@@ -431,6 +442,7 @@ let make =
       solveTimeout,
       skipRepositoryUpdate,
       solveCudfCommand,
+      globalPathVariable,
     ) => {
   open RunAsync.Syntax;
 
@@ -464,6 +476,7 @@ let make =
     solveTimeout,
     skipRepositoryUpdate,
     solveCudfCommand,
+    globalPathVariable,
   });
 };
 
@@ -486,6 +499,7 @@ let promiseTerm = {
         solveTimeout,
         skipRepositoryUpdate,
         solveCudfCommand,
+        globalPathVariable,
         (),
       ) =>
     make(
@@ -505,6 +519,7 @@ let promiseTerm = {
       solveTimeout,
       skipRepositoryUpdate,
       solveCudfCommand,
+      globalPathVariable,
     );
 
   Cmdliner.Term.(
@@ -525,6 +540,7 @@ let promiseTerm = {
     $ solveTimeoutArg
     $ skipRepositoryUpdateArg
     $ solveCudfCommandArg
+    $ globalPathVariableArg
     $ Cli.setupLogTerm
   );
 };
@@ -551,6 +567,7 @@ let promiseTermForMultiplePaths = resolvedPathTerm => {
         solveTimeout,
         skipRepositoryUpdate,
         solveCudfCommand,
+        globalPathVariable,
         (),
       ) =>
     paths
@@ -572,6 +589,7 @@ let promiseTermForMultiplePaths = resolvedPathTerm => {
            solveTimeout,
            skipRepositoryUpdate,
            solveCudfCommand,
+           globalPathVariable,
          )
        )
     |> RunAsync.List.joinAll;
@@ -602,6 +620,7 @@ let promiseTermForMultiplePaths = resolvedPathTerm => {
     $ solveTimeoutArg
     $ skipRepositoryUpdateArg
     $ solveCudfCommandArg
+    $ globalPathVariableArg
     $ Cli.setupLogTerm
   );
 };

--- a/bin/ProjectConfig.rei
+++ b/bin/ProjectConfig.rei
@@ -24,6 +24,7 @@ type t = {
   solveTimeout: option(float),
   skipRepositoryUpdate: bool,
   solveCudfCommand: option(Cmd.t),
+  globalPathVariable: option(string),
 };
 
 let storePath: t => Run.t(Path.t);

--- a/esy-build-package/Config.re
+++ b/esy-build-package/Config.re
@@ -7,6 +7,7 @@ type t = {
   storePath: EsyLib.Path.t,
   localStorePath: EsyLib.Path.t,
   disableSandbox: bool,
+  globalPathVariable: option(string),
 };
 
 type config = t;
@@ -54,6 +55,7 @@ let make =
       ~storePath,
       ~projectPath,
       ~localStorePath,
+      ~globalPathVariable,
       (),
     ) => {
   open Run;
@@ -71,6 +73,7 @@ let make =
     storePath,
     localStorePath,
     disableSandbox,
+    globalPathVariable,
   });
 };
 

--- a/esy-build-package/Config.rei
+++ b/esy-build-package/Config.rei
@@ -5,6 +5,7 @@ type t =
     storePath: Fpath.t,
     localStorePath: Fpath.t,
     disableSandbox: bool,
+    globalPathVariable: option(string),
   };
 
 let pp: Fmt.t(t);
@@ -26,6 +27,7 @@ let make:
     ~storePath: storePathConfig,
     ~projectPath: Fpath.t,
     ~localStorePath: Fpath.t,
+    ~globalPathVariable: option(string),
     unit
   ) =>
   Run.t(t, _);

--- a/esy-build-package/bin/esyBuildPackageCommand.re
+++ b/esy-build-package/bin/esyBuildPackageCommand.re
@@ -15,6 +15,7 @@ type commonOpts = {
   projectPath: option(Fpath.t),
   logLevel: option(Logs.level),
   disableSandbox: bool,
+  globalPathVariable: option(string),
 };
 
 let setupLog = (style_renderer, level) => {
@@ -27,7 +28,14 @@ let setupLog = (style_renderer, level) => {
 
 let createConfig = (copts: commonOpts) => {
   open Run;
-  let {globalStorePrefix, localStorePath, projectPath, disableSandbox, _} = copts;
+  let {
+    globalStorePrefix,
+    localStorePath,
+    projectPath,
+    disableSandbox,
+    globalPathVariable,
+    _,
+  } = copts;
   let%bind currentPath = Bos.OS.Dir.current();
   let projectPath = Option.orDefault(~default=currentPath, projectPath);
   let storePath =
@@ -47,6 +55,7 @@ let createConfig = (copts: commonOpts) => {
     ~localStorePath=
       Option.orDefault(~default=projectPath / "_store", localStorePath),
     ~projectPath,
+    ~globalPathVariable,
     (),
   );
 };
@@ -248,6 +257,15 @@ let () = {
       let doc = "Disables sandboxing and builds the package without. CAUTION: this can be dangerous";
       Arg.(value & flag & info(["disable-sandbox"], ~docs, ~doc));
     };
+    let globalPathVariable = {
+      let doc = "Specifies the PATH variable to look for global utils in the build env.";
+      let env = Arg.env_var("ESY__GLOBAL_PATH", ~doc);
+      Arg.(
+        value
+        & opt(some(string), None)
+        & info(["global-path"], ~env, ~docs, ~doc)
+      );
+    };
     let setupLogT =
       Term.(
         const(setupLog)
@@ -262,6 +280,7 @@ let () = {
           planPath,
           logLevel,
           disableSandbox,
+          globalPathVariable,
         ) => {
       {
         projectPath,
@@ -270,6 +289,7 @@ let () = {
         planPath,
         logLevel,
         disableSandbox,
+        globalPathVariable,
       };
     };
     Term.(
@@ -280,6 +300,7 @@ let () = {
       $ planPath
       $ setupLogT
       $ disableSandbox
+      $ globalPathVariable
     );
   };
   /* Command terms */

--- a/esy-build/BuildSandbox.re
+++ b/esy-build/BuildSandbox.re
@@ -552,6 +552,7 @@ let makeScope =
         ~sourcePath,
         ~mode,
         ~depspec,
+        ~globalPathVariable=sandbox.cfg.globalPathVariable,
         pkg,
         buildManifest,
       );

--- a/esy-build/Scope.re
+++ b/esy-build/Scope.re
@@ -352,6 +352,7 @@ let make =
       ~depspec,
       ~sourceType,
       ~sourcePath,
+      ~globalPathVariable,
       pkg,
       buildManifest,
     ) => {
@@ -377,12 +378,18 @@ let make =
     pkg,
     finalEnv: {
       let defaultPath =
-        switch (platform) {
-        | Windows =>
+        switch (platform, globalPathVariable) {
+        | (Windows, Some(pathVar)) =>
+          let esyGlobalPath = Sys.getenv(pathVar);
+          "$PATH;" ++ esyGlobalPath;
+        | (Windows, None) =>
           let windir = Sys.getenv("WINDIR") ++ "/System32";
           let windir = Path.normalizePathSepOfFilename(windir);
           "$PATH;/usr/local/bin;/usr/bin;/bin;/usr/sbin;/sbin;" ++ windir;
-        | _ => "$PATH:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+        | (_, Some(pathVar)) =>
+          let esyGlobalPath = Sys.getenv(pathVar);
+          "$PATH:" ++ esyGlobalPath;
+        | (_, None) => "$PATH:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
         };
 
       SandboxEnvironment.[

--- a/esy-build/Scope.rei
+++ b/esy-build/Scope.rei
@@ -19,6 +19,7 @@ let make:
     ~depspec: EsyInstall.Solution.DepSpec.t,
     ~sourceType: SourceType.t,
     ~sourcePath: SandboxPath.t,
+    ~globalPathVariable: option(string),
     EsyInstall.Package.t,
     BuildManifest.t
   ) =>

--- a/test-e2e/esy-build-env.test.js
+++ b/test-e2e/esy-build-env.test.js
@@ -263,4 +263,17 @@ describe(`'esy build-env' command`, () => {
     const env = JSON.parse((await p.esy('build-env --json -p dep@path:dep')).stdout);
     expect(env.cur__name).toBe('dep');
   });
+
+  it('expands a variable to a global path for the sandbox', async () => {
+    // Append the current path so we can access tools like `cp`
+    process.env.TEST_PATH = "/some/path:" + process.env.PATH;
+
+    const p = await createTestSandbox();
+
+    await p.esy('install');
+
+    const env = JSON.parse((await p.esy('build-env --global-path TEST_PATH --release --json')).stdout);
+
+    expect(env.PATH).toContain("/some/path");
+  });
 });


### PR DESCRIPTION
This is a re-implementation of @anmonteiro's excellent work on #1008

In addition, I've added expansion of the variable in an attempt to address #988 - this allows a user to do something like `ESY__GLOBAL_PATH=PATH esy` to hoist their path into the esy build environment.

This is really needed by Grain because we use esy to wire up opam stuff and those dependencies use conf-cmake & conf-python3, and the esy sandbox doesn't know about obscure locations for those tools (like on Windows in GitHub Actions).

I also added the test that @andreypopp asked for in the previous issue.

cc @prometheansacrifice 