### PR TITLE
remove version from ocaml buildId

### DIFF
--- a/esy-build/BuildId.rei
+++ b/esy-build/BuildId.rei
@@ -9,6 +9,7 @@ type t;
 
 let make:
   (
+    ~ocamlPkgName: string,
     ~packageId: PackageId.t,
     ~build: BuildManifest.t,
     ~mode: BuildSpec.mode,

--- a/esy-build/BuildSandbox.re
+++ b/esy-build/BuildSandbox.re
@@ -517,6 +517,7 @@ let makeScope =
       };
 
       BuildId.make(
+        ~ocamlPkgName=sandbox.cfg.ocamlPkgName,
         ~sandboxEnv=sandbox.sandboxEnv,
         ~packageId=pkg.id,
         ~platform=sandbox.platform,

--- a/esy-lib/Store.re
+++ b/esy-lib/Store.re
@@ -8,7 +8,7 @@ let stageTree = "s";
 
 let version = "3";
 
-let maxStorePaddingLength = (~ocamlPkgName, ~ocamlVersion, ()) => {
+let maxStorePaddingLength = (~ocamlPkgName, ~ocamlVersion as _, ()) => {
   /*
    * This is restricted by POSIX, Linux enforces this but macOS is more
    * forgiving.
@@ -18,8 +18,7 @@ let maxStorePaddingLength = (~ocamlPkgName, ~ocamlVersion, ()) => {
    * We reserve that amount of chars from padding so ocamlrun can be placed in
    * shebang lines
    */
-  let ocamlrunStorePath =
-    ocamlPkgName ++ "-" ++ ocamlVersion ++ "-########/bin/ocamlrun";
+  let ocamlrunStorePath = ocamlPkgName ++ "-########/bin/ocamlrun";
   maxShebangLength
   - String.length("!#")
   - String.length(


### PR DESCRIPTION
This is an alternative to the change made at #1201

## Problem

Using big versions lead to a huge reduction in the available path size for `ocamlrun` who leads to fails during install in a couple of environments

## Solution

Instead of making the version configurable, removing the version from the BuildId path solves the same problem of using custom ocaml versions but also solves the problem of big path size to ocamlrun


## Problems

I think this approach is sound as this is how the source version path also works, except that we're adding an exception for it when is the ocaml package

## Review

To avoid noise I recommend to review each commit at time