### PR TITLE
Adds --static option to `esy release`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apk add opam yarn make m4 git gcc g++ musl-dev perl perl-utils && \
  opam exec -- dune build @install && \
  opam exec -- dune install --prefix /usr/local && \
  esy  && \
- esy release && \
+ esy release --static && \
  opam exec -- dune uninstall --prefix /usr/local && \
  yarn global --prefix=/usr/local --force add $PWD/_release && \
  mv _release /app/_release && \

--- a/bin/NpmReleaseCommand.rei
+++ b/bin/NpmReleaseCommand.rei
@@ -1,1 +1,1 @@
-let run: Project.t => RunAsync.t(unit);
+let run: (bool /* static or not */, Project.t) => RunAsync.t(unit);

--- a/bin/esy.re
+++ b/bin/esy.re
@@ -1665,14 +1665,24 @@ let commandsConfig = {
         Term.(const(solveAndFetch)),
       );
 
+    let staticArg =
+      Cmdliner.Arg.(
+        value
+        & flag
+        & info(
+            ["static"],
+            ~doc=
+              "Ensures that wrappers binaries are statically linked. Useful on Alpine.",
+          )
+      );
+
     let npmReleaseCommand =
       makeProjectCommand(
         ~name="npm-release",
         ~doc="Produce npm package with prebuilt artifacts",
         ~docs=otherSection,
-        Term.(const(NpmReleaseCommand.run)),
+        Term.(const(NpmReleaseCommand.run) $ staticArg),
       );
-
     [
       /* COMMON COMMANDS */
       installCommand,


### PR DESCRIPTION
This would create statically linked binaries on supported platforms
while running `esy release`.