### PR TITLE
esy cleanup now uses list of projects(GC Root) in prefixPath as default project paths

### DIFF
--- a/bin/Cleanup.re
+++ b/bin/Cleanup.re
@@ -1,0 +1,119 @@
+open EsyBuild;
+
+let main = (projCfgs: list(ProjectConfig.t), dryRun) => {
+  switch%lwt (
+    {
+      open RunAsync.Syntax;
+      let getAllCacheEntries = globalStorePath => {
+        let* allCacheEntries' =
+          Fs.listDir(Path.(globalStorePath / Store.installTree));
+        allCacheEntries'
+        |> List.map(~f=x => Path.(globalStorePath / Store.installTree / x))
+        |> RunAsync.return;
+      };
+      let getAllSourceEntries = prefixPath => {
+        let basePath = Path.(prefixPath / "source" / "i");
+        let* allCacheEntries' = Fs.listDir(basePath); /* TODO: probably use esy installsandbox to get this path */
+        allCacheEntries'
+        |> List.map(~f=x => Path.(basePath / x))
+        |> RunAsync.return;
+      };
+      let mode = BuildSpec.BuildDev;
+      /* projects.json is local to every esy prefix. Every project found
+         there would use the same global store path. We can safely pick any
+         project and get it's store path */
+      let* randomProjCfg =
+        try(RunAsync.return(projCfgs |> List.hd)) {
+        | _ => RunAsync.error("No esy projects on this machine")
+        };
+      let* globalStorePath =
+        randomProjCfg |> ProjectConfig.storePath |> RunAsync.ofRun;
+      let* allCacheEntries = getAllCacheEntries(globalStorePath);
+      let* allSourceEntries =
+        getAllSourceEntries(
+          ProjectConfig.globalStorePrefixPath(randomProjCfg),
+        );
+      let allCacheEntries =
+        Path.Set.of_list @@ allCacheEntries @ allSourceEntries;
+      let shortBuildPath =
+        Path.(
+          ProjectConfig.globalStorePrefixPath(randomProjCfg)
+          / Store.version
+          / Store.buildTree
+        );
+      let pathsToBeRemoved = [
+        // staging area before installed artifacts can be installed
+        Path.(globalStorePath / Store.stageTree),
+        // Ex: ~/.esy/3/b - this usually contains build cache. Usually cold, and can be removed
+        shortBuildPath,
+        // Older versions used the longer ~/.esy/3____.../b to store build cache
+        Path.(globalStorePath / Store.buildTree),
+      ];
+      let f = (cacheEntriesToKeep, projCfg) => {
+        open Project;
+        let* (project, _) = Project.make(projCfg);
+        let* sourceCacheEntries =
+          RunAsync.ofRun(
+            {
+              open Run.Syntax;
+              let* solved = project.solved;
+              let* {installation, _} = solved.fetched;
+              installation
+              |> EsyFetch.Installation.entries
+              |> List.map(~f=((_, location)) => location)
+              |> Run.return;
+            },
+          );
+        let* plan = Project.plan(mode, project);
+        let* allProjectDependencies =
+          BuildSandbox.Plan.all(plan)
+          |> List.map(~f=task =>
+               Scope.installPath(task.BuildSandbox.Task.scope)
+               |> Project.renderSandboxPath(project.buildCfg)
+             )
+          |> RunAsync.return;
+
+        List.iter(~f=p => print_endline(Path.show(p)), sourceCacheEntries);
+        RunAsync.return(
+          cacheEntriesToKeep @ allProjectDependencies @ sourceCacheEntries,
+        );
+      };
+      let* cacheEntriesToKeep =
+        RunAsync.List.foldLeft(~init=[], ~f, projCfgs);
+
+      let buildsToBePurged = {
+        let f = (acc, pathToBeRemoved) => {
+          Path.Set.add(pathToBeRemoved, acc);
+        };
+        let init =
+          cacheEntriesToKeep
+          |> Path.Set.of_list
+          |> Path.Set.diff(allCacheEntries);
+        List.fold_left(~f, ~init, pathsToBeRemoved);
+      };
+
+      if (dryRun) {
+        if (!Path.Set.is_empty(buildsToBePurged)) {
+          print_endline("Will be purging the following");
+          Path.Set.iter(
+            p => p |> Path.show |> print_endline,
+            buildsToBePurged,
+          );
+        } else {
+          print_endline("No builds to be purged");
+        };
+        RunAsync.return();
+      } else {
+        let queue = LwtTaskQueue.create(~concurrency=40, ());
+        Path.Set.elements(buildsToBePurged)
+        |> List.map(~f=p => LwtTaskQueue.submit(queue, () => Fs.rmPath(p)))
+        |> RunAsync.List.waitAll;
+      };
+    }
+  ) {
+  | Ok () => RunAsync.return()
+  | Error(e) =>
+      RunAsync.ofLwt @@ Esy_logs_lwt.info(m => m("%s", Run.formatError(e)));
+  };
+};
+

--- a/bin/Cleanup.re
+++ b/bin/Cleanup.re
@@ -112,8 +112,8 @@ let main = (projCfgs: list(ProjectConfig.t), dryRun) => {
     }
   ) {
   | Ok () => RunAsync.return()
-  | Error(e) =>
-      RunAsync.ofLwt @@ Esy_logs_lwt.info(m => m("%s", Run.formatError(e)));
+  | Error((msg, _context)) =>
+      RunAsync.ofLwt @@ Esy_logs_lwt.app(m => m("%s", msg));
   };
 };
 

--- a/bin/ProjectConfig.re
+++ b/bin/ProjectConfig.re
@@ -655,15 +655,7 @@ let promiseTermForMultiplePaths = resolvedPathTerm => {
           | None => EsyBuildPackage.Config.storePrefixDefault
           };
 
-        let projectsPath = Path.(prefixPath / "projects.json");
-        let%bind json = Fs.readJsonFile(projectsPath);
-        let%bind json =
-          switch (Json.Decode.(list(string, json))) {
-          | Ok(json) => return(json)
-          | Error(err) =>
-            errorf("%s cannot be parsed", projectsPath |> Path.show)
-          };
-        json |> List.map(~f=Path.v) |> return;
+        EsyFetch.ProjectList.get(prefixPath);
       | _ => return(paths)
       };
     paths

