### PR TITLE
Use latest nightly on CI

### DIFF
--- a/.ci/utils/use-esy.yml
+++ b/.ci/utils/use-esy.yml
@@ -1,7 +1,7 @@
 # steps to install esy globally
 
 steps:
-- script: "yarn global add @esy-nightly/esy@0.6.8-bbdfb8"
+- script: "yarn global add @esy-nightly/esy@0.6.8-8fc543"
   displayName: "Install esy (via yarn)"
   condition: ne(variables['AGENT.OS'], 'Windows_NT')
   


### PR DESCRIPTION
The wrapper around esy retains $SHELL when built with older nightly. A recent fix
https://github.com/esy/esy/pull/1225 inherits $SHELL which helps fix esy-harfbuzz