### PR TITLE
Disable opam {post} variable

### DIFF
--- a/esy-solve/OpamManifest.re
+++ b/esy-solve/OpamManifest.re
@@ -285,7 +285,7 @@ let convertDependencies = manifest => {
     let%bind formula =
       filterAndConvertOpamFormula(
         ~build=true,
-        ~post=true,
+        ~post=false,
         ~test=false,
         ~doc=false,
         ~dev=false,


### PR DESCRIPTION
Ref #1306 #1309 

I'm not sure why the `{post}` variable was set to true previously, but I was digging into the opam logic and found that it is `false` by default: https://github.com/ocaml/opam/blob/074df6b6d87d4114116ea41311892b342cfad3de/src/client/opamListCommand.ml#L36

I have no idea what this would break, but it seems to make the example in #1309 install successfully.

I'm happy to implement a different way, if y'all can guide me on it (I tried a few different attempts today before finding the above).

cc @EduardoRFS @ManasJayanth @andreypopp 