### PR TITLE
Support bundling arm64 macos binaries

### DIFF
--- a/.ci/pipelines-release.js
+++ b/.ci/pipelines-release.js
@@ -60,6 +60,7 @@ const packageJson = JSON.stringify(
       "esyInstallRelease.js",
       "platform-linux/",
       "platform-darwin/",
+      "platform-darwin-arm64/",
       "platform-windows-x64/"
     ]
   },

--- a/.ci/release-postinstall.js
+++ b/.ci/release-postinstall.js
@@ -169,7 +169,7 @@ switch (platform) {
     break;
   case "linux":
   case "darwin":
-    copyPlatformBinaries(platform);
+    copyPlatformBinaries(platform + (process.arch === "x64" ? "": "-arm64"));
     break;
   default:
     console.warn("error: no release built for the " + platform + " platform");


### PR DESCRIPTION
On the CI, we wont be generating the arm64 binaries, but the postinstall scripts are tweaked in a way to support bundling afterwards locally.