### PR TITLE
Regression: handles bash scripts without hashbang

### DIFF
--- a/bin/NpmReleaseCommand.re
+++ b/bin/NpmReleaseCommand.re
@@ -174,6 +174,12 @@ let makeBinWrapper = (~destPrefix, ~bin, ~environment: Environment.Bindings.t) =
          ++ EsyLib.Path.normalizePathSepOfFilename(value)
          ++ "|}"
        )
+    |> List.append([
+         switch (Sys.getenv_opt("SHELL")) {
+         | Some(v) => "{|SHELL|}, {|" ++ v ++ "|}"
+         | None => "{|SHELL|}, {|/bin/sh|}"
+         },
+       ])
     |> String.concat(";");
 
   Printf.sprintf(


### PR DESCRIPTION
Package esy-harfbuzz fails to build with master because of the missing $SHELL in the binary wrapper. We removed $SHELL from the binary so that `esy shell` falls back to `/bin/bash`.

This PR instead looks for $SHELL from the shell at the time `esy release` was run. Ideally, this should be explicitly configured. The default (or the fallback) should choose a convenient shell widely available on many machines. (sh but bash seem more convenient)

Please note:
To test this PR, add the newly created binary to your $PATH. Example,

```sh
xport PATH=/home/path/to/esy/development-source/_esy/default/store/i/esy-1f8b7db4/bin:$PATH
```

Without this, the global esy, which if it happens to be the nightly, will use it's embedded $PATH. This is not an issue for 0.6.7

Keeping this open for review. TODO: update CI to correctly local esy