### PR TITLE
fix signal handling on unix

### DIFF
--- a/bin/NpmReleaseCommand.re
+++ b/bin/NpmReleaseCommand.re
@@ -330,12 +330,16 @@ let makeBinWrapper = (~destPrefix, ~bin, ~environment: Environment.Bindings.t) =
       else (
         let program = expandFallback storePrefix program in
         Sys.argv.(0) <- program;
-        let pid = Unix.create_process_env program Sys.argv expandedEnv Unix.stdin Unix.stdout Unix.stderr in
-        let (_, status) = Unix.waitpid [] pid in
-        match status with
-        | WEXITED code -> exit code
-        | WSIGNALED code -> exit code
-        | WSTOPPED code -> exit code
+        if windows then (
+          let pid = Unix.create_process_env program Sys.argv expandedEnv Unix.stdin Unix.stdout Unix.stderr in
+          let (_, status) = Unix.waitpid [] pid in
+          match status with
+          | WEXITED code -> exit code
+          | WSIGNALED code -> exit code
+          | WSTOPPED code -> exit code
+        )
+        else
+          Unix.execve program Sys.argv expandedEnv
       )
     ;;
   |},


### PR DESCRIPTION
Using `Unix.create_process_env` starts a child process, but nothing is
setup to forward signals or interrupts. Making it impossible for the
started program to handle signal itself using `Sys.signal` or
`Sys.catch_break`. This is a minor inconvinience for CLI programs (e.g.
you can't implement a REPL that only exits when sending CTRL-C twice
like nodejs does), but this is a major problem for program that are
supposed to run in k8s.

K8s expects programs to keep serving requests when it sends a TERM
signal. The TERM signal is send before k8s makes sure that they won't
receive traffic anymore. It's expected that they mark themselves as not
ready, handle all open traffic, and shutdown when done. For this the
programs need to handle the TERM signal.