### PR TITLE
unset variable on buildEnv and exportedEnv

### DIFF
--- a/esy-build/BuildSandbox.re
+++ b/esy-build/BuildSandbox.re
@@ -532,10 +532,10 @@ let makeScope =
     let sourcePath = Scope.SandboxPath.ofPath(sandbox.cfg, location);
 
     let sandboxEnv = {
-      let f = (env, item) =>
+      let f = (env, {BuildEnv.name, value}) =>
         // TODO: what should that do?
-        switch (item) {
-        | BuildEnv.Set({name, value}) => [
+        switch (value) {
+        | Set(value) => [
             (
               name,
               Scope.SandboxEnvironment.Bindings.value(
@@ -544,7 +544,7 @@ let makeScope =
               ),
             ),
           ]
-        | Unset({name}) => env |> List.filter(~f=((key, _)) => name != key)
+        | Unset => env |> List.filter(~f=((key, _)) => name != key)
         };
       StringMap.values(sandbox.sandboxEnv)
       |> List.fold_left(~f, ~init=[])

--- a/esy-lib/Environment.rei
+++ b/esy-lib/Environment.rei
@@ -40,6 +40,7 @@ module type S = {
     let value: (~origin: string=?, string, value) => Binding.t(value);
     let prefixValue: (~origin: string=?, string, value) => Binding.t(value);
     let suffixValue: (~origin: string=?, string, value) => Binding.t(value);
+    let remove: (~origin: string=?, string) => Binding.t(value);
 
     let empty: t;
     let render: (ctx, t) => list(Binding.t(string));

--- a/esy-package-config/BuildEnv.re
+++ b/esy-package-config/BuildEnv.re
@@ -15,6 +15,7 @@ type t = StringMap.t(item);
 let empty = StringMap.empty;
 
 let set = (name, value) => {name, value: Set(value)};
+let unset = name => {name, value: Unset};
 
 let item_of_yojson = (name, json) =>
   switch (json) {

--- a/esy-package-config/BuildEnv.rei
+++ b/esy-package-config/BuildEnv.rei
@@ -1,8 +1,10 @@
 type t = StringMap.t(item)
-and item = {
-  name: string,
-  value: string,
-};
+and item =
+  | Unset({name: string})
+  | Set({
+      name: string,
+      value: string,
+    });
 
 let empty: t;
 

--- a/esy-package-config/BuildEnv.rei
+++ b/esy-package-config/BuildEnv.rei
@@ -9,6 +9,7 @@ and item = {
 
 let empty: t;
 let set: (string, string) => item;
+let unset: string => item;
 
 include S.COMPARABLE with type t := t;
 include S.JSONABLE with type t := t;

--- a/esy-package-config/BuildEnv.rei
+++ b/esy-package-config/BuildEnv.rei
@@ -1,12 +1,14 @@
+type value =
+  | Set(string)
+  | Unset;
 type t = StringMap.t(item)
-and item =
-  | Unset({name: string})
-  | Set({
-      name: string,
-      value: string,
-    });
+and item = {
+  name: string,
+  value,
+};
 
 let empty: t;
+let set: (string, string) => item;
 
 include S.COMPARABLE with type t := t;
 include S.JSONABLE with type t := t;

--- a/esy-package-config/ExportedEnv.rei
+++ b/esy-package-config/ExportedEnv.rei
@@ -1,15 +1,20 @@
 type t = StringMap.t(item)
 and item = {
   name: string,
-  value: string,
+  value,
   scope,
   exclusive: bool,
 }
 and scope =
   | Local
-  | Global;
+  | Global
+and value =
+  | Set(string)
+  | Unset;
 
 let empty: t;
+let set: (~exclusive: bool=?, scope, string, string) => item;
+let unset: (~exclusive: bool=?, scope, string) => item;
 
 include S.COMPARABLE with type t := t;
 include S.JSONABLE with type t := t;


### PR DESCRIPTION
We should be able to describe a environment without a variable, like removing `OCAMLLIB` for cross compiled packages, to achieve that this PR implement's two features, `esy.buildEnv['OCAMLLIB']: null` and `esy.exportedEnv['OCAMLLIB'].val: null`

```json
{
  "esy": {
    "buildEnv": { "OCAMLLIB": null },
    "exportedEnv": { "OCAMLLIB": { "val": null, "scope": "global" } }
  }
}
```
