### PR TITLE
Fix simple typo in docs

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -190,7 +190,7 @@ two reasons,
 1. They are installed in a global location somewhere else. Like
    `/usr/local`, `/usr/bin`
 2. Running them directly (`$ /path/to/hello.exe`) is rarely reliable
-   as they might depend on a version of libary that simply may not be
+   as they might depend on a version of library that simply may not be
    present, or the wrong version.
    
 Just like build environments, it would be nice to our project binaries

--- a/site/versioned_docs/version-0.6.10/getting-started.md
+++ b/site/versioned_docs/version-0.6.10/getting-started.md
@@ -191,7 +191,7 @@ two reasons,
 1. They are installed in a global location somewhere else. Like
    `/usr/local`, `/usr/bin`
 2. Running them directly (`$ /path/to/hello.exe`) is rarely reliable
-   as they might depend on a version of libary that simply may not be
+   as they might depend on a version of library that simply may not be
    present, or the wrong version.
    
 Just like build environments, it would be nice to our project binaries

--- a/site/versioned_docs/version-0.6.8/getting-started.md
+++ b/site/versioned_docs/version-0.6.8/getting-started.md
@@ -191,7 +191,7 @@ two reasons,
 1. They are installed in a global location somewhere else. Like
    `/usr/local`, `/usr/bin`
 2. Running them directly (`$ /path/to/hello.exe`) is rarely reliable
-   as they might depend on a version of libary that simply may not be
+   as they might depend on a version of library that simply may not be
    present, or the wrong version.
    
 Just like build environments, it would be nice to our project binaries


### PR DESCRIPTION
I started to use `esy` and reading through the docs I've found this typo, simple fix.