### PR TITLE
fix github versions with subfolders

### DIFF
--- a/esy-lib/Path.re
+++ b/esy-lib/Path.re
@@ -4,7 +4,9 @@ type ext = Fpath.ext;
 module Set = Fpath.Set;
 
 let v = Fpath.v;
-let (/) = Fpath.(/);
+// in Fpath / is an alias to add_seg which fails if !is_seg
+let (/) = (path, string) =>
+  Fpath.(/\/)(path, Stdlib.Result.get_ok(string |> Fpath.of_string));
 let (/\/) = Fpath.(/\/);
 
 let dirSep = Fpath.dir_sep;


### PR DESCRIPTION
## Why?

Currently using github versions with subfolders will cause it to fail on Invalid_argument because of `Fpath.(/)`

## Solution

It seems to make sense for me that `Path.(/)(l, r)` is essentially `Path.(//)(l, ofStringExn(r))` at least by looking at the signature.

## Example

```json
{
  "dependencies": {
    "generate": "EduardoRFS/reason-mobile:generate/package.json#0813679bb30270361d51aa3620bfa48bb3bf9e59"
  }
}
```