### PR TITLE
Fix store padding calculation

### DIFF
--- a/esy-lib/Store.re
+++ b/esy-lib/Store.re
@@ -18,7 +18,7 @@ let maxStorePaddingLength = {
    * We reserve that amount of chars from padding so ocamlrun can be placed in
    * shebang lines
    */
-  let ocamlrunStorePath = "ocaml-n.00.000-########/bin/ocamlrun";
+  let ocamlrunStorePath = "ocaml-n.00.0000-########/bin/ocamlrun";
   maxShebangLength
   - String.length("!#")
   - String.length(

--- a/test-e2e/test/helpers.js
+++ b/test-e2e/test/helpers.js
@@ -117,7 +117,7 @@ var STORE_INSTALL_TREE = 'i';
 var STORE_STAGE_TREE = 's';
 var ESY_STORE_VERSION = 3;
 var MAX_SHEBANG_LENGTH = 127;
-var OCAMLRUN_STORE_PATH = 'ocaml-n.00.000-########/bin/ocamlrun';
+var OCAMLRUN_STORE_PATH = 'ocaml-n.00.0000-########/bin/ocamlrun';
 var ESY_STORE_PADDING_LENGTH =
   MAX_SHEBANG_LENGTH -
   '!#'.length -


### PR DESCRIPTION
Esy incorrectly assumed patch version to be 3 digits long (should
be 4)

Closes #1171 