### PR TITLE
use static Alpine build by default on Linux

### DIFF
--- a/.ci/build-release.yml
+++ b/.ci/build-release.yml
@@ -55,21 +55,18 @@ jobs:
         displayName: "Run Docker Container"
       - script:  docker cp esy-container:/app/_release $PWD/_container_release
         displayName: "Copy _release from container"
-      - script: npm pack
-        workingDirectory: _container_release
-        displayName: "Npm pack'ing"
       - task: PublishBuildArtifacts@1
         displayName: "Publish Docker built artifact"
         inputs:
-          PathtoPublish: "_container_release/$(esy__project_name)-$(esy__project_version).tgz"
-          ArtifactName: DockerBuiltNPM.tgz
+          PathtoPublish: "_container_release"
+          ArtifactName: AlpineLinux
       - script: docker save $(esy__project_name) | gzip > $(esy__project_name)-docker-image.tar.gz
         displayName: "Save Docker image as tarball"
       - task: PublishBuildArtifacts@1
         displayName: "Publish Docker production image"
         inputs:
           PathtoPublish: "$(esy__project_name)-docker-image.tar.gz"
-          ArtifactName: DockerBuiltNPM
+          ArtifactName: AlpineLinuxDockerBuiltNPM
           
   # Need windows-2019 to do esy import/export-dependencies
   # which assumes you have bsdtar (tar.exe) in your system

--- a/.ci/cross-release.yml
+++ b/.ci/cross-release.yml
@@ -6,7 +6,7 @@ steps:
 
   - template: release-platform-setup.yml
     parameters:
-      platform: "Linux"
+      platform: "AlpineLinux"
       folder: "platform-linux"
 
   - template: release-platform-setup.yml


### PR DESCRIPTION
With this the `AlpineLinux` build will be the default one for Linux.

## Nightly

This is mostly to publish on a `@esy-nightly/esy`, so that we can start to try it on a variety of systems, especially some old ones like CentOS