### PR TITLE
Set _ in the NpmReleasecommand.re correctly for hidden commands

### DIFF
--- a/bin/NpmReleaseCommand.re
+++ b/bin/NpmReleaseCommand.re
@@ -162,6 +162,77 @@ let makeBinWrapper =
     | Some(x) => x
     | None => false
     };
+
+  let path_sep =
+    if (!Sys.unix) {
+      '\\';
+    } else {
+      '/';
+    };
+
+  let path_sep_str = String.make(1, path_sep);
+
+  let is_abs = p =>
+    if (!Sys.unix) {
+      switch (String.split_on_char(':', p)) {
+      | [drive, ..._] when String.length(drive) == 1 => true
+      | _ => false
+      };
+    } else {
+      String.length(p) > 0 && p.[0] == '/';
+    };
+
+  let normalize = p => {
+    let p = Str.global_substitute(Str.regexp("\\"), _ => "/", p);
+    let parts = String.split_on_char('/', p);
+    let need_leading_sep = Sys.unix && is_abs(p);
+    let f = (parts, part) =>
+      switch (part, parts) {
+      | ("", parts) => parts
+      | (".", parts) => parts
+      | ("..", []) => parts
+      | ("..", [part]) =>
+        if (!Sys.unix) {
+          [part];
+        } else {
+          [];
+        }
+      | ("..", [_, ...parts]) => parts
+      | (part, parts) => [part, ...parts]
+      };
+
+    let p =
+      String.concat(
+        path_sep_str,
+        List.rev(List.fold_left(~f, ~init=[], parts)),
+      );
+    if (need_leading_sep) {
+      "/" ++ p;
+    } else {
+      p;
+    };
+  };
+
+  let expandFallback = storePrefix => {
+    let dummyPrefix = String.make(String.length(storePrefix), '_');
+    let dirname = Filename.dirname(bin);
+    let pattern = Str.regexp(dummyPrefix);
+    let storePrefix = {
+      let (/) = Filename.concat;
+      normalize(dirname / ".." / "3");
+    };
+
+    let rewrite = value =>
+      Str.global_substitute(pattern, _ => storePrefix, value);
+
+    rewrite;
+  };
+
+  let storePrefix =
+    Path.show(destPrefix)
+    |> String.split_on_char('\\')
+    |> String.concat("\\\\");
+
   /* TODO: When noEnv is true, environment bindings need not be embedded */
   let environmentString =
     environment
@@ -169,6 +240,7 @@ let makeBinWrapper =
     |> List.filter(~f=((name, _)) =>
          switch (name) {
          | "SHELL"
+         | "_"
          | "cur__original_root"
          | "cur__root" => false
          | _ => true
@@ -186,6 +258,7 @@ let makeBinWrapper =
          | Some(v) => "{|SHELL|}, {|" ++ v ++ "|}"
          | None => "{|SHELL|}, {|/bin/sh|}"
          },
+         "{|_|}, {|" ++ expandFallback(storePrefix, bin) ++ "|}",
        ])
     |> String.concat(";");
 
@@ -364,9 +437,7 @@ let makeBinWrapper =
   |},
     environmentString,
     bin,
-    Path.show(destPrefix)
-    |> String.split_on_char('\\')
-    |> String.concat("\\\\"),
+    storePrefix,
     string_of_bool(noEnv),
   );
 };


### PR DESCRIPTION
Follow up PR to #1259 since we use `$_` to figure current executable path