### PR TITLE
ignore SHELL on release environment

### DIFF
--- a/bin/NpmReleaseCommand.re
+++ b/bin/NpmReleaseCommand.re
@@ -161,6 +161,7 @@ let makeBinWrapper = (~destPrefix, ~bin, ~environment: Environment.Bindings.t) =
     |> Environment.renderToList
     |> List.filter(~f=((name, _)) =>
          switch (name) {
+         | "SHELL"
          | "cur__original_root"
          | "cur__root" => false
          | _ => true


### PR DESCRIPTION
## Problem

`esy release` will make a binary wrapper who includes the complete env available during build, this is mostly desirable if the user want's to have reproducible environment for the binaries, but `$SHELL` is also part of the build env.

## Solution

I think is reasonable for any software to expect `$SHELL` to be the user shell, so just ignoring `$SHELL` from the environment is enough to fix the problem

This  fixes the problem of `esy shell` not working on the nightly
