### PR TITLE
fix: empty variables in shell expressions

### DIFF
--- a/esy-command-expression/Parser.mly
+++ b/esy-command-expression/Parser.mly
@@ -33,7 +33,8 @@
 %%
 
 start:
-  e = expr; EOF { e }
+    e = expr; EOF { e }
+  | EOF; { String "" }
 
 expr:
   e = nonempty_list(atom) {

--- a/test-e2e/esy-build-env.test.js
+++ b/test-e2e/esy-build-env.test.js
@@ -55,6 +55,7 @@ describe(`'esy build-env' command`, () => {
         esy: {
           buildEnv: {
             root__build: 'root__build__value',
+            emptyVariable: '',
           },
           exportedEnv: {
             root__local: {val: 'root__local__value'},
@@ -176,6 +177,9 @@ describe(`'esy build-env' command`, () => {
     // dev deps are not present in build env
     expect(env.devDep__local).toBe('devDep__local__value');
     expect(env.devDep__global).toBe('devDep__global__value');
+
+    // check if empty variables are defined
+    expect(env.emptyVariable).toBe('');
   });
 
   it('generates an environment in JSON (--release)', async () => {


### PR DESCRIPTION
## Problem

Empty variables throw syntax error

## Expected

Should just set the variable to a empty string

## Reprodution

```json
{
  "esy": {
    "buildEnv": {
      "VARIABLE": ""
    }
  }
}
```