### PR TITLE
Include sandbox name in error message

### DIFF
--- a/bin/Project.re
+++ b/bin/Project.re
@@ -198,6 +198,13 @@ let makeProject = (makeSolved, projcfg: ProjectConfig.t) => {
   ));
 };
 
+let getInstallCommand = spec =>
+  if (SandboxSpec.isDefault(spec)) {
+    "esy install";
+  } else {
+    Printf.sprintf("esy '@%s' install", SandboxSpec.projectName(spec));
+  };
+
 let makeSolved =
     (
       makeFetched,
@@ -228,7 +235,11 @@ let makeSolved =
         files,
       );
     return({solution, fetched});
-  | None => errorf("project is missing a lock, run `esy install`")
+  | None =>
+    errorf(
+      "project is missing a lock, run `%s`",
+      getInstallCommand(projcfg.spec),
+    )
   };
 };
 
@@ -282,7 +293,11 @@ let makeFetched =
       solution,
     )
   ) {
-  | None => errorf("project is not installed, run `esy install`")
+  | None =>
+    errorf(
+      "project is not installed, run `%s`",
+      getInstallCommand(projcfg.spec),
+    )
   | Some(installation) =>
     let%lwt () = Logs_lwt.debug(m => m("%a is up to date", Path.pp, path));
     let%bind sandbox = {

--- a/test-e2e/esy-CMD.test.js
+++ b/test-e2e/esy-CMD.test.js
@@ -265,7 +265,7 @@ describe(`'esy CMD' invocation`, () => {
     }
   });
 
-  test.disableIf(isWindows)(`nested esy invocations autoconfigure with the right root package config`, async () => {
+  test.disableIf(isWindows)(`nested esy invocations give the right error messages`, async () => {
     const p = await helpers.createTestSandbox();
     await p.fixture(
       file('package.json', JSON.stringify({

--- a/test-e2e/esy-CMD.test.js
+++ b/test-e2e/esy-CMD.test.js
@@ -265,4 +265,50 @@ describe(`'esy CMD' invocation`, () => {
     }
   });
 
+  test.disableIf(isWindows)(`nested esy invocations autoconfigure with the right root package config`, async () => {
+    const p = await helpers.createTestSandbox();
+    await p.fixture(
+      file('package.json', JSON.stringify({
+        name: 'package',
+        version: '1.0.0',
+      }, null, 2)),
+      file('dev.json', JSON.stringify({
+        name: 'dev',
+        version: '1.0.0',
+      }, null, 2))
+    );
+
+    // check the `esy install` error message.
+    {
+      await expect(p.esy('dep.cmd')).rejects.toMatchObject({
+        message: expect.stringMatching(
+          'error: project is missing a lock, run `esy install`',
+        ),
+      });
+    }
+
+    // install, to unblock testing sandbox install err message
+    {
+      await p.esy('install');
+      const {stdout} = await p.esy("esy echo '#{self.name}'");
+      expect(stdout.trim()).toBe('package');
+    }
+
+    // check `esy '@dev' install` error message
+    {
+      await expect(p.esy('@dev dep.cmd')).rejects.toMatchObject({
+        message: expect.stringMatching(
+          'error: project is missing a lock, run `esy \'@dev\' install`',
+        ),
+      });
+    }
+
+    // check `esy @dev ...`
+    {
+      await p.esy('@dev install');
+      const {stdout} = await p.esy("@dev esy echo '#{self.name}'");
+      expect(stdout.trim()).toBe('dev');
+    }
+  });
+
 });


### PR DESCRIPTION
This just swaps the "project is ___, run `esy install`" to include the sandbox name in cases where it is needed (so "project is ___, run `esy '@test' install`" etc).

This is especially a pain for projects that define scripts to run other sandboxes, since from the users point of view, they ran `esy test` and it told them to `esy install` again and they have no idea that `esy test` actually runs `esy @test run` etc. At least this way, they know the real command to fix their issue. (We've had this a few times in both Revery and Oni2).

Hopefully the code/test is reasonable! Can update if not.