### PR TITLE
esy cleanup: cleanup short build path as well

### DIFF
--- a/bin/ProjectConfig.re
+++ b/bin/ProjectConfig.re
@@ -218,6 +218,13 @@ type t = {
   globalPathVariable: option(string),
 };
 
+let globalStorePrefixPath = cfg => {
+  switch (cfg.prefixPath) {
+  | None => EsyBuildPackage.Config.storePrefixDefault
+  | Some(prefixPath) => prefixPath
+  };
+};
+
 let storePath = cfg => {
   let storePath =
     switch (cfg.prefixPath) {
@@ -225,14 +232,10 @@ let storePath = cfg => {
     | Some(path) => EsyBuildPackage.Config.StorePathOfPrefix(path)
     };
 
-  let globalStorePrefix =
-    switch (cfg.prefixPath) {
-    | None => EsyBuildPackage.Config.storePrefixDefault
-    | Some(prefixPath) => prefixPath
-    };
-
   Run.ofBosError(
-    EsyBuildPackage.Config.(configureStorePath(storePath, globalStorePrefix)),
+    EsyBuildPackage.Config.(
+      configureStorePath(storePath, globalStorePrefixPath(cfg))
+    ),
   );
 };
 

--- a/bin/ProjectConfig.rei
+++ b/bin/ProjectConfig.rei
@@ -28,6 +28,7 @@ type t = {
 };
 
 let storePath: t => Run.t(Path.t);
+let globalStorePrefixPath: t => Path.t;
 
 let show: t => string;
 let pp: Fmt.t(t);

--- a/bin/esy.re
+++ b/bin/esy.re
@@ -256,6 +256,12 @@ let cleanup = (projCfgs: list(ProjectConfig.t), dryRun) => {
             RunAsync.ofRun(ProjectConfig.storePath(projCfg));
           let%bind allDirs' =
             Fs.listDir(Path.(storePath / Store.installTree));
+          let shortBuildPath =
+            Path.(
+              ProjectConfig.globalStorePrefixPath(projCfg)
+              / Store.version
+              / Store.buildTree
+            );
           RunAsync.return((
             Path.Set.union(dirsToKeep, allProjectDependencies),
             Path.Set.union(
@@ -263,6 +269,7 @@ let cleanup = (projCfgs: list(ProjectConfig.t), dryRun) => {
               Path.Set.of_list([
                 Path.(storePath / Store.buildTree),
                 Path.(storePath / Store.stageTree),
+                shortBuildPath,
                 ...allDirs'
                    |> List.map(~f=x =>
                         Path.(storePath / Store.installTree / x)


### PR DESCRIPTION
Following a [discussion on discord](https://discord.com/channels/235176658175262720/235200837608144898/739767920791650365), it turns out that the `esy cleanup` command does not clean up the "short build path" (~/.esy/3/b).

That's what this PR tries to handle. I didn't find any tests regarding this command but I've tested it manually. You can check also with the `--dry-run` option that the `~/.esy/3/b` is present.