--- a/bin/ProjectConfig.re
+++ b/bin/ProjectConfig.re
@@ -670,9 +670,9 @@ let promiseTermForMultiplePaths = resolvedPathTerm => {
     |> List.map(~f=path =>
          make(
            Some(ProjectArg.ofPath(path)),
-           mainprg,
            "ocaml", /* specifying ocaml package name for multiple paths is unsupported */
            "n.00.0000", /* specifying ocaml version for multiple paths is unsupported */
+           mainprg,
            prefixPath,
            cacheTarballsPath,
            fetchConcurrency,

--- a/bin/ProjectConfig.re
+++ b/bin/ProjectConfig.re
@@ -658,7 +658,13 @@ let promiseTermForMultiplePaths = resolvedPathTerm => {
         EsyFetch.ProjectList.get(prefixPath);
       | _ => return(paths)
       };
-    paths
+    let%bind pathsThatExist =
+      paths
+      |> RunAsync.List.filter(
+           /* What the appropriate ~concurrency here? */
+           ~f=Fs.exists,
+         );
+    pathsThatExist
     |> List.map(~f=path =>
          make(
            Some(ProjectArg.ofPath(path)),

--- a/bin/esy.re
+++ b/bin/esy.re
@@ -1024,7 +1024,7 @@ let addProjectToGCRoot = (proj: Project.t) => {
     | None => EsyBuildPackage.Config.storePrefixDefault
     };
   let currentProjectPath = Path.show(proj.projcfg.path);
-  EsyFetch.ProjectList.update(prefixPath, currentProjectPath);
+  EsyFetch.ProjectList.sync(prefixPath, currentProjectPath);
 };
 
 let solveAndFetch = (proj: Project.t) => {

--- a/bin/esy.re
+++ b/bin/esy.re
@@ -1098,7 +1098,7 @@ let addProjectToGCRoot = (proj: Project.t) => {
         };
       Encode.(list(string, projects)) |> return;
     | Error(err) =>
-      errorf("%s cannot be parsed", currentProj)
+      errorf("%s cannot be parsed", projectsPath |> Path.show)
     };
 
   Fs.writeJsonFile(projects, projectsPath);
@@ -1109,7 +1109,7 @@ let solveAndFetch = (proj: Project.t) => {
   let lockPath = SandboxSpec.solutionLockPath(proj.projcfg.spec);
   let* digest =
     EsySolve.Sandbox.digest(proj.workflow.solvespec, proj.solveSandbox);
-  switch%bind (SolutionLock.ofPath(~digest, proj.installSandbox, lockPath)) {
+  let%bind () = switch%bind (SolutionLock.ofPath(~digest, proj.installSandbox, lockPath)) {
   | Some(solution) =>
     switch%bind (
       EsyFetch.Fetch.maybeInstallationOfSolution(

--- a/bin/esy.re
+++ b/bin/esy.re
@@ -231,124 +231,6 @@ let buildDependencies = (all, mode, pkgarg, proj: Project.t) => {
   Project.withPackage(proj, pkgarg, f);
 };
 
-let cleanup = (projCfgs: list(ProjectConfig.t), dryRun) => {
-  switch%lwt (
-    {
-      open RunAsync.Syntax;
-      let getAllCacheEntries = globalStorePath => {
-        let* allCacheEntries' =
-          Fs.listDir(Path.(globalStorePath / Store.installTree));
-        allCacheEntries'
-        |> List.map(~f=x => Path.(globalStorePath / Store.installTree / x))
-        |> RunAsync.return;
-      };
-      let getAllSourceEntries = prefixPath => {
-        let basePath = Path.(prefixPath / "source" / "i");
-        let* allCacheEntries' = Fs.listDir(basePath); /* TODO: probably use esy installsandbox to get this path */
-        allCacheEntries'
-        |> List.map(~f=x => Path.(basePath / x))
-        |> RunAsync.return;
-      };
-      let mode = BuildSpec.BuildDev;
-      /* projects.json is local to every esy prefix. Every project found
-         there would use the same global store path. We can safely pick any
-         project and get it's store path */
-      let* randomProjCfg =
-        try(RunAsync.return(projCfgs |> List.hd)) {
-        | _ => RunAsync.error("No esy projects on this machine")
-        };
-      let* globalStorePath =
-        randomProjCfg |> ProjectConfig.storePath |> RunAsync.ofRun;
-      let* allCacheEntries = getAllCacheEntries(globalStorePath);
-      let* allSourceEntries =
-        getAllSourceEntries(
-          ProjectConfig.globalStorePrefixPath(randomProjCfg),
-        );
-      let allCacheEntries =
-        Path.Set.of_list @@ allCacheEntries @ allSourceEntries;
-      let shortBuildPath =
-        Path.(
-          ProjectConfig.globalStorePrefixPath(randomProjCfg)
-          / Store.version
-          / Store.buildTree
-        );
-      let pathsToBeRemoved = [
-        // staging area before installed artifacts can be installed
-        Path.(globalStorePath / Store.stageTree),
-        // Ex: ~/.esy/3/b - this usually contains build cache. Usually cold, and can be removed
-        shortBuildPath,
-        // Older versions used the longer ~/.esy/3____.../b to store build cache
-        Path.(globalStorePath / Store.buildTree),
-      ];
-      let f = (cacheEntriesToKeep, projCfg) => {
-        open Project;
-        let* (project, _) = Project.make(projCfg);
-        let* sourceCacheEntries =
-          RunAsync.ofRun(
-            {
-              open Run.Syntax;
-              let* solved = project.solved;
-              let* {installation, _} = solved.fetched;
-              installation
-              |> EsyFetch.Installation.entries
-              |> List.map(~f=((_, location)) => location)
-              |> Run.return;
-            },
-          );
-        let* plan = Project.plan(mode, project);
-        let* allProjectDependencies =
-          BuildSandbox.Plan.all(plan)
-          |> List.map(~f=task =>
-               Scope.installPath(task.BuildSandbox.Task.scope)
-               |> Project.renderSandboxPath(project.buildCfg)
-             )
-          |> RunAsync.return;
-
-        List.iter(~f=p => print_endline(Path.show(p)), sourceCacheEntries);
-        RunAsync.return(
-          cacheEntriesToKeep @ allProjectDependencies @ sourceCacheEntries,
-        );
-      };
-      let* cacheEntriesToKeep =
-        RunAsync.List.foldLeft(~init=[], ~f, projCfgs);
-
-      let buildsToBePurged = {
-        let f = (acc, pathToBeRemoved) => {
-          Path.Set.add(pathToBeRemoved, acc);
-        };
-        let init =
-          cacheEntriesToKeep
-          |> Path.Set.of_list
-          |> Path.Set.diff(allCacheEntries);
-        List.fold_left(~f, ~init, pathsToBeRemoved);
-      };
-
-      if (dryRun) {
-        if (!Path.Set.is_empty(buildsToBePurged)) {
-          print_endline("Will be purging the following");
-          Path.Set.iter(
-            p => p |> Path.show |> print_endline,
-            buildsToBePurged,
-          );
-        } else {
-          print_endline("No builds to be purged");
-        };
-        RunAsync.return();
-      } else {
-        let queue = LwtTaskQueue.create(~concurrency=40, ());
-        Path.Set.elements(buildsToBePurged)
-        |> List.map(~f=p => LwtTaskQueue.submit(queue, () => Fs.rmPath(p)))
-        |> RunAsync.List.waitAll;
-      };
-    }
-  ) {
-  | Ok () => RunAsync.return()
-  | Error(e) =>
-    print_endline(Run.formatError(e));
-    RunAsync.return();
-  };
-};
-
 let execCommand =
     (
       buildIsInProgress,
@@ -2073,7 +1955,7 @@ let commandsConfig = {
         ~doc="Purge unused builds from global cache",
         ~docs="COMMON COMMANDS",
         Term.(
-          const(cleanup)
+          const(Cleanup.main)
           $ ProjectConfig.multipleProjectConfigsTerm(resolvedPathTerm)
           $ Arg.(
               value

--- a/bin/esy.re
+++ b/bin/esy.re
@@ -232,62 +232,120 @@ let buildDependencies = (all, mode, pkgarg, proj: Project.t) => {
 };
 
 let cleanup = (projCfgs: list(ProjectConfig.t), dryRun) => {
-  open RunAsync.Syntax;
-  let getAllCacheEntries = globalStorePath => {
-    let* allCacheEntries' =
-      Fs.listDir(Path.(globalStorePath / Store.installTree));
-    allCacheEntries'
-    |> List.map(~f=x => Path.(globalStorePath / Store.installTree / x))
-    |> Path.Set.of_list
-    |> RunAsync.return;
-  };
-  let mode = BuildSpec.BuildDev;
-  /* projects.json is local to every esy prefix. Every project found
-     there would use the same global store path. We can safely pick any
-     project and get it's store path */
-  let randomProjCfg = projCfgs |> List.hd;
-  let* globalStorePath =
-    randomProjCfg |> ProjectConfig.storePath |> RunAsync.ofRun;
-  let* allCacheEntries = getAllCacheEntries(globalStorePath);
-  let shortBuildPath =
-    Path.(
-      ProjectConfig.globalStorePrefixPath(randomProjCfg)
-      / Store.version
-      / Store.buildTree
-    );
-  let pathsToBeRemoved = [
-    // staging area before installed artifacts can be installed
-    Path.(globalStorePath / Store.stageTree),
-    // Ex: ~/.esy/3/b - this usually contains build cache. Usually cold, and can be removed
-    shortBuildPath,
-    // Older versions used the longer ~/.esy/3____.../b to store build cache
-    Path.(globalStorePath / Store.buildTree),
-  ];
-  let f = (cacheEntriesToKeep, projCfg) => {
-    let* (proj, _) = Project.make(projCfg);
-    let* plan = Project.plan(mode, proj);
-    let* allProjectDependencies =
-      BuildSandbox.Plan.all(plan)
-      |> List.map(~f=task =>
-           Scope.installPath(task.BuildSandbox.Task.scope)
-           |> Project.renderSandboxPath(proj.Project.buildCfg)
-         )
-      |> RunAsync.return;
-    RunAsync.return(cacheEntriesToKeep @ allProjectDependencies);
-  };
-  let* cacheEntriesToKeep =
-    RunAsync.List.foldLeft(~init=pathsToBeRemoved, ~f, projCfgs);
-  let buildsToBePurged =
-    cacheEntriesToKeep |> Path.Set.of_list |> Path.Set.diff(allCacheEntries);
-  if (dryRun) {
-    print_endline("Will be purging the following");
-    Path.Set.iter(p => p |> Path.show |> print_endline, buildsToBePurged);
+  switch%lwt (
+    {
+      open RunAsync.Syntax;
+      let getAllCacheEntries = globalStorePath => {
+        let* allCacheEntries' =
+          Fs.listDir(Path.(globalStorePath / Store.installTree));
+        allCacheEntries'
+        |> List.map(~f=x => Path.(globalStorePath / Store.installTree / x))
+        |> RunAsync.return;
+      };
+      let getAllSourceEntries = prefixPath => {
+        let basePath = Path.(prefixPath / "source" / "i");
+        let* allCacheEntries' = Fs.listDir(basePath); /* TODO: probably use esy installsandbox to get this path */
+        allCacheEntries'
+        |> List.map(~f=x => Path.(basePath / x))
+        |> RunAsync.return;
+      };
+      let mode = BuildSpec.BuildDev;
+      /* projects.json is local to every esy prefix. Every project found
+         there would use the same global store path. We can safely pick any
+         project and get it's store path */
+      let* randomProjCfg =
+        try(RunAsync.return(projCfgs |> List.hd)) {
+        | _ => RunAsync.error("No esy projects on this machine")
+        };
+      let* globalStorePath =
+        randomProjCfg |> ProjectConfig.storePath |> RunAsync.ofRun;
+      let* allCacheEntries = getAllCacheEntries(globalStorePath);
+      let* allSourceEntries =
+        getAllSourceEntries(
+          ProjectConfig.globalStorePrefixPath(randomProjCfg),
+        );
+      let allCacheEntries =
+        Path.Set.of_list @@ allCacheEntries @ allSourceEntries;
+      let shortBuildPath =
+        Path.(
+          ProjectConfig.globalStorePrefixPath(randomProjCfg)
+          / Store.version
+          / Store.buildTree
+        );
+      let pathsToBeRemoved = [
+        // staging area before installed artifacts can be installed
+        Path.(globalStorePath / Store.stageTree),
+        // Ex: ~/.esy/3/b - this usually contains build cache. Usually cold, and can be removed
+        shortBuildPath,
+        // Older versions used the longer ~/.esy/3____.../b to store build cache
+        Path.(globalStorePath / Store.buildTree),
+      ];
+      let f = (cacheEntriesToKeep, projCfg) => {
+        open Project;
+        let* (project, _) = Project.make(projCfg);
+        let* sourceCacheEntries =
+          RunAsync.ofRun(
+            {
+              open Run.Syntax;
+              let* solved = project.solved;
+              let* {installation, _} = solved.fetched;
+              installation
+              |> EsyFetch.Installation.entries
+              |> List.map(~f=((_, location)) => location)
+              |> Run.return;
+            },
+          );
+        let* plan = Project.plan(mode, project);
+        let* allProjectDependencies =
+          BuildSandbox.Plan.all(plan)
+          |> List.map(~f=task =>
+               Scope.installPath(task.BuildSandbox.Task.scope)
+               |> Project.renderSandboxPath(project.buildCfg)
+             )
+          |> RunAsync.return;
+
+        List.iter(~f=p => print_endline(Path.show(p)), sourceCacheEntries);
+        RunAsync.return(
+          cacheEntriesToKeep @ allProjectDependencies @ sourceCacheEntries,
+        );
+      };
+      let* cacheEntriesToKeep =
+        RunAsync.List.foldLeft(~init=[], ~f, projCfgs);
+
+      let buildsToBePurged = {
+        let f = (acc, pathToBeRemoved) => {
+          Path.Set.add(pathToBeRemoved, acc);
+        };
+        let init =
+          cacheEntriesToKeep
+          |> Path.Set.of_list
+          |> Path.Set.diff(allCacheEntries);
+        List.fold_left(~f, ~init, pathsToBeRemoved);
+      };
+
+      if (dryRun) {
+        if (!Path.Set.is_empty(buildsToBePurged)) {
+          print_endline("Will be purging the following");
+          Path.Set.iter(
+            p => p |> Path.show |> print_endline,
+            buildsToBePurged,
+          );
+        } else {
+          print_endline("No builds to be purged");
+        };
+        RunAsync.return();
+      } else {
+        let queue = LwtTaskQueue.create(~concurrency=40, ());
+        Path.Set.elements(buildsToBePurged)
+        |> List.map(~f=p => LwtTaskQueue.submit(queue, () => Fs.rmPath(p)))
+        |> RunAsync.List.waitAll;
+      };
+    }
+  ) {
+  | Ok () => RunAsync.return()
+  | Error(e) =>
+    print_endline(Run.formatError(e));
     RunAsync.return();
-  } else {
-    let queue = LwtTaskQueue.create(~concurrency=40, ());
-    Path.Set.elements(buildsToBePurged)
-    |> List.map(~f=p => LwtTaskQueue.submit(queue, () => Fs.rmPath(p)))
-    |> RunAsync.List.waitAll;
   };
 };
 

--- a/esy-build/EsyRc.re
+++ b/esy-build/EsyRc.re
@@ -1,19 +1,41 @@
+open RunAsync.Syntax;
+
 [@deriving of_yojson]
 type t = {prefixPath: option(Path.t)};
 
 let empty = {prefixPath: None};
 
-let ofPath = path => {
-  open RunAsync.Syntax;
+let normalizePath = (~path, p) =>
+  if (Path.isAbs(p)) {
+    p;
+  } else {
+    Path.(normalize(path /\/ p));
+  };
 
-  let normalizePath = p =>
-    if (Path.isAbs(p)) {
-      p;
-    } else {
-      Path.(normalize(path /\/ p));
+let ofFile = (~basePath, filename) => {
+  let* data = Fs.readFile(filename);
+  let* json =
+    switch (Json.parse(data)) {
+    | Ok(json) => return(json)
+    | Error(err) =>
+      errorf(
+        "expected %a to be a JSON file but got error: %a",
+        Path.pp,
+        filename,
+        Run.ppError,
+        err,
+      )
     };
 
-  let ofFile = filename => {
+  let* rc = RunAsync.ofStringError(of_yojson(json));
+  let rc = {
+    prefixPath: Option.map(~f=normalizePath(~path=basePath), rc.prefixPath),
+  };
+  return(rc);
+};
+
+let ofFileOpt = (~basePath, filename) => {
+  let rc = {
     let* data = Fs.readFile(filename);
     let* json =
       switch (Json.parse(data)) {
@@ -29,20 +51,42 @@ let ofPath = path => {
       };
 
     let* rc = RunAsync.ofStringError(of_yojson(json));
-    let rc = {prefixPath: Option.map(~f=normalizePath, rc.prefixPath)};
-    return(rc);
+    let rc = {
+      prefixPath:
+        Option.map(~f=normalizePath(~path=basePath), rc.prefixPath),
+    };
+    return(Some(rc));
   };
 
+  RunAsync.try_(~catch=_ => return(None), rc);
+};
+
+let ofPath = path => {
   let filename = Path.(path / ".esyrc");
   let filenameInHome = Path.(Path.homePath() / ".esyrc");
 
   if%bind (Fs.exists(filename)) {
-    ofFile(filename);
+    ofFile(~basePath=path, filename);
   } else {
     if%bind (Fs.exists(filenameInHome)) {
-      ofFile(filenameInHome);
+      ofFile(~basePath=path, filenameInHome);
     } else {
       return(empty);
+    };
+  };
+};
+
+let ofPathOpt = path => {
+  let filename = Path.(path / ".esyrc");
+  let filenameInHome = Path.(Path.homePath() / ".esyrc");
+
+  if%bind (Fs.exists(filename)) {
+    ofFileOpt(~basePath=path, filename);
+  } else {
+    if%bind (Fs.exists(filenameInHome)) {
+      ofFileOpt(~basePath=path, filenameInHome);
+    } else {
+      return(Some(empty));
     };
   };
 };

--- a/esy-build/EsyRc.rei
+++ b/esy-build/EsyRc.rei
@@ -1,3 +1,4 @@
 type t = {prefixPath: option(Path.t)};
 
 let ofPath: Fpath.t => RunAsync.t(t);
+let ofPathOpt: Fpath.t => RunAsync.t(option(t));

--- a/esy-fetch/Config.re
+++ b/esy-fetch/Config.re
@@ -7,17 +7,6 @@ type t = {
   fetchConcurrency: option(int),
 };
 
-let cacheGCRoot = (prefixPath) => {
-  open RunAsync.Syntax;
-  let pathToProjects = Path.(prefixPath / "projects.json");
-
-  if%bind (Fs.exists(pathToProjects)) {
-    return();
-  } else {
-    Fs.writeJsonFile(`List([]), pathToProjects);
-  }
-};
-
 let make =
     (
       ~prefixPath=?,
@@ -63,7 +52,7 @@ let make =
   let sourceInstallPath = Path.(sourcePath / "i");
   let* () = Fs.createDir(sourceInstallPath);
 
-  let%bind () = cacheGCRoot(prefixPath);
+  let%bind () = ProjectList.init(prefixPath);
 
   return({
     sourceArchivePath,

--- a/esy-fetch/Config.re
+++ b/esy-fetch/Config.re
@@ -7,6 +7,17 @@ type t = {
   fetchConcurrency: option(int),
 };
 
+let cacheGCRoot = (prefixPath) => {
+  open RunAsync.Syntax;
+  let pathToProjects = Path.(prefixPath / "projects.json");
+
+  if%bind (Fs.exists(pathToProjects)) {
+    return();
+  } else {
+    Fs.writeJsonFile(`List([]), pathToProjects);
+  }
+};
+
 let make =
     (
       ~prefixPath=?,
@@ -51,6 +62,8 @@ let make =
 
   let sourceInstallPath = Path.(sourcePath / "i");
   let* () = Fs.createDir(sourceInstallPath);
+
+  let%bind () = cacheGCRoot(prefixPath);
 
   return({
     sourceArchivePath,

--- a/esy-fetch/ProjectList.re
+++ b/esy-fetch/ProjectList.re
@@ -31,12 +31,19 @@ let sync = (prefixPath, currentProj) => {
   let* projects =
     switch (Decode.(list(string, json))) {
     | Ok(projects) =>
-      let projects =
-        if (List.mem(currentProj, ~set=projects)) {
+      let projects = {
+        let f = a => {
+          switch (Path.ofString(a), Path.ofString(currentProj)) {
+          | (Ok(pa), Ok(pb)) => Path.equal(pa, pb)
+          | _ => false
+          };
+        };
+        if (List.exists(~f, projects)) {
           projects;
         } else {
           [currentProj, ...projects];
         };
+      };
       let* projects =
         RunAsync.List.filter(
           ~f=

--- a/esy-fetch/ProjectList.re
+++ b/esy-fetch/ProjectList.re
@@ -1,0 +1,60 @@
+open RunAsync.Syntax;
+
+let filename = "projects.json";
+
+let init = prefixPath => {
+  let pathToProjects = Path.(prefixPath / filename);
+  if%bind (Fs.exists(pathToProjects)) {
+    return();
+  } else {
+    Fs.writeJsonFile(~json=`List([]), pathToProjects);
+  };
+};
+
+let get = prefixPath => {
+  let* () = init(prefixPath);
+  let projectsPath = Path.(prefixPath / "projects.json");
+  let* json = Fs.readJsonFile(projectsPath);
+  let* json =
+    switch (Json.Decode.(list(string, json))) {
+    | Ok(json) => return(json)
+    | Error(err) => errorf("%s cannot be parsed", projectsPath |> Path.show)
+    };
+  json |> List.map(~f=Path.v) |> return;
+};
+
+let update = (prefixPath, currentProj) => {
+  open Json;
+  let* () = init(prefixPath);
+  let projectsPath = Path.(prefixPath / "projects.json");
+  let* json = Fs.readJsonFile(projectsPath);
+  let* projects =
+    switch (Decode.(list(string, json))) {
+    | Ok(projects) =>
+      let projects =
+        if (List.mem(currentProj, ~set=projects)) {
+          projects;
+        } else {
+          [currentProj, ...projects];
+        };
+      let* projects =
+        RunAsync.List.filter(
+          ~f=
+            project => {
+              switch (Path.ofString(project)) {
+              | Ok(path) =>
+                if%bind (Fs.exists(path)) {
+                  RunAsync.return(true);
+                } else {
+                  RunAsync.return(false);
+                }
+              | Error(`Msg(_)) => RunAsync.return(false)
+              }
+            },
+          projects,
+        );
+      Encode.(list(string, projects)) |> return;
+    | Error(_err) => errorf("%s cannot be parsed", projectsPath |> Path.show)
+    };
+  Fs.writeJsonFile(~json=projects, projectsPath);
+};

--- a/esy-fetch/ProjectList.re
+++ b/esy-fetch/ProjectList.re
@@ -18,12 +18,12 @@ let get = prefixPath => {
   let* json =
     switch (Json.Decode.(list(string, json))) {
     | Ok(json) => return(json)
-    | Error(err) => errorf("%s cannot be parsed", projectsPath |> Path.show)
+    | Error(_err) => errorf("%s cannot be parsed", projectsPath |> Path.show)
     };
   json |> List.map(~f=Path.v) |> return;
 };
 
-let update = (prefixPath, currentProj) => {
+let sync = (prefixPath, currentProj) => {
   open Json;
   let* () = init(prefixPath);
   let projectsPath = Path.(prefixPath / "projects.json");
@@ -57,4 +57,10 @@ let update = (prefixPath, currentProj) => {
     | Error(_err) => errorf("%s cannot be parsed", projectsPath |> Path.show)
     };
   Fs.writeJsonFile(~json=projects, projectsPath);
+};
+
+let update = (prefixPath, activeProjectPaths) => {
+  let* () = init(prefixPath);
+  let projectsPath = Path.(prefixPath / "projects.json");
+  Fs.writeJsonFile(~json=`List(activeProjectPaths |> List.map(~f=path => `String(Path.show(path)))), projectsPath);
 };

--- a/esy-fetch/ProjectList.re
+++ b/esy-fetch/ProjectList.re
@@ -62,5 +62,11 @@ let sync = (prefixPath, currentProj) => {
 let update = (prefixPath, activeProjectPaths) => {
   let* () = init(prefixPath);
   let projectsPath = Path.(prefixPath / "projects.json");
-  Fs.writeJsonFile(~json=`List(activeProjectPaths |> List.map(~f=path => `String(Path.show(path)))), projectsPath);
+  Fs.writeJsonFile(
+    ~json=
+      `List(
+        activeProjectPaths |> List.map(~f=path => `String(Path.show(path))),
+      ),
+    projectsPath,
+  );
 };

--- a/esy-lib/Path.re
+++ b/esy-lib/Path.re
@@ -174,3 +174,5 @@ let safePath = {
     |> Str.global_replace(replaceColon, "__c__");
   make;
 };
+
+let equal = Fpath.equal;

--- a/esy-lib/Path.rei
+++ b/esy-lib/Path.rei
@@ -59,3 +59,5 @@ let remEmptySeg: t => t;
 let normalize: t => t;
 let normalizePathSepOfFilename: string => string;
 let normalizeAndRemoveEmptySeg: t => t;
+
+let equal: (t, t) => bool;

--- a/esy-lib/Run.rei
+++ b/esy-lib/Run.rei
@@ -3,7 +3,11 @@
  */
 
 type t('v) = result('v, error)
-and error;
+and error = (string, context)
+and context = list(contextItem)
+and contextItem =
+  | Line(string)
+  | LogOutput((string, string));
 
 /**
  * Failied computation with an error specified by a message.

--- a/esy-lib/RunAsync.re
+++ b/esy-lib/RunAsync.re
@@ -57,12 +57,11 @@ let ofStringError = r => ofRun(Run.ofStringError(r));
 let ofBosError = r => ofRun(Run.ofBosError(r));
 
 let try_ = (~catch, computation) => {
-  switch%lwt(computation) {
+  switch%lwt (computation) {
   | Ok(value) => return(value)
-  | Error(error) => catch(error);
+  | Error(error) => catch(error)
   };
 };
-
 
 module Syntax = {
   let return = return;

--- a/esy-lib/RunAsync.re
+++ b/esy-lib/RunAsync.re
@@ -56,6 +56,14 @@ let ofLwt = lwt => Lwt.bind(lwt, v => Lwt.return(Ok(v)));
 let ofStringError = r => ofRun(Run.ofStringError(r));
 let ofBosError = r => ofRun(Run.ofBosError(r));
 
+let try_ = (~catch, computation) => {
+  switch%lwt(computation) {
+  | Ok(value) => return(value)
+  | Error(error) => catch(error);
+  };
+};
+
+
 module Syntax = {
   let return = return;
   let error = error;

--- a/esy-lib/RunAsync.re
+++ b/esy-lib/RunAsync.re
@@ -52,6 +52,7 @@ let both = (a, b) => {
 };
 
 let ofRun = Lwt.return;
+let ofLwt = lwt => Lwt.bind(lwt, v => Lwt.return(Ok(v)));
 let ofStringError = r => ofRun(Run.ofStringError(r));
 let ofBosError = r => ofRun(Run.ofBosError(r));
 

--- a/esy-lib/RunAsync.rei
+++ b/esy-lib/RunAsync.rei
@@ -49,6 +49,12 @@ let runExn: (~err: string=?, t('a)) => 'a;
 let ofRun: Run.t('a) => t('a);
 
 /**
+ * Convert [Lwt.t] into [t].
+ */
+
+let ofLwt: Lwt.t('a) => t('a);
+
+/**
  * Convert an Rresult into [t]
  */
 

--- a/esy-lib/RunAsync.rei
+++ b/esy-lib/RunAsync.rei
@@ -67,6 +67,8 @@ let ofBosError:
   ) =>
   t('a);
 
+let try_: (~catch: Run.error => t('a), t('a)) => t('a)
+
 /**
  * Convert [option] into [t].
  *

--- a/esy-lib/RunAsync.rei
+++ b/esy-lib/RunAsync.rei
@@ -67,7 +67,7 @@ let ofBosError:
   ) =>
   t('a);
 
-let try_: (~catch: Run.error => t('a), t('a)) => t('a)
+let try_: (~catch: Run.error => t('a), t('a)) => t('a);
 
 /**
  * Convert [option] into [t].

--- a/test-e2e/esy-cleanup.test.js
+++ b/test-e2e/esy-cleanup.test.js
@@ -6,54 +6,72 @@ const path = require('path');
 const fs = require('./test/fs.js');
 const {test, isWindows} = helpers;
 
-describe('cleanup command', () => {
-  test(`should add project path to project.json`, async () => {
-    const fixture = [
-      helpers.packageJson({
-        name: 'root',
-        version: '1.0.0',
-        esy: {},
-        dependencies: {},
-      }),
-    ];
-    const p = await helpers.createTestSandbox(...fixture);
+(describe(
+  "cleanup command",
+  () => {
+    test(
+      `should add project path to project.json`,
+      async () => {
+        const fixture = [
+          helpers.packageJson(
+            {name: "root", version: "1.0.0", esy: {}, dependencies: {}},
+          ),
+        ];
+        const p = await helpers.createTestSandbox(...fixture);
+        
+        await p.esy("install");
+        
+        await expect(fs.readJson(p.esyPrefixPath + "/projects.json")).resolves.toMatchObject(
+          [p.projectPath],
+        );
+      },
+    );
     
-    {
-      const {stderr} = await p.esy('install');
-    }
-
-
-    await expect(fs.readJson(p.esyPrefixPath + '/projects.json'))
-    .resolves
-    .toMatchObject([
-      p.projectPath
-    ]);
-  });
-
-  test(`should skip adding project if it is already added`, async () => {
-    const fixture = [
-      helpers.packageJson({
-        name: 'root',
-        version: '1.0.0',
-        esy: {},
-        dependencies: {},
-      }),
-    ];
-    const p = await helpers.createTestSandbox(...fixture);
-    await fs.writeJson(p.esyPrefixPath + "/projects.json", [
-      p.projectPath
-    ])
+    test(
+      `should skip adding project if it is already added`,
+      async () => {
+        const fixture = [
+          helpers.packageJson(
+            {name: "root", version: "1.0.0", esy: {}, dependencies: {}},
+          ),
+        ];
+        const p = await helpers.createTestSandbox(...fixture);
+        await fs.writeJson(p.esyPrefixPath + "/projects.json", [p.projectPath]);
+        const {stderr} = await p.esy("install");
+        
+        await expect(fs.readJson(p.esyPrefixPath + "/projects.json")).resolves.toMatchObject(
+          [p.projectPath],
+        );
+      },
+    );
     
-    {
-      const {stderr} = await p.esy('install');
-    }
+    test(
+      `should default to all paths in projects.json if not path provided`,
+      async () => {
+        const fixture = [
+          helpers.packageJson(
+            {
+              name: "root",
+              version: "1.0.0",
+              esy: {},
+              dependencies: {
+                [`one-fixed-dep`]: `1.0.0`,
+                [`one-range-dep`]: `1.0.0`,
+              },
+            },
+          ),
+        ];
+        
+        const p = await helpers.createTestSandbox(...fixture);
+        await p.esy("install");
+        
+        const {stderr} = await p.esy("cleanup");
+        
+        // const {stderr, stdout} = await p.esy("ls-builds -T");
 
-
-    await expect(fs.readJson(p.esyPrefixPath + '/projects.json'))
-    .resolves
-    .toMatchObject([
-      p.projectPath
-    ]);
-  });
-})
+        await expect(stderr).toBe("info cleanup 0.6.10\n");
+      },
+    );
+  },
+))
 

--- a/test-e2e/esy-cleanup.test.js
+++ b/test-e2e/esy-cleanup.test.js
@@ -1,0 +1,59 @@
+// @flow
+
+const outdent = require('outdent');
+const helpers = require('./test/helpers.js');
+const path = require('path');
+const fs = require('./test/fs.js');
+const {test, isWindows} = helpers;
+
+describe('cleanup command', () => {
+  test(`should add project path to project.json`, async () => {
+    const fixture = [
+      helpers.packageJson({
+        name: 'root',
+        version: '1.0.0',
+        esy: {},
+        dependencies: {},
+      }),
+    ];
+    const p = await helpers.createTestSandbox(...fixture);
+    
+    {
+      const {stderr} = await p.esy('install');
+    }
+
+
+    await expect(fs.readJson(p.esyPrefixPath + '/projects.json'))
+    .resolves
+    .toMatchObject([
+      p.projectPath
+    ]);
+  });
+
+  test(`should skip adding project if it is already added`, async () => {
+    const fixture = [
+      helpers.packageJson({
+        name: 'root',
+        version: '1.0.0',
+        esy: {},
+        dependencies: {},
+      }),
+    ];
+    const p = await helpers.createTestSandbox(...fixture);
+    await fs.writeJson(p.esyPrefixPath + "/projects.json", [
+      p.projectPath
+    ])
+    
+    {
+      const {stderr} = await p.esy('install');
+    }
+
+
+    await expect(fs.readJson(p.esyPrefixPath + '/projects.json'))
+    .resolves
+    .toMatchObject([
+      p.projectPath
+    ]);
+  });
+})
+

--- a/test-e2e/esy-cleanup.test.js
+++ b/test-e2e/esy-cleanup.test.js
@@ -4,74 +4,243 @@ const outdent = require('outdent');
 const helpers = require('./test/helpers.js');
 const path = require('path');
 const fs = require('./test/fs.js');
-const {test, isWindows} = helpers;
+const {createTestSandbox, defineNpmPackage, packageJson, test, isWindows} = helpers;
 
-(describe(
-  "cleanup command",
-  () => {
-    test(
-      `should add project path to project.json`,
-      async () => {
-        const fixture = [
-          helpers.packageJson(
-            {name: "root", version: "1.0.0", esy: {}, dependencies: {}},
-          ),
-        ];
-        const p = await helpers.createTestSandbox(...fixture);
-        
-        await p.esy("install");
-        
-        await expect(fs.readJson(p.esyPrefixPath + "/projects.json")).resolves.toMatchObject(
-          [p.projectPath],
-        );
-      },
-    );
-    
-    test(
-      `should skip adding project if it is already added`,
-      async () => {
-        const fixture = [
-          helpers.packageJson(
-            {name: "root", version: "1.0.0", esy: {}, dependencies: {}},
-          ),
-        ];
-        const p = await helpers.createTestSandbox(...fixture);
-        await fs.writeJson(p.esyPrefixPath + "/projects.json", [p.projectPath]);
-        const {stderr} = await p.esy("install");
-        
-        await expect(fs.readJson(p.esyPrefixPath + "/projects.json")).resolves.toMatchObject(
-          [p.projectPath],
-        );
-      },
-    );
-    
-    test(
-      `should default to all paths in projects.json if not path provided`,
-      async () => {
-        const fixture = [
-          helpers.packageJson(
-            {
-              name: "root",
-              version: "1.0.0",
-              esy: {},
-              dependencies: {
-                [`one-fixed-dep`]: `1.0.0`,
-                [`one-range-dep`]: `1.0.0`,
-              },
-            },
-          ),
-        ];
-        
-        const p = await helpers.createTestSandbox(...fixture);
-        await p.esy("install");
-        
-        const {stderr} = await p.esy("cleanup");
-        
-        // const {stderr, stdout} = await p.esy("ls-builds -T");
+const testFolder = './tests/';
 
-        await expect(stderr).toBe("info cleanup 0.6.10\n");
-      },
-    );
-  },
-))
+class EsyInstallCacheEntry {
+  constructor(entry) {
+    let matches = entry.match(/(?<entryBaseName>[^\-]+-[^\-]+)+-(?<hash>[a-h0-9]+)$/);
+    if (matches) {
+      let {entryBaseName, hash} = matches.groups;
+      this.entry = entryBaseName;
+      this.hash = hash;
+    }
+  }
+  toString() {
+    return `[Cache entry base name: ${this.entry} hash: ${this.hash}]`;
+  }
+  equals(other) {
+    // It's not important that hashes match
+    return this.entry === other.entry;
+  }
+}
 
+class EsySourceCacheEntry {
+  constructor(entry) {
+    let groups = entry.split('__');
+    this.hash = groups.pop();
+    this.version = groups.pop();
+    this.name = groups.join('__');
+  }
+  toString() {
+    return `[Cache entry name: ${this.name} version:{this.version} hash: ${this.hash}]`;
+  }
+  equals(other) {
+    // It's not important that hashes match
+    return this.name === other.name && this.version === other.version;
+  }
+}
+
+function areInstallCacheEntriesEqual(a, b) {
+  const isAEsyCacheEntry = a instanceof EsyInstallCacheEntry;
+  const isBEsyCacheEntry = b instanceof EsyInstallCacheEntry;
+
+  if (isAEsyCacheEntry && isBEsyCacheEntry) {
+    return a.equals(b);
+  } else if (isAEsyCacheEntry !== isBEsyCacheEntry) {
+    return false;
+  } else {
+    return undefined;
+  }
+}
+
+function areSourceCacheEntriesEqual(a, b) {
+  const isAEsyCacheEntry = a instanceof EsySourceCacheEntry;
+  const isBEsyCacheEntry = b instanceof EsySourceCacheEntry;
+
+  if (isAEsyCacheEntry && isBEsyCacheEntry) {
+    return a.equals(b);
+  } else if (isAEsyCacheEntry !== isBEsyCacheEntry) {
+    return false;
+  } else {
+    return undefined;
+  }
+}
+
+expect.addEqualityTesters([areInstallCacheEntriesEqual, areSourceCacheEntriesEqual]);
+
+describe('cleanup command', () => {
+  test(`should add project path to project.json`, async () => {
+    const fixture = [
+      helpers.packageJson({name: 'root', version: '1.0.0', esy: {}, dependencies: {}}),
+    ];
+    const p = await helpers.createTestSandbox(...fixture);
+
+    await p.esy('install');
+
+    await expect(fs.readJson(p.esyPrefixPath + '/projects.json')).resolves.toMatchObject([
+      p.projectPath,
+    ]);
+  });
+
+  test(`should skip adding project if it is already added`, async () => {
+    const fixture = [
+      helpers.packageJson({name: 'root', version: '1.0.0', esy: {}, dependencies: {}}),
+    ];
+    const p = await helpers.createTestSandbox(...fixture);
+    await fs.writeJson(p.esyPrefixPath + '/projects.json', [p.projectPath]);
+    const {stderr} = await p.esy('install');
+
+    await expect(fs.readJson(p.esyPrefixPath + '/projects.json')).resolves.toMatchObject([
+      p.projectPath,
+    ]);
+  });
+
+  test(`should default to all paths in projects.json if not path provided`, async () => {
+    const fixture = [
+      helpers.packageJson({
+        name: 'root',
+        version: '1.0.0',
+        esy: {},
+        dependencies: {
+          [`one-fixed-dep`]: `1.0.0`,
+          [`one-range-dep`]: `1.0.0`,
+        },
+      }),
+    ];
+
+    const p = await helpers.createTestSandbox(...fixture);
+    await p.esy('install');
+
+    const {stderr} = await p.esy('cleanup');
+
+    // const {stderr, stdout} = await p.esy("ls-builds -T");
+
+    await expect(stderr).toMatch(/info cleanup/);
+  });
+
+  it('cleanup - more workflows', async () => {
+    let sandbox = await createTestSandbox();
+    let projectsJsonPath = path.join(sandbox.esyPrefixPath, 'projects.json');
+    await sandbox.defineNpmPackage({
+      name: 'dep',
+      version: '1.0.0',
+      dependencies: {depDep: `1.0.0`},
+      esy: {
+        build: 'true',
+      },
+    });
+    await sandbox.defineNpmPackage({
+      name: 'depDep',
+      version: '1.0.0',
+      esy: {
+        build: 'true',
+      },
+    });
+    await sandbox.defineNpmPackage({
+      name: 'depDep',
+      version: '2.0.0',
+      esy: {
+        build: 'true',
+      },
+    });
+    await sandbox.fixture(
+      packageJson({
+        name: 'root',
+        version: '1.0.0',
+        dependencies: {dep: `1.0.0`},
+        esy: {
+          build: 'true',
+        },
+      }),
+    );
+    await sandbox.esy();
+    let installCache = await fs.readdir(path.join(sandbox.esyStorePath, 'i'));
+    function toEsyInstallCacheEntry(l) {
+      return l.map((x) => new EsyInstallCacheEntry(x));
+    }
+    expect(toEsyInstallCacheEntry(installCache)).toEqual(
+      toEsyInstallCacheEntry(['dep-1.0.0-e3915c0b', 'depdep-1.0.0-a4fc2165']),
+    );
+    expect(
+      toEsyInstallCacheEntry(
+        await fs.readdir(path.join(sandbox.esyPrefixPath, 'source', 'i')),
+      ),
+    ).toEqual(
+      toEsyInstallCacheEntry(['dep__1.0.0__b35a2f2d', 'depdep__1.0.0__37e7a60c']),
+    );
+    await sandbox.fixture(
+      packageJson({
+        name: 'root',
+        version: '1.0.0',
+        dependencies: {depDep: `2.0.0`},
+        esy: {
+          build: 'true',
+        },
+      }),
+    );
+    await sandbox.esy();
+    expect(require(projectsJsonPath)).toEqual([sandbox.projectPath]);
+    expect(
+      toEsyInstallCacheEntry(await fs.readdir(path.join(sandbox.esyStorePath, 'i'))),
+    ).toEqual(
+      toEsyInstallCacheEntry([
+        'dep-1.0.0-e3915c0b',
+        'depdep-1.0.0-a4fc2165',
+        'depdep-2.0.0-d88993ca',
+      ]),
+    );
+    expect(
+      toEsyInstallCacheEntry(
+        await fs.readdir(path.join(sandbox.esyPrefixPath, 'source', 'i')),
+      ),
+    ).toEqual(
+      toEsyInstallCacheEntry([
+        'dep__1.0.0__b35a2f2d',
+        'depdep__1.0.0__37e7a60c',
+        'depdep__2.0.0__8560b5e1',
+      ]),
+    );
+    await sandbox.esy('cleanup');
+    expect(
+      toEsyInstallCacheEntry(await fs.readdir(path.join(sandbox.esyStorePath, 'i'))),
+    ).toEqual(toEsyInstallCacheEntry(['depdep-2.0.0-d88993ca']));
+    expect(
+      toEsyInstallCacheEntry(
+        await fs.readdir(path.join(sandbox.esyPrefixPath, 'source', 'i')),
+      ),
+    ).toEqual(toEsyInstallCacheEntry(['depdep__2.0.0__8560b5e1']));
+    await sandbox.esy('cleanup');
+    expect(
+      toEsyInstallCacheEntry(await fs.readdir(path.join(sandbox.esyStorePath, 'i'))),
+    ).toEqual(toEsyInstallCacheEntry(['depdep-2.0.0-d88993ca']));
+    expect(
+      toEsyInstallCacheEntry(
+        await fs.readdir(path.join(sandbox.esyPrefixPath, 'source', 'i')),
+      ),
+    ).toEqual(toEsyInstallCacheEntry(['depdep__2.0.0__8560b5e1']));
+    await fs.rename(projectsJsonPath, `${projectsJsonPath}.bak`);
+    await sandbox.esy('cleanup');
+    expect(
+      toEsyInstallCacheEntry(await fs.readdir(path.join(sandbox.esyStorePath, 'i'))),
+    ).toEqual(toEsyInstallCacheEntry(['depdep-2.0.0-d88993ca']));
+    expect(
+      toEsyInstallCacheEntry(
+        await fs.readdir(path.join(sandbox.esyPrefixPath, 'source', 'i')),
+      ),
+    ).toEqual(toEsyInstallCacheEntry(['depdep__2.0.0__8560b5e1']));
+    // TODO: when the last/one-and-only project gets removed,
+    // cleanup command receives an empty list. This is confusing because
+    // it could be that projects.json wasn't present in the first place.
+    // If a projects.json is missing, cleanup with no args must be
+    // a noop - not assume that everything can be deleted!
+    // ----
+    // await fs.rename(`${projectsJsonPath}.bak`, projectsJsonPath);
+    // await sandbox.cd('..');
+    // await fs.remove(sandbox.projectPath);
+    // await sandbox.esy('cleanup');
+    // expect(await fs.readdir(path.join(sandbox.esyStorePath, 'i'))).toEqual([]);
+    // expect(await fs.readdir(path.join(sandbox.esyPrefixPath, 'source', 'i'))).toEqual([]);
+  });
+});

--- a/test-e2e/test/fs.js
+++ b/test-e2e/test/fs.js
@@ -10,17 +10,19 @@ const tmp = require('tmp');
 const zlib = require('zlib');
 const {Minimatch} = require('minimatch');
 
+export {rename} from 'fs-extra';
+
 function stringPatternMatch(
   string: string,
   patterns: Array<string>,
   {matchBase = false, dot = true}: {|matchBase?: boolean, dot?: boolean|} = {},
 ): boolean {
   const compiledPatterns = (Array.isArray(patterns) ? patterns : [patterns]).map(
-    pattern => new Minimatch(pattern, {matchBase, dot}),
+    (pattern) => new Minimatch(pattern, {matchBase, dot}),
   );
 
   // If there's only negated patterns, we assume that everything should match by default
-  let status = compiledPatterns.every(compiledPattern => compiledPattern.negated);
+  let status = compiledPatterns.every((compiledPattern) => compiledPattern.negated);
 
   for (const compiledPattern of compiledPatterns) {
     if (compiledPattern.negated) {
@@ -64,7 +66,7 @@ exports.walk = function walk(
     const paths = [];
 
     const walker = klaw(source, {
-      filter: itemPath => {
+      filter: (itemPath) => {
         if (!filter) {
           return true;
         }
@@ -118,7 +120,7 @@ exports.packToStream = function packToStream(
   const zipperStream = zlib.createGzip();
 
   const packStream = tarFs.pack(source, {
-    map: header => {
+    map: (header) => {
       if (true) {
         header.name = path.resolve('/', header.name);
         header.name = path.relative('/', header.name);
@@ -135,7 +137,7 @@ exports.packToStream = function packToStream(
 
   packStream.pipe(zipperStream);
 
-  packStream.on('error', error => {
+  packStream.on('error', (error) => {
     zipperStream.emit('error', error);
   });
 
@@ -153,11 +155,11 @@ exports.packToFile = function packToFile(
   packStream.pipe(tarballStream);
 
   return new Promise((resolve, reject) => {
-    tarballStream.on('error', error => {
+    tarballStream.on('error', (error) => {
       reject(error);
     });
 
-    packStream.on('error', error => {
+    packStream.on('error', (error) => {
       reject(error);
     });
 
@@ -235,7 +237,7 @@ exports.chmod = function chmod(target: string, mod: number): Promise<void> {
   return fs.chmod(target, mod);
 };
 
-exports.makeFakeBinary = async function(
+exports.makeFakeBinary = async function (
   target: string,
   {output = `Fake binary`, exitCode = 1}: {|output: string, exitCode: number|} = {},
 ): Promise<void> {


### PR DESCRIPTION
- Added GC Root Creation: a json `projects.json` is created and populated when `esy install` is run with the path of that project.
- this json acts like a GC Root to run `cleanup` on.
- if `cleanup` is called without any arguments, it reads the `projects.json` and runs cleanup on the projects inside.