### PR TITLE
Unix.open process args

### DIFF
--- a/esy-lib/EsyBash.re
+++ b/esy-lib/EsyBash.re
@@ -48,10 +48,8 @@ let normalizePathForCygwin = path =>
   switch (System.Platform.host) {
   | System.Platform.Windows =>
     let rootPath = getCygPath();
-    let ic =
-      Unix.open_process_in(
-        Fpath.to_string(rootPath) ++ " \"" ++ path ++ " \"",
-      );
+    let binary = Fpath.to_string(rootPath);
+    let ic = Unix.open_process_args_in(binary, [|binary, path|]);
     let result = String.trim(input_line(ic));
     let () = close_in(ic);
     result;
@@ -91,11 +89,16 @@ let normalizePathForWindows = (path: Fpath.t) =>
     | '\\' =>
       let rootPath = getCygPath();
       /* Use the `cygpath` utility with the `-w` flag to resolve to a Windows path */
-      let commandToRun =
-        String.trim(Fpath.to_string(rootPath))
-        ++ " -w "
-        ++ Path.normalizePathSepOfFilename(Fpath.to_string(path));
-      let ic = Unix.open_process_in(commandToRun);
+      let binary = String.trim(Fpath.to_string(rootPath));
+      let ic =
+        Unix.open_process_args_in(
+          binary,
+          [|
+            binary,
+            "-w",
+            Path.normalizePathSepOfFilename(Fpath.to_string(path)),
+          |],
+        );
       let result = Fpath.v(String.trim(input_line(ic)));
       let () = close_in(ic);
       result;

--- a/esy-lib/System.re
+++ b/esy-lib/System.re
@@ -91,15 +91,14 @@ module Arch = {
 
   let host = {
     let uname = () => {
-      let cmd =
-        switch (Platform.host) {
-        | Windows => "echo %PROCESSOR_ARCHITECTURE%"
-        | _ => "uname -m"
-        };
+      let ic = Unix.open_process_in("uname -m");
 
-      let ic = Unix.open_process_in(cmd);
       let uname = input_line(ic);
       let () = close_in(ic);
+      uname;
+    };
+
+    let convert = uname => {
       switch (String.trim(String.lowercase_ascii(uname))) {
       /* Return values for Windows PROCESSOR_ARCHITECTURE environment variable */
       | "x86" => X86_32
@@ -114,7 +113,11 @@ module Arch = {
       };
     };
 
-    uname();
+    switch (Platform.host) {
+    // Should be defined at session statup globally
+    | Windows => convert(Sys.getenv("PROCESSOR_ARCHITECTURE"))
+    | _ => convert(uname())
+    };
   };
 };
 


### PR DESCRIPTION
First some user has issue with space in username and it seemed we have a quote issue. We can workaround with direct creation process. This should benefit Windows while fixing.

I have seen 2 other old open_process_in they call uname but it seem a bit harder to replace (we have to get the direct path).

Now I am able to use esy with space in my username but some package don't build yet.