### PR TITLE
Replaced `let%bind` with monadic `let*`

### DIFF
--- a/bin/ProjectConfig.re
+++ b/bin/ProjectConfig.re
@@ -134,11 +134,11 @@ module ProjectArg = {
         let kind = classifyPath(path);
         switch (kind) {
         | NoProject =>
-          let%bind parent = parentPath(path);
+          let* parent = parentPath(path);
           climb(parent);
         | Project =>
           let next = {
-            let%bind parent = parentPath(path);
+            let* parent = parentPath(path);
             climb(parent);
           };
           switch (next) {
@@ -151,13 +151,13 @@ module ProjectArg = {
       | Some(projectName) =>
         switch (checkPathByProjectName(path, projectName)) {
         | None =>
-          let%bind parent = parentPath(path);
+          let* parent = parentPath(path);
           climb(parent);
         | Some(path) => return((Kind.ProjectForced, path))
         }
       };
 
-    let%bind (_kind, path) = climb(currentPath);
+    let* (_kind, path) = climb(currentPath);
     return(path);
   };
 
@@ -180,7 +180,7 @@ module ProjectArg = {
         };
       };
 
-    let%bind projectPath =
+    let* projectPath =
       switch (project) {
       | Some(ByPath(path)) => return(path)
       | Some(ByName(name)) => climbFrom(Path.currentPath(), Some(name))
@@ -501,14 +501,14 @@ let make =
     ) => {
   open RunAsync.Syntax;
 
-  let%bind projectPath = RunAsync.ofRun(ProjectArg.resolve(project));
-  let%bind spec = EsyInstall.SandboxSpec.ofPath(projectPath);
+  let* projectPath = RunAsync.ofRun(ProjectArg.resolve(project));
+  let* spec = EsyInstall.SandboxSpec.ofPath(projectPath);
 
-  let%bind prefixPath =
+  let* prefixPath =
     switch (prefixPath) {
     | Some(prefixPath) => return(Some(prefixPath))
     | None =>
-      let%bind rc = EsyRc.ofPath(spec.EsyInstall.SandboxSpec.path);
+      let* rc = EsyRc.ofPath(spec.EsyInstall.SandboxSpec.path);
       return(rc.EsyRc.prefixPath);
     };
 

--- a/bin/Scripts.re
+++ b/bin/Scripts.re
@@ -45,8 +45,8 @@ let ofSandbox = (spec: EsyInstall.SandboxSpec.t) =>
   RunAsync.Syntax.(
     switch (spec.manifest) {
     | [@implicit_arity] EsyInstall.SandboxSpec.Manifest(Esy, filename) =>
-      let%bind json = Fs.readJsonFile(Path.(spec.path / filename));
-      let%bind pkgJson =
+      let* json = Fs.readJsonFile(Path.(spec.path / filename));
+      let* pkgJson =
         RunAsync.ofRun(Json.parseJsonWith(OfPackageJson.of_yojson, json));
       return(pkgJson.OfPackageJson.scripts);
 

--- a/esy-build-package/BigSurArm.re
+++ b/esy-build-package/BigSurArm.re
@@ -19,7 +19,7 @@ open Bos.OS.Cmd;
  [sign'] does exactly that. */
 
 let codesign = fpath => {
-  let%bind status =
+  let* status =
     run_status(
       ~quiet=true,
       Cmd.(
@@ -52,14 +52,14 @@ let codesign = fpath => {
 };
 
 let sign' = path => {
-  let%bind () = codesign(path);
+  let* () = codesign(path);
   let tmpDir = Filename.get_temp_dir_name();
   let fileBeingCopied = path |> Fpath.to_string |> Filename.basename;
   let workAroundFilePath = Fpath.(v(tmpDir) / "workaround" / fileBeingCopied);
-  let%bind () = mkdir(Fpath.(v(tmpDir) / "workaround"));
-  let%bind () = copyFile(path, workAroundFilePath);
-  let%bind () = rm(path);
-  let%bind () = copyFile(~perm=0o775, workAroundFilePath, path);
+  let* () = mkdir(Fpath.(v(tmpDir) / "workaround"));
+  let* () = copyFile(path, workAroundFilePath);
+  let* () = rm(path);
+  let* () = copyFile(~perm=0o775, workAroundFilePath, path);
   codesign(path);
 };
 
@@ -67,6 +67,6 @@ let rec sign =
   fun
   | [] => return()
   | [h, ...rest] => {
-      let%bind () = sign'(h);
+      let* () = sign'(h);
       sign(rest);
     };

--- a/esy-build-package/Config.re
+++ b/esy-build-package/Config.re
@@ -24,20 +24,20 @@ let cwd = EsyLib.Path.v(Sys.getcwd());
 
 let initStore = (path: Fpath.t) => {
   open Run;
-  let%bind () = mkdir(Fpath.(path / "i"));
-  let%bind () = mkdir(Fpath.(path / "b"));
-  let%bind () = mkdir(Fpath.(path / "s"));
+  let* () = mkdir(Fpath.(path / "i"));
+  let* () = mkdir(Fpath.(path / "b"));
+  let* () = mkdir(Fpath.(path / "s"));
   return();
 };
 
 let rec configureStorePath =
         (~ocamlPkgName, ~ocamlVersion, cfg, globalStorePrefix) => {
   open Run;
-  let%bind path =
+  let* path =
     switch (cfg) {
     | StorePath(storePath) => return(storePath)
     | StorePathOfPrefix(prefixPath) =>
-      let%bind padding =
+      let* padding =
         Store.getPadding(~ocamlPkgName, ~ocamlVersion, prefixPath);
       let storePath = prefixPath / (Store.version ++ padding);
       return(storePath);
@@ -49,8 +49,8 @@ let rec configureStorePath =
         globalStorePrefix,
       )
     };
-  let%bind () = initStore(path);
-  let%bind () = mkdir(Fpath.(globalStorePrefix / Store.version / "b"));
+  let* () = initStore(path);
+  let* () = mkdir(Fpath.(globalStorePrefix / Store.version / "b"));
   return(path);
 };
 
@@ -67,7 +67,7 @@ let make =
       (),
     ) => {
   open Run;
-  let%bind storePath =
+  let* storePath =
     configureStorePath(
       ~ocamlPkgName,
       ~ocamlVersion,
@@ -80,7 +80,7 @@ let make =
     Unix.unlink(Fpath.to_string(storeSymlinkPath))
   | _ => ()
   };
-  let%bind () = initStore(localStorePath);
+  let* () = initStore(localStorePath);
   return({
     ocamlPkgName,
     ocamlVersion,

--- a/esy-build-package/Install.re
+++ b/esy-build-package/Install.re
@@ -1,6 +1,6 @@
-module Let_syntax = Run.Let_syntax;
-
 module F = OpamFile.Dot_install;
+
+let ( let* ) = Run.( let* );
 
 /* This checks if we should try adding .exe extension */
 let shouldTryAddExeIfNotExist =
@@ -63,8 +63,8 @@ let installFile =
           unsetExecutable(origPerm);
         };
 
-      let%bind () = Run.mkdir(Fpath.parent(dstPath));
-      let%bind () =
+      let* () = Run.mkdir(Fpath.parent(dstPath));
+      let* () =
         if (enableLinkingOptimization && origPerm == perm) {
           switch (EsyLib.System.Platform.host) {
           | Windows => Run.link(~force=true, ~target=srcPath, dstPath)
@@ -110,7 +110,7 @@ let installSection =
           | (None, None) => None
           };
 
-        let%bind () =
+        let* () =
           installFile(
             ~executable,
             ~enableLinkingOptimization,
@@ -128,8 +128,8 @@ let installSection =
 let install = (~enableLinkingOptimization, ~prefixPath, filename) => {
   let rootPath = Fpath.parent(filename);
 
-  let%bind (packageName, spec) = {
-    let%bind data = Run.read(filename);
+  let* (packageName, spec) = {
+    let* data = Run.read(filename);
     let packageName = Fpath.basename(Fpath.rem_ext(filename));
     let spec = {
       let filename =
@@ -147,7 +147,7 @@ let install = (~enableLinkingOptimization, ~prefixPath, filename) => {
    * for explanations on each section.
    */
 
-  let%bind () =
+  let* () =
     installSection(
       ~enableLinkingOptimization,
       ~executable=false,
@@ -156,7 +156,7 @@ let install = (~enableLinkingOptimization, ~prefixPath, filename) => {
       F.lib(spec),
     );
 
-  let%bind () =
+  let* () =
     installSection(
       ~enableLinkingOptimization,
       ~executable=false,
@@ -165,7 +165,7 @@ let install = (~enableLinkingOptimization, ~prefixPath, filename) => {
       F.lib_root(spec),
     );
 
-  let%bind () =
+  let* () =
     installSection(
       ~enableLinkingOptimization,
       ~executable=true,
@@ -174,7 +174,7 @@ let install = (~enableLinkingOptimization, ~prefixPath, filename) => {
       F.libexec(spec),
     );
 
-  let%bind () =
+  let* () =
     installSection(
       ~enableLinkingOptimization,
       ~executable=true,
@@ -183,7 +183,7 @@ let install = (~enableLinkingOptimization, ~prefixPath, filename) => {
       F.libexec_root(spec),
     );
 
-  let%bind () =
+  let* () =
     installSection(
       ~enableLinkingOptimization,
       ~executable=true,
@@ -192,7 +192,7 @@ let install = (~enableLinkingOptimization, ~prefixPath, filename) => {
       F.bin(spec),
     );
 
-  let%bind () =
+  let* () =
     installSection(
       ~enableLinkingOptimization,
       ~executable=true,
@@ -201,7 +201,7 @@ let install = (~enableLinkingOptimization, ~prefixPath, filename) => {
       F.sbin(spec),
     );
 
-  let%bind () =
+  let* () =
     installSection(
       ~enableLinkingOptimization,
       ~executable=false,
@@ -210,7 +210,7 @@ let install = (~enableLinkingOptimization, ~prefixPath, filename) => {
       F.toplevel(spec),
     );
 
-  let%bind () =
+  let* () =
     installSection(
       ~enableLinkingOptimization,
       ~executable=false,
@@ -219,7 +219,7 @@ let install = (~enableLinkingOptimization, ~prefixPath, filename) => {
       F.share(spec),
     );
 
-  let%bind () =
+  let* () =
     installSection(
       ~enableLinkingOptimization,
       ~executable=false,
@@ -228,7 +228,7 @@ let install = (~enableLinkingOptimization, ~prefixPath, filename) => {
       F.share_root(spec),
     );
 
-  let%bind () =
+  let* () =
     installSection(
       ~enableLinkingOptimization,
       ~executable=false,
@@ -237,7 +237,7 @@ let install = (~enableLinkingOptimization, ~prefixPath, filename) => {
       F.etc(spec),
     );
 
-  let%bind () =
+  let* () =
     installSection(
       ~enableLinkingOptimization,
       ~executable=false,
@@ -246,7 +246,7 @@ let install = (~enableLinkingOptimization, ~prefixPath, filename) => {
       F.doc(spec),
     );
 
-  let%bind () =
+  let* () =
     installSection(
       ~enableLinkingOptimization,
       ~executable=true,
@@ -255,7 +255,7 @@ let install = (~enableLinkingOptimization, ~prefixPath, filename) => {
       F.stublibs(spec),
     );
 
-  let%bind () = {
+  let* () = {
     let makeDstFilename = src => {
       let num = Fpath.get_ext(src);
       Fpath.(v("man" ++ num) / basename(src));

--- a/esy-build-package/Plan.re
+++ b/esy-build-package/Plan.re
@@ -24,8 +24,8 @@ type t = {
 };
 
 let ofFile = (path: Path.t) => {
-  module Let_syntax = EsyLib.Result.Syntax.Let_syntax;
-  let%bind data = Run.read(path);
+  open EsyLib.Result.Syntax;
+  let* data = Run.read(path);
   let json = Yojson.Safe.from_string(data);
   switch (of_yojson(json)) {
   | Ok(plan) => Ok(plan)

--- a/esy-build-package/Run.rei
+++ b/esy-build-package/Run.rei
@@ -15,7 +15,8 @@ type t('v, 'e) = result('v, err('e));
 let return: 'v => t('v, _);
 let error: string => t(_, _);
 let errorf: format4('a, Format.formatter, unit, t('v, 'e)) => 'a;
-let bind: (~f: 'a => result('b, 'c), result('a, 'c)) => result('b, 'c);
+let ( let* ): (result('a, 'c), 'a => result('b, 'c)) => result('b, 'c);
+
 let coerceFromMsgOnly: result('a, [ | `Msg(string)]) => t('a, _);
 let coerceFromClosed:
   result('a, [ | `Msg(string) | `CommandError(Cmd.t, Bos.OS.Cmd.status)]) =>

--- a/esy-build-package/Sandbox.re
+++ b/esy-build-package/Sandbox.re
@@ -44,7 +44,7 @@ module Darwin = {
   let sandboxExec = config => {
     open Run;
     let configData = renderConfig(config);
-    let%bind configFilename = createTmpFile(configData);
+    let* configFilename = createTmpFile(configData);
     Logs.debug(m =>
       m("sandbox-exec config:@;<0 2>@[<v 2>%a@]", Fmt.lines, configData)
     );
@@ -88,7 +88,7 @@ module Windows = {
        * because we need the current PATH/env to pick up node and run the shell
        */
       let jsonString = convertEnvToJsonString(env);
-      let%bind environmentTempFile = createTmpFile(jsonString);
+      let* environmentTempFile = createTmpFile(jsonString);
       let commandAsList = Cmd.to_list(command);
 
       /* Normalize slashes in the command we send to esy-bash */

--- a/esy-build-package/bin/esyBuildPackageCommand.re
+++ b/esy-build-package/bin/esyBuildPackageCommand.re
@@ -40,7 +40,7 @@ let createConfig = (copts: commonOpts) => {
     globalPathVariable,
     _,
   } = copts;
-  let%bind currentPath = Bos.OS.Dir.current();
+  let* currentPath = Bos.OS.Dir.current();
   let projectPath = Option.orDefault(~default=currentPath, projectPath);
   let storePath =
     switch (globalStorePrefix) {
@@ -70,9 +70,9 @@ let build = (~buildOnly=false, copts: commonOpts) => {
   open Run;
   let {planPath, _} = copts;
   let planPath = Option.orDefault(~default=v("build.json"), planPath);
-  let%bind cfg = createConfig(copts);
-  let%bind plan = Plan.ofFile(planPath);
-  let%bind () = Build.build(~buildOnly, ~cfg, plan);
+  let* cfg = createConfig(copts);
+  let* plan = Plan.ofFile(planPath);
+  let* () = Build.build(~buildOnly, ~cfg, plan);
   Ok();
 };
 
@@ -80,8 +80,8 @@ let shell = (copts: commonOpts) => {
   open Run;
   let {planPath, _} = copts;
   let planPath = Option.orDefault(~default=v("build.json"), planPath);
-  let%bind cfg = createConfig(copts);
-  let%bind plan = Plan.ofFile(planPath);
+  let* cfg = createConfig(copts);
+  let* plan = Plan.ofFile(planPath);
 
   let ppBanner = (build: Build.t) => {
     open Fmt;
@@ -120,7 +120,7 @@ let shell = (copts: commonOpts) => {
 
   let runShell = build => {
     ppBanner(build);
-    let%bind rcFilename =
+    let* rcFilename =
       createTmpFile(
         {|
         export PS1="[build $cur__name] % ";
@@ -136,7 +136,7 @@ let shell = (copts: commonOpts) => {
     Build.runCommandInteractive(build, cmd);
   };
 
-  let%bind () = Build.withBuild(~cfg, plan, runShell);
+  let* () = Build.withBuild(~cfg, plan, runShell);
   ok;
 };
 
@@ -144,13 +144,13 @@ let exec = (copts, command) => {
   open Run;
   let {planPath, _} = copts;
   let planPath = Option.orDefault(~default=v("build.json"), planPath);
-  let%bind cfg = createConfig(copts);
+  let* cfg = createConfig(copts);
   let runCommand = build => {
     let cmd = Cmd.of_list(command);
     Build.runCommandInteractive(build, cmd);
   };
-  let%bind plan = Plan.ofFile(planPath);
-  let%bind () = Build.withBuild(~cfg, plan, runCommand);
+  let* plan = Plan.ofFile(planPath);
+  let* () = Build.withBuild(~cfg, plan, runCommand);
   ok;
 };
 

--- a/esy-build-package/bin/esyRewritePrefixCommand.re
+++ b/esy-build-package/bin/esyRewritePrefixCommand.re
@@ -11,7 +11,7 @@ let rewritePrefixesInFile = (~origPrefix, ~destPrefix, path) => {
   Result.Syntax.(
     switch (System.Platform.host) {
     | Windows =>
-      let%bind _ =
+      let* _ =
         Result.List.map(
           ~f=
             ((origPrefix, destPrefix)) => {
@@ -35,12 +35,12 @@ let rewritePrefixesInFile = (~origPrefix, ~destPrefix, path) => {
 
 let rewriteTargetInSymlink = (~origPrefix, ~destPrefix, path) => {
   open Result.Syntax;
-  let%bind targetPath = Run.readlink(path);
+  let* targetPath = Run.readlink(path);
   switch (Path.remPrefix(origPrefix, targetPath)) {
   | Some(basePath) =>
     let nextTargetPath = Path.append(destPrefix, basePath);
-    let%bind () = Run.rm(path);
-    let%bind () = Run.symlink(~target=nextTargetPath, path);
+    let* () = Run.rm(path);
+    let* () = Run.symlink(~target=nextTargetPath, path);
     return();
   | None => return()
   };

--- a/esy-build/BuildInfo.re
+++ b/esy-build/BuildInfo.re
@@ -37,7 +37,7 @@ let toFile = (path: Path.t, info: t) => {
 let ofFile = (path: EsyLib.Path.t) => {
   open RunAsync.Syntax;
   if%bind (Fs.exists(path)) {
-    let%bind json = Fs.readJsonFile(path);
+    let* json = Fs.readJsonFile(path);
     switch (of_yojson(json)) {
     | Ok(v) => return(Some(v))
     | Error(_err) => return(None)

--- a/esy-build/EsyBuildPackageApi.re
+++ b/esy-build/EsyBuildPackageApi.re
@@ -28,7 +28,7 @@ let run =
     };
 
   let runProcess = buildJsonFilename => {
-    let%bind command =
+    let* command =
       RunAsync.ofRun(
         Run.Syntax.(
           return(
@@ -59,7 +59,7 @@ let run =
       | `Keep => `FD_copy(Unix.stdin)
       };
 
-    let%bind (stdout, stderr, log) =
+    let* (stdout, stderr, log) =
       switch (logPath) {
       | Some(logPath) =>
         let%lwt () =
@@ -67,7 +67,7 @@ let run =
           | _ => Lwt.return()
           };
 
-        let%bind () = Fs.createDir(Path.parent(logPath));
+        let* () = Fs.createDir(Path.parent(logPath));
 
         let%lwt fd =
           Lwt_unix.openfile(
@@ -131,7 +131,7 @@ let build =
        );
   };
 
-  let%bind (status, log) = run(~logPath?, ~args, cfg, `Build, plan);
+  let* (status, log) = run(~logPath?, ~args, cfg, `Build, plan);
   switch (status, log) {
   | (Unix.WEXITED(0), Some((_, fd))) =>
     UnixLabels.close(fd);
@@ -142,7 +142,7 @@ let build =
   | (Unix.WSIGNALED(code), Some((logPath, fd)))
   | (Unix.WSTOPPED(code), Some((logPath, fd))) =>
     UnixLabels.close(fd);
-    let%bind log = Fs.readFile(logPath);
+    let* log = Fs.readFile(logPath);
     RunAsync.withContextOfLog(
       ~header="build log:",
       log,
@@ -158,7 +158,7 @@ let build =
 
 let buildShell = (cfg, plan) => {
   open RunAsync.Syntax;
-  let%bind (status, _log) = run(~stdin=`Keep, cfg, `Shell, plan);
+  let* (status, _log) = run(~stdin=`Keep, cfg, `Shell, plan);
   return(status);
 };
 
@@ -166,6 +166,6 @@ let buildExec = (cfg, plan, cmd) => {
   open RunAsync.Syntax;
   let (tool, args) = Cmd.getToolAndArgs(cmd);
   let args = ["--", tool, ...args];
-  let%bind (status, _log) = run(~stdin=`Keep, ~args, cfg, `Exec, plan);
+  let* (status, _log) = run(~stdin=`Keep, ~args, cfg, `Exec, plan);
   return(status);
 };

--- a/esy-build/EsyRc.re
+++ b/esy-build/EsyRc.re
@@ -14,8 +14,8 @@ let ofPath = path => {
     };
 
   let ofFile = filename => {
-    let%bind data = Fs.readFile(filename);
-    let%bind json =
+    let* data = Fs.readFile(filename);
+    let* json =
       switch (Json.parse(data)) {
       | Ok(json) => return(json)
       | Error(err) =>
@@ -28,7 +28,7 @@ let ofPath = path => {
         )
       };
 
-    let%bind rc = RunAsync.ofStringError(of_yojson(json));
+    let* rc = RunAsync.ofStringError(of_yojson(json));
     let rc = {prefixPath: Option.map(~f=normalizePath, rc.prefixPath)};
     return(rc);
   };

--- a/esy-command-expression/EsyCommandExpression.re
+++ b/esy-command-expression/EsyCommandExpression.re
@@ -66,7 +66,7 @@ let formatName =
 
 let eval = (~envVar, ~pathSep, ~colon, ~scope, string) => {
   open Result.Syntax;
-  let%bind expr = parse(string);
+  let* expr = parse(string);
 
   let lookupValue = name =>
     switch (scope(name)) {
@@ -103,22 +103,22 @@ let eval = (~envVar, ~pathSep, ~colon, ~scope, string) => {
         eval(e);
       }
     | [@implicit_arity] E.And(a, b) => {
-        let%bind a = evalToBool(a);
-        let%bind b = evalToBool(b);
+        let* a = evalToBool(a);
+        let* b = evalToBool(b);
         return(V.Bool(a && b));
       }
     | [@implicit_arity] E.Or(a, b) => {
-        let%bind a = evalToBool(a);
-        let%bind b = evalToBool(b);
+        let* a = evalToBool(a);
+        let* b = evalToBool(b);
         return(V.Bool(a || b));
       }
     | E.Not(a) => {
-        let%bind a = evalToBool(a);
+        let* a = evalToBool(a);
         return(V.Bool(!a));
       }
     | [@implicit_arity] E.Rel(relop, a, b) => {
-        let%bind a = eval(a);
-        let%bind b = eval(b);
+        let* a = eval(a);
+        let* b = eval(b);
         let r =
           switch (relop) {
           | E.EQ => V.equal(a, b)
@@ -129,11 +129,11 @@ let eval = (~envVar, ~pathSep, ~colon, ~scope, string) => {
       }
     | E.Concat(exprs) => {
         let f = (s, expr) => {
-          let%bind v = evalToString(expr);
+          let* v = evalToString(expr);
           return(s ++ v);
         };
 
-        let%bind v = Result.List.foldLeft(~f, ~init="", exprs);
+        let* v = Result.List.foldLeft(~f, ~init="", exprs);
         return(V.String(v));
       };
 

--- a/esy-install/Config.re
+++ b/esy-install/Config.re
@@ -16,7 +16,7 @@ let make =
       (),
     ) => {
   open RunAsync.Syntax;
-  let%bind prefixPath =
+  let* prefixPath =
     RunAsync.ofRun(
       Run.Syntax.(
         switch (prefixPath) {
@@ -33,24 +33,24 @@ let make =
     | Some(path) => path
     | None => Path.(prefixPath / "source")
     };
-  let%bind () = Fs.createDir(sourcePath);
+  let* () = Fs.createDir(sourcePath);
 
-  let%bind sourceArchivePath =
+  let* sourceArchivePath =
     switch (cacheTarballsPath) {
     | Some(path) =>
-      let%bind () = Fs.createDir(path);
+      let* () = Fs.createDir(path);
       return(Some(path));
     | None => return(None)
     };
 
   let sourceFetchPath = Path.(sourcePath / "f");
-  let%bind () = Fs.createDir(sourceFetchPath);
+  let* () = Fs.createDir(sourceFetchPath);
 
   let sourceStagePath = Path.(sourcePath / "s");
-  let%bind () = Fs.createDir(sourceStagePath);
+  let* () = Fs.createDir(sourceStagePath);
 
   let sourceInstallPath = Path.(sourcePath / "i");
-  let%bind () = Fs.createDir(sourceInstallPath);
+  let* () = Fs.createDir(sourceInstallPath);
 
   return({
     sourceArchivePath,

--- a/esy-install/Installation.re
+++ b/esy-install/Installation.re
@@ -25,9 +25,8 @@ let entries = PackageId.Map.bindings;
 let ofPath = path => {
   open RunAsync.Syntax;
   if%bind (Fs.exists(path)) {
-    let%bind json = Fs.readJsonFile(path);
-    let%bind installation =
-      RunAsync.ofRun(Json.parseJsonWith(of_yojson, json));
+    let* json = Fs.readJsonFile(path);
+    let* installation = RunAsync.ofRun(Json.parseJsonWith(of_yojson, json));
     return(Some(installation));
   } else {
     return(None);

--- a/esy-install/Package.re
+++ b/esy-install/Package.re
@@ -28,9 +28,9 @@ let opam = pkg =>
     | Install({opam: Some(opam), _}) =>
       let name = OpamPackage.Name.to_string(opam.name);
       let version = Version.Opam(opam.version);
-      let%bind opamfile = {
+      let* opamfile = {
         let path = Path.(opam.path / "opam");
-        let%bind data = Fs.readFile(path);
+        let* data = Fs.readFile(path);
         let filename =
           OpamFile.make(OpamFilename.of_string(Path.show(path)));
         try(return(OpamFile.OPAM.read_from_string(~filename, data))) {

--- a/esy-install/PkgSpec.re
+++ b/esy-install/PkgSpec.re
@@ -45,10 +45,10 @@ let parse =
         | (name, Some(rest)) =>
           switch (split(rest)) {
           | Some(_) =>
-            let%bind id = PackageId.parse(v);
+            let* id = PackageId.parse(v);
             return(ById(id));
           | None =>
-            let%bind version = Version.parse(rest);
+            let* version = Version.parse(rest);
             return([@implicit_arity] ByNameVersion(name, version));
           }
         };

--- a/esy-install/SandboxSpec.re
+++ b/esy-install/SandboxSpec.re
@@ -82,16 +82,16 @@ let ofPath = path => {
   open RunAsync.Syntax;
 
   let discoverOfDir = path => {
-    let%bind fnames = Fs.listDir(path);
+    let* fnames = Fs.listDir(path);
     let fnames = StringSet.of_list(fnames);
 
-    let%bind manifest =
+    let* manifest =
       if (StringSet.mem("esy.json", fnames)) {
         return(Manifest((Esy, "esy.json")));
       } else if (StringSet.mem("package.json", fnames)) {
         return(Manifest((Esy, "package.json")));
       } else {
-        let%bind hasOpam = {
+        let* hasOpam = {
           let has = StringSet.mem("opam", fnames);
           if (has) {
             let%map isDir = Fs.isDir(Path.(path / "opam"));
@@ -103,11 +103,11 @@ let ofPath = path => {
         if (hasOpam) {
           return(Manifest((Opam, "opam")));
         } else {
-          let%bind filenames = {
+          let* filenames = {
             let f = filename => {
               let path = Path.(path / filename);
               if (Path.(hasExt(".opam", path))) {
-                let%bind data = Fs.readFile(path);
+                let* data = Fs.readFile(path);
                 return(String.(length(trim(data))) > 0);
               } else {
                 return(false);

--- a/esy-lib/Checksum.re
+++ b/esy-lib/Checksum.re
@@ -78,7 +78,7 @@ let computeOfFile = (~kind=Sha256, path) => {
     {
       open Result.Syntax;
       let path = EsyBash.normalizePathForCygwin(Path.show(path));
-      let%bind out = EsyBash.runOut(Cmd.(cmd % path |> toBosCmd));
+      let* out = EsyBash.runOut(Cmd.(cmd % path |> toBosCmd));
       switch (Astring.String.cut(~sep=" ", out)) {
       | Some((v, _)) => return((kind, v))
       | None => return((kind, String.trim(out)))
@@ -90,7 +90,7 @@ let computeOfFile = (~kind=Sha256, path) => {
 let checkFile = (~path, checksum: t) => {
   open RunAsync.Syntax;
 
-  let%bind value = {
+  let* value = {
     let cmd =
       switch (checksum) {
       | (Md5, _) => md5sum
@@ -104,7 +104,7 @@ let checkFile = (~path, checksum: t) => {
       {
         open Result.Syntax;
         let path = EsyBash.normalizePathForCygwin(Path.show(path));
-        let%bind out = EsyBash.runOut(Cmd.(cmd % path |> toBosCmd));
+        let* out = EsyBash.runOut(Cmd.(cmd % path |> toBosCmd));
         switch (Astring.String.cut(~sep=" ", out)) {
         | Some((v, _)) => return(v)
         | None => return(String.trim(out))

--- a/esy-lib/ChildProcess.re
+++ b/esy-lib/ChildProcess.re
@@ -84,12 +84,12 @@ let withProcess =
 
   let env = prepareEnv(env);
 
-  let%bind cmd =
+  let* cmd =
     RunAsync.ofRun(
       {
         open Run.Syntax;
         let (prg, args) = Cmd.getToolAndArgs(cmd);
-        let%bind prg =
+        let* prg =
           switch (resolveProgramInEnv, env) {
           | (true, Some((env, _))) => resolveCmdInEnv(~env, prg)
           | _ => Ok(prg)
@@ -205,12 +205,12 @@ let runOut =
     | CustomEnv(env) => Some(env)
     };
 
-  let%bind cmdLwt =
+  let* cmdLwt =
     RunAsync.ofRun(
       {
         open Run.Syntax;
         let (prg, args) = Cmd.getToolAndArgs(cmd);
-        let%bind prg =
+        let* prg =
           switch (resolveProgramInEnv, env) {
           | (true, Some(env)) => resolveCmdInEnv(~env, prg)
           | _ => Ok(prg)

--- a/esy-lib/Cmd.re
+++ b/esy-lib/Cmd.re
@@ -108,13 +108,13 @@ let checkIfExecutable = path =>
     /* In particular, the Unix.stat implementation emulates this on Windows by checking the extension for `exe`/`com`/`cmd`/`bat` */
     /* But in our case, since we're deferring to the Cygwin layer, it's possible to have executables that don't confirm to that rule */
     | Windows =>
-      let%bind exists = Bos.OS.Path.exists(path);
+      let* exists = Bos.OS.Path.exists(path);
       switch (exists) {
       | true => Ok(Some(path))
       | _ => Ok(None)
       };
     | _ =>
-      let%bind stats = Bos.OS.Path.stat(path);
+      let* stats = Bos.OS.Path.stat(path);
       switch (stats.Unix.st_kind, isExecutable(stats)) {
       | (Unix.S_REG, true) => Ok(Some(path))
       | _ => Ok(None)
@@ -177,7 +177,7 @@ let resolveCmd = (path, cmd) => {
 
 let resolveInvocation = (path, (tool, args)) => {
   open Result.Syntax;
-  let%bind tool = resolveCmd(path, tool);
+  let* tool = resolveCmd(path, tool);
   return((tool, args));
 };
 

--- a/esy-lib/Curl.re
+++ b/esy-lib/Curl.re
@@ -12,7 +12,7 @@ let parseStdout = stdout =>
   Run.Syntax.(
     switch (String.cut(~rev=true, ~sep="\n", stdout)) {
     | Some((stdout, httpcode)) =>
-      let%bind httpcode =
+      let* httpcode =
         try(return(int_of_string(httpcode))) {
         | Failure(_) => errorf("unable to parse HTTP code: %s", httpcode)
         };

--- a/esy-lib/Digestv.re
+++ b/esy-lib/Digestv.re
@@ -4,7 +4,7 @@ type part = Digest.t;
 let part_to_yojson = v => Json.Encode.string(Digest.to_hex(v));
 let part_of_yojson = json => {
   open Result.Syntax;
-  let%bind part = Json.Decode.string(json);
+  let* part = Json.Decode.string(json);
   return(Digest.from_hex(part));
 };
 
@@ -23,7 +23,7 @@ let ofJson = v => [json(v)];
 
 let ofFile = path => {
   open RunAsync.Syntax;
-  let%bind data = Fs.readFile(path);
+  let* data = Fs.readFile(path);
   return(ofString(data));
 };
 

--- a/esy-lib/Environment.re
+++ b/esy-lib/Environment.re
@@ -171,7 +171,7 @@ module Make =
         switch (binding.Binding.value) {
         | Value(value) =>
           let value = V.show(value);
-          let%bind value = EsyShellExpansion.render(~scope, value);
+          let* value = EsyShellExpansion.render(~scope, value);
           let value = V.v(value);
           Ok(StringMap.add(binding.name, value, env));
         | ExpandedValue(value) =>
@@ -292,7 +292,7 @@ let renderToShellSource =
         lines;
       };
 
-    let%bind line =
+    let* line =
       switch (value) {
       | Value(value) =>
         let value = escapeDoubleQuote(value);
@@ -314,7 +314,7 @@ let renderToShellSource =
     [@implicit_arity] Ok([line, ...lines], origin);
   };
 
-  let%bind (lines, _) = Run.List.foldLeft(~f, ~init=([], None), bindings);
+  let* (lines, _) = Run.List.foldLeft(~f, ~init=([], None), bindings);
   return(header ++ "\n" ++ (lines |> List.rev |> String.concat("\n")));
 };
 

--- a/esy-lib/Fs.re
+++ b/esy-lib/Fs.re
@@ -41,7 +41,7 @@ let openFile = (~mode, ~perm, path) =>
 
 let readJsonFile = (path: Path.t) => {
   open RunAsync.Syntax;
-  let%bind data = readFile(path);
+  let* data = readFile(path);
   try(return(Yojson.Safe.from_string(data))) {
   | Yojson.Json_error(msg) =>
     errorf("error reading JSON file: %a@\n%s", Path.pp, path, msg)
@@ -349,7 +349,7 @@ let rec copyPathLwt = (~src, ~dst) => {
 
 let copyPath = (~src, ~dst) => {
   open RunAsync.Syntax;
-  let%bind () = createDir(Path.parent(dst));
+  let* () = createDir(Path.parent(dst));
   try%lwt(
     {
       let%lwt () = copyPathLwt(~src, ~dst);
@@ -456,7 +456,7 @@ let withTempDir = (~tempPath=?, f) => {
     | None => Path.v(Filename.get_temp_dir_name())
     };
 
-  let%bind path = createRandomPath(tempPath, "esy-%s");
+  let* path = createRandomPath(tempPath, "esy-%s");
   Lwt.finalize(
     () => f(path),
     () =>
@@ -579,13 +579,13 @@ let realpath = path => {
     if (Fpath.is_root(path)) {
       return(path);
     } else {
-      let%bind isSymlink = isSymlinkAndExists(path);
+      let* isSymlink = isSymlinkAndExists(path);
       if (isSymlink) {
-        let%bind target = readlink(path);
+        let* target = readlink(path);
         aux(target |> Fpath.append(Fpath.parent(path)) |> Fpath.normalize);
       } else {
         let parentPath = path |> Fpath.parent |> Fpath.rem_empty_seg;
-        let%bind parentPath = aux(parentPath);
+        let* parentPath = aux(parentPath);
         return(Path.(parentPath / Fpath.basename(path)));
       };
     };

--- a/esy-lib/Option.re
+++ b/esy-lib/Option.re
@@ -32,6 +32,7 @@ let isSome =
 
 module Syntax = {
   let return = v => Some(v);
+  let ( let* ) = (v, f) => bind(~f, v);
   module Let_syntax = {
     let bind = bind;
     let map = map;

--- a/esy-lib/Parse.re
+++ b/esy-lib/Parse.re
@@ -22,7 +22,7 @@ let failIf = (msg, p) => {
 };
 
 let till = (c, p) => {
-  let%bind input = take_while1(c);
+  let* input = take_while1(c);
   switch (parse_string(~consume=All, p, input)) {
   | Ok(fname) => return(fname)
   | Error(msg) => fail(msg)

--- a/esy-lib/Result.re
+++ b/esy-lib/Result.re
@@ -38,6 +38,11 @@ module Syntax = {
   let return = return;
   let error = error;
   let errorf = errorf;
+  let ( let* ) = (v, f) =>
+    switch (v) {
+    | Ok(v) => f(v)
+    | Error(e) => Error(e)
+    };
 
   let (>>) = (v, f) => {
     switch (v) {
@@ -90,7 +95,7 @@ module List = {
       } else {
         return(xs);
       };
-    let%bind xs = foldLeft(~f, ~init=[], xs);
+    let* xs = foldLeft(~f, ~init=[], xs);
     return(List.rev(xs));
   };
 };

--- a/esy-lib/Result.rei
+++ b/esy-lib/Result.rei
@@ -24,6 +24,7 @@ module Syntax: {
   let return: 'v => t('v, _);
   let error: 'err => t(_, 'err);
   let errorf: format4('a, Format.formatter, unit, t(_, string)) => 'a;
+  let ( let* ): (t('a, 'err), 'a => t('b, 'err)) => t('b, 'err);
   let (>>): (t(unit, 'err), unit => t('b, 'err)) => t('b, 'err);
 
   module Let_syntax: {

--- a/esy-lib/Run.re
+++ b/esy-lib/Run.re
@@ -128,6 +128,8 @@ module Syntax = {
   let return = return;
   let error = error;
   let errorf = errorf;
+  let ( let* ) = (v, f) => bind(~f, v);
+
   module Let_syntax = {
     let bind = bind;
     let map = map;

--- a/esy-lib/Run.rei
+++ b/esy-lib/Run.rei
@@ -72,8 +72,8 @@ let toResult: t('a) => result('a, string);
  * Convenience module which is designed to be openned locally with the
  * code which heavily relies on Run.t.
  *
- * This also brings Let_syntax module into scope and thus compatible with
- * ppx_let.
+ * This also brings monadic let operators and Let_syntax module into scope
+ * and thus compatible with ppx_let.
  *
  * Example
  *
@@ -89,6 +89,7 @@ module Syntax: {
   let return: 'a => t('a);
   let error: string => t('a);
   let errorf: format4('a, Format.formatter, unit, t('v)) => 'a;
+  let ( let* ): (t('a), 'a => t('b)) => t('b);
 
   module Let_syntax: {
     let bind: (~f: 'a => t('b), t('a)) => t('b);

--- a/esy-lib/RunAsync.re
+++ b/esy-lib/RunAsync.re
@@ -63,6 +63,7 @@ module Syntax = {
   let return = return;
   let error = error;
   let errorf = errorf;
+  let ( let* ) = (v, f) => bind(~f, v);
 
   module Let_syntax = {
     let map = map;
@@ -166,7 +167,7 @@ module List = {
         return(None);
       };
     let f = limitWithConccurrency(concurrency, f);
-    let%bind xs = joinAll(List.map(~f, xs));
+    let* xs = joinAll(List.map(~f, xs));
     return(List.filterNone(xs));
   };
 
@@ -177,7 +178,7 @@ module List = {
       fun
       | [] => return()
       | [x, ...xs] => {
-          let%bind () = f(x);
+          let* () = f(x);
           processSeq(~f, xs);
         }
     );

--- a/esy-lib/RunAsync.rei
+++ b/esy-lib/RunAsync.rei
@@ -89,8 +89,8 @@ let ofOption: (~err: string=?, option('a)) => t('a);
  * Convenience module which is designed to be openned locally with the
  * code which heavily relies on RunAsync.t.
  *
- * This also brings Let_syntax module into scope and thus compatible with
- * ppx_let.
+ * This also brings monadic let operators and Let_syntax module into scope
+ * and thus compatible with ppx_let.
  *
  * Example
  *
@@ -107,6 +107,7 @@ module Syntax: {
 
   let error: string => t('a);
   let errorf: format4('a, Format.formatter, unit, t('v)) => 'a;
+  let ( let* ): (t('a), 'a => t('b)) => t('b);
 
   module Let_syntax: {
     let bind: (~f: 'a => t('b), t('a)) => t('b);

--- a/esy-lib/StringMap.re
+++ b/esy-lib/StringMap.re
@@ -36,7 +36,7 @@ let of_yojson = v_of_yojson =>
     fun
     | `Assoc(items) => {
         let f = (items, (k, json)) => {
-          let%bind v = v_of_yojson(json);
+          let* v = v_of_yojson(json);
           return(add(k, v, items));
         };
 
@@ -96,7 +96,7 @@ module Override: {
             let override = Drop;
             return(add(name, override, map));
           | _ =>
-            let%bind value = value_of_yojson(name, json);
+            let* value = value_of_yojson(name, json);
             let override = Edit(value);
             return(add(name, override, map));
           };

--- a/esy-lib/StringSet.re
+++ b/esy-lib/StringSet.re
@@ -4,6 +4,6 @@ let to_yojson = set => Json.Encode.(list(string))(elements(set));
 
 let of_yojson = json => {
   open Result.Syntax;
-  let%bind elements = Json.Decode.(list(string))(json);
+  let* elements = Json.Decode.(list(string))(json);
   Ok(of_list(elements));
 };

--- a/esy-lib/Tarball.re
+++ b/esy-lib/Tarball.re
@@ -30,8 +30,8 @@ let stripComponentFrom = (~stripComponents=?, out) => {
 
 let copyAll = (~src, ~dst, ()) => {
   open RunAsync.Syntax;
-  let%bind items = Fs.listDir(src);
-  let%bind () = Fs.createDir(dst);
+  let* items = Fs.listDir(src);
+  let* () = Fs.createDir(dst);
   let f = item => Fs.copyPath(~src=Path.(src / item), ~dst=Path.(dst / item));
   RunAsync.List.processSeq(~f, items);
 };
@@ -70,7 +70,7 @@ let run = cmd => {
 let unpackWithTar = (~stripComponents=?, ~dst, filename) => {
   open RunAsync.Syntax;
   let unpack = out => {
-    let%bind cmd =
+    let* cmd =
       RunAsync.ofBosError(
         {
           open Result.Syntax;
@@ -86,8 +86,8 @@ let unpackWithTar = (~stripComponents=?, ~dst, filename) => {
   switch (stripComponents) {
   | Some(stripComponents) =>
     Fs.withTempDir(out => {
-      let%bind () = unpack(out);
-      let%bind out = stripComponentFrom(~stripComponents, out);
+      let* () = unpack(out);
+      let* out = stripComponentFrom(~stripComponents, out);
       copyAll(~src=out, ~dst, ());
     })
   | None => unpack(dst)
@@ -101,8 +101,8 @@ let unpackWithUnzip = (~stripComponents=?, ~dst, filename) => {
   switch (stripComponents) {
   | Some(stripComponents) =>
     Fs.withTempDir(out => {
-      let%bind () = unpack(out);
-      let%bind out = stripComponentFrom(~stripComponents, out);
+      let* () = unpack(out);
+      let* out = stripComponentFrom(~stripComponents, out);
       copyAll(~src=out, ~dst, ());
     })
   | None => unpack(dst)
@@ -156,7 +156,7 @@ let create = (~filename, ~outpath=".", src) =>
       let nf = EsyBash.normalizePathForCygwin(Path.show(filename));
       let ns = EsyBash.normalizePathForCygwin(Path.show(src));
       let cmd = Cmd.(v("tar") % "czf" % nf % "-C" % ns % outpath);
-      let%bind res = EsyBash.run(Cmd.toBosCmd(cmd));
+      let* res = EsyBash.run(Cmd.toBosCmd(cmd));
       return(res);
     },
   );

--- a/esy-package-config/BuildEnv.re
+++ b/esy-package-config/BuildEnv.re
@@ -29,7 +29,7 @@ let of_yojson =
     fun
     | `Assoc(items) => {
         let f = (items, (name, json)) => {
-          let%bind item = item_of_yojson(name, json);
+          let* item = item_of_yojson(name, json);
           return(StringMap.add(name, item, items));
         };
 

--- a/esy-package-config/CommandList.re
+++ b/esy-package-config/CommandList.re
@@ -11,7 +11,7 @@ let of_yojson = (json: Json.t) =>
     | `List(commands) =>
       Json.Decode.list(Command.of_yojson, `List(commands))
     | `String(command) =>
-      let%bind command = Command.of_yojson(`String(command));
+      let* command = Command.of_yojson(`String(command));
       return([command]);
     | _ => Error("expected either a null, a string or an array")
     }

--- a/esy-package-config/ExportedEnv.re
+++ b/esy-package-config/ExportedEnv.re
@@ -59,7 +59,7 @@ let unset = (~exclusive=?, scope, name) => {
 
 let item_of_yojson = (name, json) => {
   open Result.Syntax;
-  let%bind {Item.value, scope, exclusive} = Item.of_yojson(json);
+  let* {Item.value, scope, exclusive} = Item.of_yojson(json);
   let value =
     switch (value) {
     | Some(value) => Set(value)
@@ -73,7 +73,7 @@ let of_yojson =
   | `Assoc(items) => {
       open Result.Syntax;
       let f = (items, (name, json)) => {
-        let%bind item = item_of_yojson(name, json);
+        let* item = item_of_yojson(name, json);
         return(StringMap.add(name, item, items));
       };
 

--- a/esy-package-config/File.re
+++ b/esy-package-config/File.re
@@ -16,7 +16,7 @@ let ofDir = base => {
     open RunAsync.Syntax;
     let root = Path.(base /\/ sub);
     if%bind (Fs.exists(root)) {
-      let%bind files = Fs.listDir(root);
+      let* files = Fs.listDir(root);
       let f = name =>
         if%bind (Fs.isDir(Path.(root / name))) {
           loop(Path.(sub / name));
@@ -24,7 +24,7 @@ let ofDir = base => {
           return([{name: Path.(sub / name), root: base}]);
         };
 
-      let%bind lists = RunAsync.List.mapAndJoin(~concurrency=20, ~f, files);
+      let* lists = RunAsync.List.mapAndJoin(~concurrency=20, ~f, files);
       return(List.concat(lists));
     } else {
       return([]);
@@ -46,6 +46,6 @@ let placeAt = (path, file) => {
         Path.showPretty(dst),
       )
     );
-  let%bind () = Fs.createDir(Path.parent(dst));
+  let* () = Fs.createDir(Path.parent(dst));
   Fs.copyFile(~src, ~dst);
 };

--- a/esy-package-config/NpmFormula.re
+++ b/esy-package-config/NpmFormula.re
@@ -8,10 +8,10 @@ let pp = (fmt, deps) =>
 
 let of_yojson = json => {
   open Result.Syntax;
-  let%bind items = Json.Decode.assoc(json);
+  let* items = Json.Decode.assoc(json);
   let f = (deps, (name, json)) => {
-    let%bind spec = Json.Decode.string(json);
-    let%bind req = Req.parse(name ++ "@" ++ spec);
+    let* spec = Json.Decode.string(json);
+    let* req = Req.parse(name ++ "@" ++ spec);
     return([req, ...deps]);
   };
 
@@ -51,7 +51,7 @@ module Override = {
   let of_yojson = {
     let req_of_yojson = (name, json) => {
       open Result.Syntax;
-      let%bind spec = Json.Decode.string(json);
+      let* spec = Json.Decode.string(json);
       Req.parse(name ++ "@" ++ spec);
     };
 

--- a/esy-package-config/OfPackageJson.re
+++ b/esy-package-config/OfPackageJson.re
@@ -90,14 +90,14 @@ module InstallManifestV1 = {
         json,
       ) => {
     open Run.Syntax;
-    let%bind pkgJson = Json.parseJsonWith(Manifest.of_yojson, json);
+    let* pkgJson = Json.parseJsonWith(Manifest.of_yojson, json);
     let originalVersion =
       switch (pkgJson.Manifest.version) {
       | Some(version) => Some(Version.Npm(version))
       | None => None
       };
 
-    let%bind source =
+    let* source =
       switch (source, pkgJson.dist) {
       | (Some(source), _) => return(source)
       | (None, Some(dist)) =>
@@ -128,25 +128,24 @@ module InstallManifestV1 = {
       List.filter(~f, dependencies);
     };
 
-    let%bind dependencies = rebaseDependencies(source, dependencies);
+    let* dependencies = rebaseDependencies(source, dependencies);
 
-    let%bind devDependencies =
+    let* devDependencies =
       switch (parseDevDependencies) {
       | false => return(NpmFormula.empty)
       | true =>
-        let%bind {DevDependenciesOfManifest.devDependencies} =
+        let* {DevDependenciesOfManifest.devDependencies} =
           Json.parseJsonWith(DevDependenciesOfManifest.of_yojson, json);
 
-        let%bind devDependencies =
-          rebaseDependencies(source, devDependencies);
+        let* devDependencies = rebaseDependencies(source, devDependencies);
         return(devDependencies);
       };
 
-    let%bind resolutions =
+    let* resolutions =
       switch (parseResolutions) {
       | false => return(Resolutions.empty)
       | true =>
-        let%bind {ResolutionsOfManifest.resolutions} =
+        let* {ResolutionsOfManifest.resolutions} =
           Json.parseJsonWith(ResolutionsOfManifest.of_yojson, json);
 
         return(resolutions);
@@ -212,7 +211,7 @@ module BuildManifestV1 = {
 
   let ofJson = json => {
     open Run.Syntax;
-    let%bind pkgJson = Json.parseJsonWith(packageJson_of_yojson, json);
+    let* pkgJson = Json.parseJsonWith(packageJson_of_yojson, json);
     switch (pkgJson.esy) {
     | Some(m) =>
       let warnings = [];
@@ -244,8 +243,8 @@ module EsyVersion = {
 
   let of_yojson = json => {
     open Result.Syntax;
-    let%bind constr = Json.Decode.string(json);
-    let%bind constr = SemverVersion.Formula.parse(constr);
+    let* constr = Json.Decode.string(json);
+    let* constr = SemverVersion.Formula.parse(constr);
     switch (constr) {
     | [
         [
@@ -280,7 +279,7 @@ module EsyVersion = {
           let f = ((key, _json)) => key == "esy";
           switch (List.find_opt(~f, items)) {
           | Some((_, json)) =>
-            let%bind esy = of_yojson(json);
+            let* esy = of_yojson(json);
             return({esy: Some(esy)});
           | None => return({esy: None})
           };
@@ -331,7 +330,7 @@ let installManifest =
       json,
     ) => {
   open Run.Syntax;
-  let%bind esyVersion = EsyVersion.OfPackageJson.parse(json);
+  let* esyVersion = EsyVersion.OfPackageJson.parse(json);
   switch (esyVersion) {
   | Some(1) =>
     InstallManifestV1.ofJson(
@@ -344,7 +343,7 @@ let installManifest =
     )
   | Some(v) => unknownEsyVersionError(v)
   | None =>
-    let%bind (m, warnings) =
+    let* (m, warnings) =
       InstallManifestV1.ofJson(
         ~parseResolutions,
         ~parseDevDependencies,
@@ -360,7 +359,7 @@ let installManifest =
 
 let buildManifest = json => {
   open Run.Syntax;
-  let%bind esyVersion = EsyVersion.OfPackageJson.parse(json);
+  let* esyVersion = EsyVersion.OfPackageJson.parse(json);
   switch (esyVersion) {
   | Some(1) => BuildManifestV1.ofJson(json)
   | Some(v) => unknownEsyVersionError(v)

--- a/esy-package-config/OpamPackageVersion.re
+++ b/esy-package-config/OpamPackageVersion.re
@@ -11,7 +11,7 @@ module Version = {
   let parse = v => Ok(OpamPackage.Version.of_string(v));
   let parser = {
     open Parse;
-    let%bind input = take_while1(_ => true);
+    let* input = take_while1(_ => true);
     try(return(OpamPackage.Version.of_string(input))) {
     | _ => fail("cannot parse opam version")
     };
@@ -45,8 +45,8 @@ let caretRange = v =>
         {...v, major: v.major + 1};
       };
 
-    let%bind v = Version.ofSemver(v);
-    let%bind ve = Version.ofSemver(ve);
+    let* v = Version.ofSemver(v);
+    let* ve = Version.ofSemver(ve);
     [@implicit_arity] Ok(v, ve);
   | Error(_) => Error("^ cannot be applied to: " ++ v)
   };
@@ -56,8 +56,8 @@ let tildaRange = v =>
   | Ok(v) =>
     open Result.Syntax;
     let ve = {...v, minor: v.minor + 1};
-    let%bind v = Version.ofSemver(v);
-    let%bind ve = Version.ofSemver(ve);
+    let* v = Version.ofSemver(v);
+    let* ve = Version.ofSemver(ve);
     [@implicit_arity] Ok(v, ve);
   | Error(_) => Error("~ cannot be applied to: " ++ v)
   };
@@ -97,34 +97,34 @@ module Formula = {
         switch (fst, snd) {
         | (Some('^'), _) =>
           let v = String.Sub.(text |> v(~start=1) |> to_string);
-          let%bind (v, ve) = caretRange(v);
+          let* (v, ve) = caretRange(v);
           return([C.GTE(v), C.LT(ve)]);
         | (Some('~'), _) =>
           let v = String.Sub.(text |> v(~start=1) |> to_string);
-          let%bind (v, ve) = tildaRange(v);
+          let* (v, ve) = tildaRange(v);
           return([C.GTE(v), C.LT(ve)]);
         | (Some('='), _) =>
           let text = String.Sub.(text |> v(~start=1) |> to_string);
-          let%bind v = Version.parse(text);
+          let* v = Version.parse(text);
           return([C.EQ(v)]);
         | (Some('<'), Some('=')) =>
           let text = String.Sub.(text |> v(~start=2) |> to_string);
-          let%bind v = Version.parse(text);
+          let* v = Version.parse(text);
           return([C.LTE(v)]);
         | (Some('<'), _) =>
           let text = String.Sub.(text |> v(~start=1) |> to_string);
-          let%bind v = Version.parse(text);
+          let* v = Version.parse(text);
           return([C.LT(v)]);
         | (Some('>'), Some('=')) =>
           let text = String.Sub.(text |> v(~start=2) |> to_string);
-          let%bind v = Version.parse(text);
+          let* v = Version.parse(text);
           return([C.GTE(v)]);
         | (Some('>'), _) =>
           let text = String.Sub.(text |> v(~start=1) |> to_string);
-          let%bind v = Version.parse(text);
+          let* v = Version.parse(text);
           return([C.GT(v)]);
         | (_, _) =>
-          let%bind v = Version.parse(text);
+          let* v = Version.parse(text);
           return([C.EQ(v)]);
         };
       }
@@ -171,7 +171,7 @@ module Formula = {
 
   let parserDnf = {
     open P;
-    let%bind input = take_while1(_ => true);
+    let* input = take_while1(_ => true);
     return(parseExn(input));
   };
 

--- a/esy-package-config/Override.re
+++ b/esy-package-config/Override.re
@@ -62,15 +62,15 @@ let json = override =>
 
 let build = override => {
   open RunAsync.Syntax;
-  let%bind json = json(override);
-  let%bind override = RunAsync.ofStringError(build_of_yojson(json));
+  let* json = json(override);
+  let* override = RunAsync.ofStringError(build_of_yojson(json));
   return(Some(override));
 };
 
 let install = override => {
   open RunAsync.Syntax;
-  let%bind json = json(override);
-  let%bind override = RunAsync.ofStringError(install_of_yojson(json));
+  let* json = json(override);
+  let* override = RunAsync.ofStringError(install_of_yojson(json));
   return(Some(override));
 };
 

--- a/esy-package-config/PackageId.re
+++ b/esy-package-config/PackageId.re
@@ -41,20 +41,20 @@ let parse = v => {
     Result.Syntax.(
       switch (split(v)) {
       | Some(("", name)) =>
-        let%bind (name, version) = parseName(name);
+        let* (name, version) = parseName(name);
         return(("@" ++ name, version));
       | Some((name, version)) => return((name, version))
       | None => error("invalid id: missing version")
       }
     );
 
-  let%bind (name, v) = parseName(v);
+  let* (name, v) = parseName(v);
   switch (split(v)) {
   | Some((version, digest)) =>
-    let%bind version = parseVersion(version);
+    let* version = parseVersion(version);
     return({name, version, digest: Some(digest)});
   | None =>
-    let%bind version = parseVersion(v);
+    let* version = parseVersion(v);
     return({name, version, digest: None});
   };
 };
@@ -136,8 +136,8 @@ module Map = {
       fun
       | `Assoc(items) => {
           let f = (map, (k, v)) => {
-            let%bind k = parse(k);
-            let%bind v = v_of_yojson(v);
+            let* k = parse(k);
+            let* v = v_of_yojson(v);
             return(add(k, v, map));
           };
 

--- a/esy-package-config/PackageSource.re
+++ b/esy-package-config/PackageSource.re
@@ -78,22 +78,22 @@ let of_yojson = json => {
   open Json.Decode;
   switch%bind (fieldWith(~name="type", string, json)) {
   | "install" =>
-    let%bind source =
+    let* source =
       switch%bind (fieldWith(~name="source", list(Dist.of_yojson), json)) {
       | [source, ...mirrors] => return((source, mirrors))
       | _ => errorf("invalid source configuration")
       };
 
-    let%bind opam = fieldOptWith(~name="opam", opam_of_yojson, json);
+    let* opam = fieldOptWith(~name="opam", opam_of_yojson, json);
     Ok(Install({source, opam}));
   | "link" =>
-    let%bind path = fieldWith(~name="path", DistPath.of_yojson, json);
-    let%bind manifest =
+    let* path = fieldWith(~name="path", DistPath.of_yojson, json);
+    let* manifest =
       fieldOptWith(~name="manifest", ManifestSpec.of_yojson, json);
     Ok(Link({path, manifest, kind: LinkRegular}));
   | "link-dev" =>
-    let%bind path = fieldWith(~name="path", DistPath.of_yojson, json);
-    let%bind manifest =
+    let* path = fieldWith(~name="path", DistPath.of_yojson, json);
+    let* manifest =
       fieldOptWith(~name="manifest", ManifestSpec.of_yojson, json);
     Ok(Link({path, manifest, kind: LinkDev}));
   | typ => errorf("unknown source type: %s", typ)

--- a/esy-package-config/Req.re
+++ b/esy-package-config/Req.re
@@ -39,7 +39,7 @@ module Parse = {
     opamPackageName <|> npmPackageNameWithScope <|> npmPackageName;
 
   let parser = {
-    let%bind name = packageName;
+    let* name = packageName;
     switch%bind (peek_char) {
     | None =>
       let (name, spec) =
@@ -56,8 +56,8 @@ module Parse = {
 
       return({name, spec});
     | Some('@') =>
-      let%bind () = advance(1);
-      let%bind nextChar = peek_char;
+      let* () = advance(1);
+      let* nextChar = peek_char;
       switch (nextChar, name) {
       | (None, _) =>
         let (name, spec) =
@@ -74,10 +74,10 @@ module Parse = {
 
         return({name, spec});
       | (Some(_), `opam(name)) =>
-        let%bind spec = VersionSpec.parserOpam;
+        let* spec = VersionSpec.parserOpam;
         return({name, spec});
       | (Some(_), `npm(name)) =>
-        let%bind spec = VersionSpec.parserNpm;
+        let* spec = VersionSpec.parserNpm;
         return({name, spec});
       };
     | _ => fail("cannot parse request")

--- a/esy-package-config/Resolution.re
+++ b/esy-package-config/Resolution.re
@@ -30,12 +30,12 @@ let resolution_of_yojson = json =>
   Result.Syntax.(
     switch (json) {
     | `String(v) =>
-      let%bind version = Version.parse(v);
+      let* version = Version.parse(v);
       return(Version(version));
     | `Assoc(_) =>
-      let%bind source =
+      let* source =
         Json.Decode.fieldWith(~name="source", Source.relaxed_of_yojson, json);
-      let%bind override =
+      let* override =
         Json.Decode.fieldWith(~name="override", Json.of_yojson, json);
       return(SourceOverride({source, override}));
     | _ => Error("expected string or object")

--- a/esy-package-config/Resolutions.re
+++ b/esy-package-config/Resolutions.re
@@ -39,7 +39,7 @@ let of_yojson = {
   let parseValue = (name, json) =>
     switch (json) {
     | `String(v) =>
-      let%bind version =
+      let* version =
         switch (Astring.String.cut(~sep="/", name)) {
         | Some(("@opam", _)) => Version.parse(~tryAsOpam=true, v)
         | _ => Version.parse(v)
@@ -47,7 +47,7 @@ let of_yojson = {
 
       return({Resolution.name, resolution: Resolution.Version(version)});
     | `Assoc(_) =>
-      let%bind resolution = Resolution.resolution_of_yojson(json);
+      let* resolution = Resolution.resolution_of_yojson(json);
       return({Resolution.name, resolution});
     | _ => Error("expected string")
     };
@@ -55,8 +55,8 @@ let of_yojson = {
   fun
   | `Assoc(items) => {
       let f = (res, (key, json)) => {
-        let%bind key = parseKey(key);
-        let%bind value = parseValue(key, json);
+        let* key = parseKey(key);
+        let* value = parseValue(key, json);
         Ok(StringMap.add(key, value, res));
       };
 

--- a/esy-package-config/SemverVersion.re
+++ b/esy-package-config/SemverVersion.re
@@ -229,7 +229,7 @@ module Version = {
   let parser = {
     let p = parse;
     open P;
-    let%bind input = take_while1(_ => true);
+    let* input = take_while1(_ => true);
     switch (p(input)) {
     | Ok(v) => return(v)
     | Error(msg) => fail(msg)
@@ -787,7 +787,7 @@ module Formula = {
   let parserDnf = {
     let p = parse;
     open P;
-    let%bind input = take_while1(_ => true);
+    let* input = take_while1(_ => true);
     switch (p(input)) {
     | Ok(v) => return(v)
     | Error(msg) => fail(msg)

--- a/esy-package-config/Source.re
+++ b/esy-package-config/Source.re
@@ -102,7 +102,7 @@ module Parse = {
     let path =
       scan(false, (seenPathSep, c) => Some(seenPathSep || c == '/'));
 
-    let%bind (path, seenPathSep) = path;
+    let* (path, seenPathSep) = path;
     if (!requirePathSep || seenPathSep) {
       return(make(path));
     } else {

--- a/esy-package-config/Version.re
+++ b/esy-package-config/Version.re
@@ -180,7 +180,7 @@ let to_yojson = v => `String(show(v));
 
 let of_yojson = json => {
   open Result.Syntax;
-  let%bind v = Json.Decode.string(json);
+  let* v = Json.Decode.string(json);
   parse(v);
 };
 

--- a/esy-package-config/VersionSpec.re
+++ b/esy-package-config/VersionSpec.re
@@ -55,7 +55,7 @@ module Parse = {
   };
 
   let opamConstraint = {
-    let%bind spec = take_while1(_ => true);
+    let* spec = take_while1(_ => true);
     switch (OpamPackageVersion.Formula.parse(spec)) {
     | Ok(v) => return(Opam(v))
     | Error(msg) => fail(msg)
@@ -65,7 +65,7 @@ module Parse = {
   let npmAnyConstraint = return(Npm([[SemverVersion.Constraint.ANY]]));
 
   let npmConstraint = {
-    let%bind spec = take_while1(_ => true);
+    let* spec = take_while1(_ => true);
     switch (SemverVersion.Formula.parse(spec)) {
     | Ok(v) => return(Npm(v))
     | Error(msg) => fail(msg)

--- a/esy-solve/Config.re
+++ b/esy-solve/Config.re
@@ -54,7 +54,7 @@ let make =
       (),
     ) => {
   open RunAsync.Syntax;
-  let%bind prefixPath =
+  let* prefixPath =
     RunAsync.ofRun(
       Run.Syntax.(
         switch (prefixPath) {
@@ -117,7 +117,7 @@ let make =
   let npmRegistry =
     Option.orDefault(~default="http://registry.npmjs.org/", npmRegistry);
 
-  let%bind installCfg =
+  let* installCfg =
     EsyInstall.Config.make(
       ~prefixPath,
       ~cacheTarballsPath?,

--- a/esy-solve/DepSpec.re
+++ b/esy-solve/DepSpec.re
@@ -22,8 +22,8 @@ let rec eval = (manifest: InstallManifest.t, spec: t) => {
     | Dependencies(Self) => return(manifest.dependencies)
     | DevDependencies(Self) => return(manifest.devDependencies)
     | Union(a, b) =>
-      let%bind adeps = eval(manifest, a);
-      let%bind bdeps = eval(manifest, b);
+      let* adeps = eval(manifest, a);
+      let* bdeps = eval(manifest, b);
       switch (adeps, bdeps) {
       | (D.NpmFormula(a), D.NpmFormula(b)) =>
         let reqs = NpmFormula.override(a, b);

--- a/esy-solve/NpmRegistry.re
+++ b/esy-solve/NpmRegistry.re
@@ -89,25 +89,25 @@ let versions = (~fullMetadata=false, ~name, registry, ()) => {
     switch%bind (fetch) {
     | Curl.NotFound => return(None)
     | Curl.Success(data) =>
-      let%bind packument =
+      let* packument =
         RunAsync.context(
           Json.parseStringWith(Packument.of_yojson, data) |> RunAsync.ofRun,
           "parsing packument",
         );
 
-      let%bind versions =
+      let* versions =
         RunAsync.ofStringError(
           {
             let f = ((version, packageJson)) => {
               open Result.Syntax;
-              let%bind version = SemverVersion.Version.parse(version);
+              let* version = SemverVersion.Version.parse(version);
               PackageCache.ensureComputed(
                 registry.pkgCache,
                 (name, version),
                 () => {
                   open RunAsync.Syntax;
                   let version = Version.Npm(version);
-                  let%bind (manifest, _warnings) =
+                  let* (manifest, _warnings) =
                     RunAsync.ofRun(
                       OfPackageJson.installManifest(
                         ~name,
@@ -138,7 +138,7 @@ let versions = (~fullMetadata=false, ~name, registry, ()) => {
 
 let package = (~name, ~version, registry, ()) => {
   open RunAsync.Syntax;
-  let%bind _: option(versions) =
+  let* _: option(versions) =
     versions(~fullMetadata=true, ~name, registry, ());
   switch (PackageCache.get(registry.pkgCache, (name, version))) {
   | None =>

--- a/esy-solve/OpamOverrides.re
+++ b/esy-solve/OpamOverrides.re
@@ -22,14 +22,14 @@ let parseOverridePattern = pattern =>
 
 let init = (~cfg, ()): RunAsync.t(t) => {
   open RunAsync.Syntax;
-  let%bind repoPath =
+  let* repoPath =
     switch (cfg.Config.esyOpamOverride) {
     | Config.Local(path) => return(path)
     | Config.Remote(remote, local) =>
       let update = () => {
         let%lwt () =
           Logs_lwt.app(m => m("checking %s for updates...", remote));
-        let%bind () =
+        let* () =
           Git.ShallowClone.update(
             ~branch=Config.esyOpamOverrideVersion,
             ~dst=local,
@@ -49,7 +49,7 @@ let init = (~cfg, ()): RunAsync.t(t) => {
     };
   let packagesDir = Path.(repoPath / "packages");
 
-  let%bind names = Fs.listDir(packagesDir);
+  let* names = Fs.listDir(packagesDir);
   module String = Astring.String;
 
   let overrides = {
@@ -89,7 +89,7 @@ let find = (~name: OpamPackage.Name.t, ~version, overrides) =>
       switch (byVersion, override.default) {
       | (Some(path), _)
       | (None, Some(path)) =>
-        let%bind json = Fs.readJsonFile(Path.(path / "package.json"));
+        let* json = Fs.readJsonFile(Path.(path / "package.json"));
         let override = Override.OfOpamOverride({json, path});
         return(Some(override));
       | (None, None) => return(None)

--- a/esy-solve/OpamResolution.re
+++ b/esy-solve/OpamResolution.re
@@ -12,7 +12,7 @@ let path = ({PackageSource.path, _}) => path;
 let opam = (res: PackageSource.opam) => {
   open RunAsync.Syntax;
   let path = Path.(res.path / "opam");
-  let%bind data = Fs.readFile(path);
+  let* data = Fs.readFile(path);
   let filename = OpamFile.make(OpamFilename.of_string(Path.show(path)));
   try(return(OpamFile.OPAM.read_from_string(~filename, data))) {
   | Failure(msg) =>
@@ -26,9 +26,9 @@ let files = (res: PackageSource.opam) =>
 
 let digest = (res: PackageSource.opam) => {
   open RunAsync.Syntax;
-  let%bind files = files(res);
-  let%bind digests = RunAsync.List.mapAndJoin(~f=File.digest, files);
-  let%bind digest = Digestv.ofFile(Path.(res.path / "opam"));
+  let* files = files(res);
+  let* digests = RunAsync.List.mapAndJoin(~f=File.digest, files);
+  let* digest = Digestv.ofFile(Path.(res.path / "opam"));
   let digests = [digest, ...digests];
   let digests = List.sort(~cmp=Digestv.compare, digests);
   return(List.fold_left(~init=Digestv.empty, ~f=Digestv.combine, digests));

--- a/esy-solve/Sandbox.re
+++ b/esy-solve/Sandbox.re
@@ -43,12 +43,12 @@ let make = (~gitUsername, ~gitPassword, ~cfg, spec: EsyInstall.SandboxSpec.t) =>
 
   RunAsync.contextf(
     {
-      let%bind resolver = Resolver.make(~cfg, ~sandbox=spec, ());
+      let* resolver = Resolver.make(~cfg, ~sandbox=spec, ());
       switch (spec.manifest) {
       | EsyInstall.SandboxSpec.Manifest(manifest) =>
         let source = makeSource(manifest);
         let resolution = makeResolution(source);
-        let%bind sandbox =
+        let* sandbox =
           ofResolution(
             ~gitUsername,
             ~gitPassword,
@@ -60,7 +60,7 @@ let make = (~gitUsername, ~gitPassword, ~cfg, spec: EsyInstall.SandboxSpec.t) =>
         Resolver.setResolutions(sandbox.resolutions, sandbox.resolver);
         return(sandbox);
       | EsyInstall.SandboxSpec.ManifestAggregate(manifests) =>
-        let%bind (resolutions, deps, devDeps) = {
+        let* (resolutions, deps, devDeps) = {
           let f = ((resolutions, deps, devDeps), manifest) => {
             let source = makeSource(manifest);
             let resolution = makeResolution(source);
@@ -213,7 +213,7 @@ let digest = (solvespec, sandbox) => {
   let digest =
     Resolutions.digest(sandbox.root.resolutions) |> rootDigest(sandbox.root);
 
-  let%bind digest = {
+  let* digest = {
     let f = (digest, resolution) => {
       let resolution =
         switch (resolution.Resolution.resolution) {

--- a/esy-solve/Solver.re
+++ b/esy-solve/Solver.re
@@ -8,14 +8,14 @@ let computeOverrideDigest = (sandbox, override) =>
     | Override.OfJson({json}) => return(Digestv.ofJson(json))
     | OfDist({dist, json: _}) => return(Digestv.ofString(Dist.show(dist)))
     | OfOpamOverride(info) =>
-      let%bind files =
+      let* files =
         EsyInstall.Fetch.fetchOverrideFiles(
           sandbox.Sandbox.cfg.installCfg,
           sandbox.spec,
           override,
         );
 
-      let%bind digests = RunAsync.List.mapAndJoin(~f=File.digest, files);
+      let* digests = RunAsync.List.mapAndJoin(~f=File.digest, files);
       let digest = Digestv.ofJson(info.json);
       let digests = [digest, ...digests];
       let digests = List.sort(~cmp=Digestv.compare, digests);
@@ -27,7 +27,7 @@ let computeOverrideDigest = (sandbox, override) =>
 
 let computeOverridesDigest = (sandbox, overrides) => {
   open RunAsync.Syntax;
-  let%bind digests =
+  let* digests =
     RunAsync.List.mapAndJoin(~f=computeOverrideDigest(sandbox), overrides);
   return(List.fold_left(~init=Digestv.empty, ~f=Digestv.combine, digests));
 };
@@ -36,18 +36,17 @@ let lock = (sandbox, pkg: InstallManifest.t) =>
   RunAsync.Syntax.(
     switch (pkg.source) {
     | Install({source: _, opam: Some(opam)}) =>
-      let%bind id = {
-        let%bind opamDigest = OpamResolution.digest(opam);
-        let%bind overridesDigest =
-          computeOverridesDigest(sandbox, pkg.overrides);
+      let* id = {
+        let* opamDigest = OpamResolution.digest(opam);
+        let* overridesDigest = computeOverridesDigest(sandbox, pkg.overrides);
         let digest = Digestv.(opamDigest + overridesDigest);
         return(PackageId.make(pkg.name, pkg.version, Some(digest)));
       };
 
       return((id, pkg));
     | Install({source: _, opam: None}) =>
-      let%bind id = {
-        let%bind digest = computeOverridesDigest(sandbox, pkg.overrides);
+      let* id = {
+        let* digest = computeOverridesDigest(sandbox, pkg.overrides);
         return(PackageId.make(pkg.name, pkg.version, Some(digest)));
       };
 
@@ -232,7 +231,7 @@ module Explanation = {
       | Error(_) => Dependencies.NpmFormula([])
       };
 
-    let%bind reasons = {
+    let* reasons = {
       let f = reasons =>
         fun
         | Dose_algo.Diagnostic.Conflict((left, right, _)) => {
@@ -332,7 +331,7 @@ module Explanation = {
           Some({result: Dose_algo.Diagnostic.Failure(reasons), _}),
         ) =>
         let reasons = reasons();
-        let%bind reasons =
+        let* reasons =
           collectReasons(
             ~gitUsername,
             ~gitPassword,
@@ -492,9 +491,9 @@ let add = (~gitUsername, ~gitPassword, ~dependencies: Dependencies.t, solver) =>
       switch (manifest.kind) {
       | InstallManifest.Esy =>
         universe := Universe.add(~pkg=manifest, universe^);
-        let%bind dependencies =
+        let* dependencies =
           RunAsync.ofRun(evalDependencies(solver, manifest));
-        let%bind () =
+        let* () =
           RunAsync.contextf(
             addDependencies(dependencies),
             "resolving %a",
@@ -522,7 +521,7 @@ let add = (~gitUsername, ~gitPassword, ~dependencies: Dependencies.t, solver) =>
     }
   and addDependency = (req: Req.t) => {
     let%lwt () = report("%s", req.name);
-    let%bind resolutions =
+    let* resolutions =
       RunAsync.contextf(
         Resolver.resolve(
           ~gitUsername,
@@ -537,9 +536,9 @@ let add = (~gitUsername, ~gitPassword, ~dependencies: Dependencies.t, solver) =>
         req,
       );
 
-    let%bind packages = {
+    let* packages = {
       let fetchPackage = resolution => {
-        let%bind pkg =
+        let* pkg =
           RunAsync.contextf(
             Resolver.package(
               ~gitUsername,
@@ -566,7 +565,7 @@ let add = (~gitUsername, ~gitPassword, ~dependencies: Dependencies.t, solver) =>
       resolutions |> List.map(~f=fetchPackage) |> RunAsync.List.joinAll;
     };
 
-    let%bind () = {
+    let* () = {
       let f = (tasks, manifest) =>
         switch (manifest) {
         | Some(manifest) => [addPackage(manifest), ...tasks]
@@ -579,7 +578,7 @@ let add = (~gitUsername, ~gitPassword, ~dependencies: Dependencies.t, solver) =>
     return();
   };
 
-  let%bind () = addDependencies(dependencies);
+  let* () = addDependencies(dependencies);
 
   let%lwt () = finish();
 
@@ -691,16 +690,16 @@ let solveDependencies =
       request,
     );
     let cudfData = printCudfDoc(cudf);
-    let%bind () =
+    let* () =
       switch (dumpCudfInput) {
       | None => return()
       | Some(filename) => EsyLib.DumpToFile.dump(filename, cudfData)
       };
 
     Fs.withTempDir(path => {
-      let%bind filenameIn = {
+      let* filenameIn = {
         let filename = Path.(path / "in.cudf");
-        let%bind () = Fs.writeFile(~data=cudfData, filename);
+        let* () = Fs.writeFile(~data=cudfData, filename);
         return(filename);
       };
 
@@ -708,12 +707,12 @@ let solveDependencies =
       let (report, finish) =
         Cli.createProgressReporter(~name="solving esy constraints", ());
       let%lwt () = report("running solver");
-      let%bind () = runSolver(filenameIn, filenameOut);
+      let* () = runSolver(filenameIn, filenameOut);
       let%lwt () = finish();
-      let%bind result = {
-        let%bind dataOut = Fs.readFile(filenameOut);
+      let* result = {
+        let* dataOut = Fs.readFile(filenameOut);
         let dataOut = normalizeSolutionData(dataOut);
-        let%bind () =
+        let* () =
           switch (dumpCudfOutput) {
           | None => return()
           | Some(filename) => EsyLib.DumpToFile.dump(filename, dataOut)
@@ -808,7 +807,7 @@ let solveDependenciesNaively =
 
   let resolveOfOutside = req => {
     let%lwt () = report("%a", Req.pp, req);
-    let%bind resolutions =
+    let* resolutions =
       Resolver.resolve(
         ~gitUsername,
         ~gitPassword,
@@ -837,7 +836,7 @@ let solveDependenciesNaively =
   };
 
   let resolve = (trace, req: Req.t) => {
-    let%bind pkg =
+    let* pkg =
       switch (resolveOfInstalled(req)) {
       | None =>
         switch%bind (resolveOfOutside(req)) {
@@ -890,9 +889,9 @@ let solveDependenciesNaively =
         reqs;
       };
 
-    let%bind pkgs = {
+    let* pkgs = {
       let f = req => {
-        let%bind manifest =
+        let* manifest =
           RunAsync.contextf(
             resolve(trace, req),
             "resolving request %a",
@@ -930,9 +929,8 @@ let solveDependenciesNaively =
         ? loop(trace, seen, rest)
         : {
           let seen = InstallManifest.Set.add(pkg, seen);
-          let%bind dependencies =
-            RunAsync.ofRun(evalDependencies(solver, pkg));
-          let%bind dependencies =
+          let* dependencies = RunAsync.ofRun(evalDependencies(solver, pkg));
+          let* dependencies =
             RunAsync.contextf(
               solveDependencies([pkg, ...trace], dependencies),
               "solving dependencies of %a",
@@ -945,9 +943,9 @@ let solveDependenciesNaively =
         }
     | [] => return();
 
-  let%bind () = {
-    let%bind dependencies = solveDependencies([root], dependencies);
-    let%bind () = loop([root], InstallManifest.Set.empty, dependencies);
+  let* () = {
+    let* dependencies = solveDependencies([root], dependencies);
+    let* () = loop([root], InstallManifest.Set.empty, dependencies);
     addDependencies(root, dependencies);
     return();
   };
@@ -961,16 +959,16 @@ let solveOCamlReq = (~gitUsername, ~gitPassword, req: Req.t, resolver) => {
 
   let make = resolution => {
     let%lwt () = Logs_lwt.info(m => m("using %a", Resolution.pp, resolution));
-    let%bind pkg =
+    let* pkg =
       Resolver.package(~gitUsername, ~gitPassword, ~resolution, resolver);
-    let%bind pkg = RunAsync.ofStringError(pkg);
+    let* pkg = RunAsync.ofStringError(pkg);
     return((pkg.InstallManifest.originalVersion, Some(pkg.version)));
   };
 
   switch (req.spec) {
   | VersionSpec.Npm(_)
   | VersionSpec.NpmDistTag(_) =>
-    let%bind resolutions =
+    let* resolutions =
       Resolver.resolve(
         ~gitUsername,
         ~gitPassword,
@@ -1019,10 +1017,10 @@ let solve =
     | Ok(dependencies) => return(dependencies)
     | Error(explanation) => errorf("%a", Explanation.pp, explanation);
 
-  let%bind solver = make(solvespec, sandbox);
+  let* solver = make(solvespec, sandbox);
 
-  let%bind (dependencies, ocamlVersion) = {
-    let%bind rootDependencies =
+  let* (dependencies, ocamlVersion) = {
+    let* rootDependencies =
       RunAsync.ofRun(evalDependencies(solver, sandbox.root));
 
     let ocamlReq =
@@ -1035,7 +1033,7 @@ let solve =
     switch (ocamlReq) {
     | None => return((rootDependencies, None))
     | Some(ocamlReq) =>
-      let%bind (ocamlVersionOrig, ocamlVersion) =
+      let* (ocamlVersionOrig, ocamlVersion) =
         RunAsync.contextf(
           solveOCamlReq(
             ~gitUsername,
@@ -1048,7 +1046,7 @@ let solve =
           ocamlReq,
         );
 
-      let%bind dependencies =
+      let* dependencies =
         switch (ocamlVersion, rootDependencies) {
         | (
             Some(ocamlVersion),
@@ -1089,15 +1087,15 @@ let solve =
     | None => ()
     };
 
-  let%bind (solver, dependencies) = {
-    let%bind (solver, dependencies) =
+  let* (solver, dependencies) = {
+    let* (solver, dependencies) =
       add(~gitUsername, ~gitPassword, ~dependencies, solver);
     return((solver, dependencies));
   };
 
   /* Solve esy dependencies first. */
-  let%bind installed = {
-    let%bind res =
+  let* installed = {
+    let* res =
       solveDependencies(
         ~gitUsername,
         ~gitPassword,
@@ -1114,7 +1112,7 @@ let solve =
   };
 
   /* Solve npm dependencies now. */
-  let%bind dependenciesMap =
+  let* dependenciesMap =
     solveDependenciesNaively(
       ~gitUsername,
       ~gitPassword,
@@ -1124,12 +1122,12 @@ let solve =
       solver,
     );
 
-  let%bind (packageById, idByPackage, dependenciesById) = {
-    let%bind (packageById, idByPackage) = {
+  let* (packageById, idByPackage, dependenciesById) = {
+    let* (packageById, idByPackage) = {
       let rec aux = ((packageById, idByPackage) as acc) =>
         fun
         | [pkg, ...rest] => {
-            let%bind (id, pkg) = lock(sandbox, pkg);
+            let* (id, pkg) = lock(sandbox, pkg);
             switch (PackageId.Map.find_opt(id, packageById)) {
             | Some(_) => aux(acc, rest)
             | None =>
@@ -1193,7 +1191,7 @@ let solve =
     return((packageById, idByPackage, dependencies));
   };
 
-  let%bind solution = {
+  let* solution = {
     let allDependenciesByName = {
       let f = (_id, deps, map) => {
         let f = (_key, a, b) =>
@@ -1214,11 +1212,11 @@ let solve =
       PackageId.Map.fold(f, dependenciesById, StringMap.empty);
     };
 
-    let%bind solution = {
+    let* solution = {
       let id = InstallManifest.Map.find(sandbox.root, idByPackage);
       let dependenciesByName = PackageId.Map.find(id, dependenciesById);
 
-      let%bind root =
+      let* root =
         lockPackage(
           sandbox.resolver,
           id,
@@ -1235,10 +1233,10 @@ let solve =
       );
     };
 
-    let%bind solution = {
+    let* solution = {
       let f = (solution, (id, dependencies)) => {
         let pkg = PackageId.Map.find(id, packageById);
-        let%bind pkg =
+        let* pkg =
           lockPackage(
             sandbox.resolver,
             id,

--- a/test-e2e-re/lib/EsyShowTest.re
+++ b/test-e2e-re/lib/EsyShowTest.re
@@ -9,21 +9,21 @@ describe("esy show", ({test, _}) => {
   test("shows info about packages hosted on npm", ({expect, _}) =>
     NpmMock.runWith(mockUrl => {
       open Result.Syntax;
-      let%bind sandboxR = Helpers.createSandbox(~fixture=[], mockUrl);
+      let* sandboxR = Helpers.createSandbox(~fixture=[], mockUrl);
       let sandbox: Helpers.sandboxActions = sandboxR;
 
-      let%bind () =
+      let* () =
         sandbox.fixtures([Fixture.defaultProject()])
         >> sandbox.defineNpmPackages([
              NpmPublish.make(~name="react", ~version="1.0.0", ()),
              NpmPublish.make(~name="react", ~version="2.0.0", ()),
            ]);
-      let%bind output = sandbox.esy("show react");
+      let* output = sandbox.esy("show react");
       expect.string(output).toEqual(
         {|{ "name": "react", "versions": [ "2.0.0", "1.0.0" ] }|},
       );
 
-      let%bind output = sandbox.esy("show react@1.0.0");
+      let* output = sandbox.esy("show react@1.0.0");
       expect.string(output).toEqual(
         {|
           {
@@ -44,10 +44,10 @@ describe("esy show", ({test, _}) => {
   test("shows info about packages hosted on opam", ({expect, _}) =>
     NpmMock.runWith(mockUrl => {
       open Result.Syntax;
-      let%bind sandboxR = Helpers.createSandbox(~fixture=[], mockUrl);
+      let* sandboxR = Helpers.createSandbox(~fixture=[], mockUrl);
       let sandbox: Helpers.sandboxActions = sandboxR;
 
-      let%bind () =
+      let* () =
         sandbox.fixtures([Fixture.defaultProject()])
         >> sandbox.defineOpamPackages([
              {
@@ -64,11 +64,11 @@ describe("esy show", ({test, _}) => {
              },
            ]);
 
-      let%bind output = sandbox.esy("show @opam/bos");
+      let* output = sandbox.esy("show @opam/bos");
       expect.string(output).toEqual(
         {|{ "name": "@opam/bos", "versions": [ "2.0.0", "1.0.0" ] }|},
       );
-      let%bind output = sandbox.esy("show @opam/bos@2.0.0");
+      let* output = sandbox.esy("show @opam/bos@2.0.0");
       expect.string(output).toEqual(
         {|
           {
@@ -89,12 +89,12 @@ describe("esy show", ({test, _}) => {
   test("shows info about packages hosted on github", ({expect, _}) =>
     NpmMock.runWith(mockUrl => {
       open Result.Syntax;
-      let%bind sandboxR = Helpers.createSandbox(~fixture=[], mockUrl);
+      let* sandboxR = Helpers.createSandbox(~fixture=[], mockUrl);
       let sandbox: Helpers.sandboxActions = sandboxR;
 
-      let%bind () = sandbox.fixtures([Fixture.defaultProject()]);
+      let* () = sandbox.fixtures([Fixture.defaultProject()]);
 
-      let%bind output =
+      let* output =
         sandbox.esy("show example-yarn-package@yarnpkg/example-yarn-package");
       expect.string(output).toEqual(
         {|

--- a/test-e2e-re/lib/Fixture.re
+++ b/test-e2e-re/lib/Fixture.re
@@ -66,7 +66,7 @@ let rec layout = p =>
   | FixtureDir(spec) => {
       open Result.Syntax;
       let newPath = Path.addSeg(p, spec.name);
-      let%bind _ = Dir.create(newPath);
+      let* _ = Dir.create(newPath);
       layoutMany(newPath, spec.items);
     }
 and layoutMany = p =>

--- a/test-e2e-re/lib/Helpers.re
+++ b/test-e2e-re/lib/Helpers.re
@@ -40,7 +40,7 @@ let skipSuiteOnWindows = (~blockingIssue="Needs investigation", ()) =>
 let createSandbox = (~fixture=[], npmMock) => {
   open Result.Syntax;
   let numb = Random.int(20000);
-  let%bind tmp = getTempDir("esy-" ++ string_of_int(numb));
+  let* tmp = getTempDir("esy-" ++ string_of_int(numb));
   /* Save it, so it can be cleaned up later */
   // addSandbox(Path.show(tmp));
   /* Paths */
@@ -54,18 +54,18 @@ let createSandbox = (~fixture=[], npmMock) => {
     * Setup directores
     * Use underscore because it returns Ok(bool)
     */
-  let%bind _ = Dir.create(tmp);
-  let%bind _ = Dir.create(binPath);
-  let%bind _ = Dir.create(projectPath);
-  let%bind _ = Dir.create(npmPrefixPath);
-  let%bind () = BPath.symlink(~target=esyLocalPath, esyExePath);
+  let* _ = Dir.create(tmp);
+  let* _ = Dir.create(binPath);
+  let* _ = Dir.create(projectPath);
+  let* _ = Dir.create(npmPrefixPath);
+  let* () = BPath.symlink(~target=esyLocalPath, esyExePath);
   /* Initialize mock handlers */
-  let%bind () = Fixture.layoutMany(projectPath, fixture);
-  let%bind opamMockR = OpamMock.initialize();
+  let* () = Fixture.layoutMany(projectPath, fixture);
+  let* opamMockR = OpamMock.initialize();
   // Type issues when accesing fields otherwise
   let opamMock: OpamMock.registry = opamMockR;
 
-  let%bind currentEnv = Env.current();
+  let* currentEnv = Env.current();
   let esyEnv =
     Astring.String.Map.(
       currentEnv
@@ -82,15 +82,15 @@ let createSandbox = (~fixture=[], npmMock) => {
   let esyCmd = Cmd.v(Path.show(esyExePath));
 
   let remove = () => {
-    let%bind _ = Dir.delete(~recurse=true, tmp);
-    let%bind _ = opamMock.remove();
+    let* _ = Dir.delete(~recurse=true, tmp);
+    let* _ = opamMock.remove();
     return();
   };
   let esy = cmd => {
     let revert = changeCwd(Path.show(projectPath));
     let cmdList = String.split_on_char(' ', cmd);
     let program = Cmd.(esyCmd %% of_list(cmdList));
-    let%bind result = OS.Cmd.(run_out(~env=esyEnv, program) |> to_string);
+    let* result = OS.Cmd.(run_out(~env=esyEnv, program) |> to_string);
     revert();
     return(result);
   };
@@ -102,13 +102,13 @@ let createSandbox = (~fixture=[], npmMock) => {
   let defineNpmPackage = (package, ()) =>
     NpmPublish.publish(package, npmMock);
   let defineNpmPackages = (packages, ()) => {
-    let%bind _ = Result.List.map(~f=p => defineNpmPackage(p, ()), packages);
+    let* _ = Result.List.map(~f=p => defineNpmPackage(p, ()), packages);
     return();
   };
   let defineOpamPackage = (package, ()) =>
     OpamMock.defineOpamPackage(opamMock, package);
   let defineOpamPackages = (packages, ()) => {
-    let%bind _ = Result.List.map(~f=p => defineOpamPackage(p, ()), packages);
+    let* _ = Result.List.map(~f=p => defineOpamPackage(p, ()), packages);
     return();
   };
 

--- a/test-e2e-re/lib/Helpers.re
+++ b/test-e2e-re/lib/Helpers.re
@@ -50,10 +50,8 @@ let createSandbox = (~fixture=[], npmMock) => {
   let esyPrefixPath = Path.addSeg(tmp, "esy");
   let esyExePath = Path.addSeg(binPath, exe("esy"));
 
-  /**
-    * Setup directores
-    * Use underscore because it returns Ok(bool)
-    */
+  // Setup directores
+  // Use underscore because it returns Ok(bool)
   let* _ = Dir.create(tmp);
   let* _ = Dir.create(binPath);
   let* _ = Dir.create(projectPath);

--- a/test-e2e-re/lib/NpmPublish.re
+++ b/test-e2e-re/lib/NpmPublish.re
@@ -36,19 +36,19 @@ let putRc = (path, registry) => {
  */
 let publish = (package, registry) => {
   open Result.Syntax;
-  let%bind root = Shared.getRandomTmpDir(~prefix="esy-publish-", ());
-  let%bind _ = OS.Dir.create(root);
+  let* root = Shared.getRandomTmpDir(~prefix="esy-publish-", ());
+  let* _ = OS.Dir.create(root);
 
   let fixture =
     Fixture.FixtureFile({name: "package.json", data: toString(package)});
-  let%bind () = Fixture.layout(root, fixture);
-  let%bind () = putRc(root, registry);
+  let* () = Fixture.layout(root, fixture);
+  let* () = putRc(root, registry);
 
   let program = Cmd.(npmPublish % "--registry" % registry %% flags);
   let revert = Shared.changeCwd(Path.show(root));
   /* Do not bind here to make sure cleanup gets executed */
   let result = OS.Cmd.(run_out(~err=err_null, program) |> to_null);
   revert();
-  let%bind () = OS.Dir.delete(~must_exist=true, ~recurse=true, root);
+  let* () = OS.Dir.delete(~must_exist=true, ~recurse=true, root);
   result;
 };

--- a/test-e2e-re/lib/OpamMock.re
+++ b/test-e2e-re/lib/OpamMock.re
@@ -25,21 +25,21 @@ let repoFile =
 
 let withPackages = name => {
   open Result.Syntax;
-  let%bind root = Shared.getRandomTmpDir(~prefix=name, ());
-  let%bind _ = OS.Dir.create(~path=true, Path.addSeg(root, "packages"));
+  let* root = Shared.getRandomTmpDir(~prefix=name, ());
+  let* _ = OS.Dir.create(~path=true, Path.addSeg(root, "packages"));
   return(root);
 };
 
 let initialize = () => {
   open Result.Syntax;
-  let%bind registryPath = withPackages("esy-opam-registry");
-  let%bind overridePath = withPackages("esy-opam-override");
+  let* registryPath = withPackages("esy-opam-registry");
+  let* overridePath = withPackages("esy-opam-override");
 
-  let%bind _ = OS.File.write(Path.addSeg(registryPath, "repo"), repoFile);
+  let* _ = OS.File.write(Path.addSeg(registryPath, "repo"), repoFile);
 
   let remove = () => {
-    let%bind _ = OS.Dir.delete(~recurse=true, registryPath);
-    let%bind _ = OS.Dir.delete(~recurse=true, overridePath);
+    let* _ = OS.Dir.delete(~recurse=true, registryPath);
+    let* _ = OS.Dir.delete(~recurse=true, overridePath);
     return();
   };
 
@@ -50,14 +50,13 @@ let defineOpamPackage = (registry, spec) => {
   open Result.Syntax;
   let packagePath =
     Path.(append(registry.registryPath, v("./packages/" ++ spec.name)));
-  // let%bind _ = OS.Dir.create(~path=true, packagePath);
+  // let* _ = OS.Dir.create(~path=true, packagePath);
   let packageVersionPath =
     Path.addSeg(packagePath, spec.name ++ "." ++ spec.version);
-  let%bind _ = OS.Dir.create(~path=true, packageVersionPath);
+  let* _ = OS.Dir.create(~path=true, packageVersionPath);
   // Put contents
-  let%bind _ =
-    OS.File.write(Path.addSeg(packageVersionPath, "opam"), spec.opam);
-  let%bind _ =
+  let* _ = OS.File.write(Path.addSeg(packageVersionPath, "opam"), spec.opam);
+  let* _ =
     switch (spec.url) {
     | Some(url) => OS.File.write(Path.addSeg(packageVersionPath, "url"), url)
     | None => return()

--- a/test/Checksum.re
+++ b/test/Checksum.re
@@ -8,14 +8,14 @@ let%test "checksum validates a simple file: md5" = {
       open RunAsync.Syntax;
       let path = Path.(tempPath / "checksum-test.txt");
       let data = "test checksum file";
-      let%bind () = Fs.writeFile(~data, path);
+      let* () = Fs.writeFile(~data, path);
 
       let expectedChecksum =
         EsyLib.Checksum.parse("md5:97d37ce810cfcff2665f45e9da4449b7");
       switch (expectedChecksum) {
       | Error(_) => return(false)
       | Ok(v) =>
-        let%bind _actualChecksum = EsyLib.Checksum.checkFile(~path, v);
+        let* _actualChecksum = EsyLib.Checksum.checkFile(~path, v);
         return(true);
       };
     };

--- a/test/Curl.re
+++ b/test/Curl.re
@@ -12,8 +12,8 @@ let%test "curl download simple file" = {
       open RunAsync.Syntax;
       let fileToCurl = Path.(tempPath / "input.txt");
       let data = "test";
-      let%bind () = Fs.createDir(tempPath);
-      let%bind () = Fs.writeFile(~data, fileToCurl);
+      let* () = Fs.createDir(tempPath);
+      let* () = Fs.writeFile(~data, fileToCurl);
 
       /* use curl to copy the file, as opposed to hitting an external server */
       let output = Path.(tempPath / "output.txt");
@@ -23,7 +23,7 @@ let%test "curl download simple file" = {
       /* This won't impact HTTP requests though - just our test using the local file system */
       let url = EsyBash.normalizePathForCygwin(Path.show(fileToCurl));
 
-      let%bind () = EsyLib.Curl.download(~output, "file://" ++ url);
+      let* () = EsyLib.Curl.download(~output, "file://" ++ url);
 
       /* validate we were able to download it */
       Fs.exists(output);

--- a/test/Fs.re
+++ b/test/Fs.re
@@ -12,10 +12,10 @@ let%test "copyPathLwt - copy simple file" = {
       let src = Path.(tempPath / "src.txt");
       let dst = Path.(tempPath / "dst.txt");
       let data = "test";
-      let%bind () = Fs.createDir(tempPath);
-      let%bind () = Fs.writeFile(~data, src);
+      let* () = Fs.createDir(tempPath);
+      let* () = Fs.writeFile(~data, src);
 
-      let%bind () = Fs.copyPath(~src, ~dst);
+      let* () = Fs.copyPath(~src, ~dst);
 
       Fs.exists(dst);
     };
@@ -35,10 +35,10 @@ let%test "copyPathLwt - copy nested file" = {
       let src = Path.(nestedSrc / "src.txt");
       let dst = Path.(nestedDest / "dst.txt");
       let data = "test";
-      let%bind () = Fs.createDir(nestedSrc);
-      let%bind () = Fs.writeFile(~data, src);
+      let* () = Fs.createDir(nestedSrc);
+      let* () = Fs.writeFile(~data, src);
 
-      let%bind () = Fs.copyPath(~src, ~dst);
+      let* () = Fs.copyPath(~src, ~dst);
 
       Fs.exists(dst);
     };
@@ -55,14 +55,14 @@ let%test "rmPathLwt - delete read only file" = {
       open RunAsync.Syntax;
       let src = Path.(tempPath / "test.txt");
       let data = "test";
-      let%bind () = Fs.writeFile(~data, src);
+      let* () = Fs.writeFile(~data, src);
 
       /* Set file as read only, and verify we can still delete it */
       /* Tested on Windows, this sets the read-only flag there too */
       let () = Unix.chmod(Path.show(src), 0o444);
 
-      let%bind () = Fs.rmPath(src);
-      let%bind exists = Fs.exists(src);
+      let* () = Fs.rmPath(src);
+      let* exists = Fs.exists(src);
       return(!exists);
     };
 
@@ -79,9 +79,9 @@ let%test "rename - can rename a directory" = {
       let src = Path.(srcTempPath / "test.txt");
       let dst = Path.(dstTempPath / "");
       let data = "test";
-      let%bind () = Fs.writeFile(~data, src);
+      let* () = Fs.writeFile(~data, src);
       let src = Path.(srcTempPath / "");
-      let%bind () = Fs.rename(~src, dst);
+      let* () = Fs.rename(~src, dst);
       return(true);
     };
 

--- a/test/Patch.re
+++ b/test/Patch.re
@@ -12,14 +12,14 @@ let%test "simple patch test" = {
 
       /* Simple patch file to go from "Hello OCaml" -> "Hello Reason" */
       let patchContents = "--- input.txt\n+++ input.txt\n@@ -1 +1 @@\n-Hello OCaml\n+Hello Reason\n";
-      let%bind () = Fs.createDir(tempPath);
-      let%bind () = Fs.writeFile(~data=originalContents, fileToPatch);
-      let%bind () = Fs.writeFile(~data=patchContents, patchFile);
+      let* () = Fs.createDir(tempPath);
+      let* () = Fs.writeFile(~data=originalContents, fileToPatch);
+      let* () = Fs.writeFile(~data=patchContents, patchFile);
 
-      let%bind () =
+      let* () =
         EsyLib.Patch.apply(~strip=0, ~root=tempPath, ~patch=patchFile, ());
 
-      let%bind c = Fs.readFile(fileToPatch);
+      let* c = Fs.readFile(fileToPatch);
       return(c == "Hello Reason\n");
     };
 

--- a/test/Tarball.re
+++ b/test/Tarball.re
@@ -9,22 +9,22 @@ let%test "creates and unpacks a tarball" = {
     let f = tempPath => {
       open RunAsync.Syntax;
       let folderToCreate = Path.(tempPath / "test-folder");
-      let%bind () = Fs.createDir(folderToCreate);
+      let* () = Fs.createDir(folderToCreate);
       let fileToCreate = Path.(folderToCreate / "test-file.txt");
       let data = "test data";
-      let%bind () = Fs.writeFile(~data, fileToCreate);
+      let* () = Fs.writeFile(~data, fileToCreate);
 
       /* package up the file into a tarball */
       let filename = Path.(tempPath / "output.tar.gz");
-      let%bind () = EsyLib.Tarball.create(~filename, folderToCreate);
+      let* () = EsyLib.Tarball.create(~filename, folderToCreate);
 
       /* unpack the tarball */
       let dst = Path.(tempPath / "extract-folder");
-      let%bind () = Fs.createDir(dst);
-      let%bind () = EsyLib.Tarball.unpack(~dst, filename);
+      let* () = Fs.createDir(dst);
+      let* () = EsyLib.Tarball.unpack(~dst, filename);
 
       let expectedOutputFile = Path.(dst / "test-file.txt");
-      let%bind result = Fs.readFile(expectedOutputFile);
+      let* result = Fs.readFile(expectedOutputFile);
       return(result == data);
     };
 
@@ -42,24 +42,24 @@ let%test "unpack tarball with stripcomponents" = {
         Path.(
           tempPath / "test-folder" / "nested-folder-1" / "nested-folder-2"
         );
-      let%bind () = Fs.createDir(folderToCreate);
+      let* () = Fs.createDir(folderToCreate);
       let fileToCreate = Path.(folderToCreate / "test-file.txt");
       let data = "test data";
-      let%bind () = Fs.writeFile(~data, fileToCreate);
+      let* () = Fs.writeFile(~data, fileToCreate);
 
       /* package up the file into a tarball */
       let folderToPackage = Path.(tempPath / "test-folder");
       let filename = Path.(tempPath / "output.tar.gz");
-      let%bind () = EsyLib.Tarball.create(~filename, folderToPackage);
+      let* () = EsyLib.Tarball.create(~filename, folderToPackage);
 
       /* unpack the tarball */
       let dst = Path.(tempPath / "extract-folder");
-      let%bind () = Fs.createDir(dst);
+      let* () = Fs.createDir(dst);
       let stripComponents = 2;
-      let%bind () = EsyLib.Tarball.unpack(~stripComponents, ~dst, filename);
+      let* () = EsyLib.Tarball.unpack(~stripComponents, ~dst, filename);
 
       let expectedOutputFile = Path.(dst / "test-file.txt");
-      let%bind result = Fs.readFile(expectedOutputFile);
+      let* result = Fs.readFile(expectedOutputFile);
       return(result == data);
     };
 


### PR DESCRIPTION
- This PR is a part of the effort to remove `ppx_let` and `ppx_lwt` as dependencies from `esy`.
- Operators are brought into scope along with `Let_syntax` module.
- following modules were modified to add operators along with `Let_syntax`: 
  - `esy-build-package/Run.re`
  - `esy-lib/Option.re`
  - `esy-lib/Result.re`
  - `esy-lib/Run.re`
  - `esy-lib/RunAsync.re`