### PR TITLE
RFC: always git shallow clone

### DIFF
--- a/esy-install/DistStorage.re
+++ b/esy-install/DistStorage.re
@@ -120,20 +120,17 @@ let fetch' = (sandbox, dist, gitUsername, gitPassword) => {
           | _ => []
           };
         /* Optimisation: if we find that the commit hash is long, we can shallow clone. */
-        let%bind () =
-          if (String.length(github.commit) == 40) {
-            let%bind () =
-              Git.clone(~dst=stagePath, ~config, ~remote, ~depth=1, ());
-            Git.fetch(
-              ~ref=github.commit,
-              ~depth=1,
-              ~dst=stagePath,
-              ~remote,
-              (),
-            );
-          } else {
-            Git.clone(~config, ~dst=stagePath, ~remote, ());
-          };
+        let%bind () = {
+          let%bind () =
+            Git.clone(~dst=stagePath, ~config, ~remote, ~depth=1, ());
+          Git.fetch(
+            ~ref=github.commit,
+            ~depth=1,
+            ~dst=stagePath,
+            ~remote,
+            (),
+          );
+        };
         let%bind () = Git.checkout(~ref=github.commit, ~repo=stagePath, ());
         let%bind () = Git.updateSubmodules(~config, ~repo=stagePath, ());
         let%bind () = Fs.rename(~skipIfExists=true, ~src=stagePath, path);

--- a/esy-lib/Git.re
+++ b/esy-lib/Git.re
@@ -104,11 +104,6 @@ let clone = (~branch=?, ~config as configKVs=?, ~depth=?, ~dst, ~remote, ()) => 
   return();
 };
 
-let revParse = (~repo, ~ref, ()) => {
-  let cmd = Cmd.(v("git") % "rev-parse" % "-C" % p(repo) % ref);
-  runGit(cmd);
-};
-
 let fetch = (~depth=?, ~dst, ~ref, ~remote, ()) => {
   let cmd = Cmd.(v("git") % "-C" % Path.show(dst) % "fetch" % remote % ref);
   let cmd =

--- a/esy-lib/Git.rei
+++ b/esy-lib/Git.rei
@@ -38,7 +38,6 @@ let pull:
 /** Checkout the [ref] in the [repo] */
 
 let checkout: (~ref: ref, ~repo: Fpath.t, unit) => RunAsync.t(unit);
-let revParse: (~repo: Fpath.t, ~ref: string, unit) => RunAsync.t(string);
 
 let fetch:
   (~depth: int=?, ~dst: Fpath.t, ~ref: ref, ~remote: remote, unit) =>


### PR DESCRIPTION
- In https://github.com/esy/esy/pull/1089/#issuecomment-619298308, @ManasJayanth mentioned you can only shallow clone long hashes because otherwise you can't call `rev-parse`.
- However, the `Git.revParse` function isn't used anywhere throughout the codebase.

This proposal lifts the restriction that you can only shallow clone long hashes. I'm not aware of all the implications, though, so I appreciate folks chiming in if this is a no-go.