### PR TITLE
disable rewrite prefix for esy

### DIFF
--- a/esy.json
+++ b/esy.json
@@ -8,7 +8,7 @@
     "buildDev": "refmterr dune build -p esy",
     "install": "esy-installer esy.install",
     "release": {
-      "rewritePrefix": true,
+      "rewritePrefix": false,
       "bin": ["esy", "esyBuildPackageCommand", "esyRewritePrefixCommand", "esySolveCudfCommand"]
     },
     "buildsInSource": "_build"


### PR DESCRIPTION
As discussed, with @ManasJayanth 

Currently esy doesn't require path rewriting to work, and this is breaking when using the nightly on CI, so disabled temporarily until we fix it, which should probably be something related to #1215 