### PR TITLE
Add --no-env option so that esy wrappers dont load the env bindings

### DIFF
--- a/bin/NpmReleaseCommand.re
+++ b/bin/NpmReleaseCommand.re
@@ -336,7 +336,7 @@ let makeBinWrapper =
       let env = [|%s|] in
       let program = "%s" in
       let storePrefix = "%s" in
-      let no_wrapper = "%s" in
+      let no_wrapper = %s in
       let expandedEnv = expandFallbackEnv storePrefix (expandEnv env) in
       if Array.length Sys.argv = 2 && Sys.argv.(1) = "----where" then
         print_endline (expandFallback storePrefix program)

--- a/bin/NpmReleaseCommand.rei
+++ b/bin/NpmReleaseCommand.rei
@@ -1,1 +1,3 @@
-let run: (bool /* static or not */, Project.t) => RunAsync.t(unit);
+let run:
+  (bool /* static or not */, bool /* wrap environment or not */, Project.t) =>
+  RunAsync.t(unit);

--- a/bin/esy.re
+++ b/bin/esy.re
@@ -1698,12 +1698,23 @@ let commandsConfig = {
           )
       );
 
+    let noEnv =
+      Cmdliner.Arg.(
+        value
+        & flag
+        & info(
+            ["no-env"],
+            ~doc=
+              "Ensures that wrappers binaries are not wrapped with the environment. Useful for debugging wrapped environments.",
+          )
+      );
+
     let npmReleaseCommand =
       makeProjectCommand(
         ~name="npm-release",
         ~doc="Produce npm package with prebuilt artifacts",
         ~docs=otherSection,
-        Term.(const(NpmReleaseCommand.run) $ staticArg),
+        Term.(const(NpmReleaseCommand.run) $ staticArg $ noEnv),
       );
     [
       /* COMMON COMMANDS */


### PR DESCRIPTION
Helps work around the esy-harfbuzz issue. Can help users debug issues related to environment bindings