### PR TITLE
WIP: Release lock after creating build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ yarn-error.log
 .esy-bash-path
 test-e2e-re/lib/verdaccio/storage
 *~
+/.vscode

--- a/esy-build-package/Build.re
+++ b/esy-build-package/Build.re
@@ -128,7 +128,6 @@ module JbuilderHack = {
 };
 
 let configureBuild = (~cfg: Config.t, plan: Plan.t) => {
-  Logs.app(m => m(">>> configureBuild()"));
   let* env = {
     let f = (k, v) =>
       fun
@@ -261,22 +260,16 @@ let withLock = (lockPath: Path.t, f) => {
       )
     );
   let release = () => {
-    Logs.app(m => m(">>> Lock released"));
     UnixLabels.(lockf(fd, ~mode=F_ULOCK, ~len=0));
     Unix.close(fd);
   };
-  Logs.app(m => m(">>> acquring lock"));
   UnixLabels.(lockf(fd, ~mode=F_TLOCK, ~len=0));
   let res =
-    try(
-      {
-        Logs.app(m => m(">>> before perform"));
-        let res = f();
-        Logs.app(m => m(">>> after perform"));
-        release();
-        res;
-      }
-    ) {
+    try({
+      let res = f();
+      release();
+      res;
+    }) {
     | e =>
       release();
       raise(e);
@@ -415,15 +408,6 @@ let withBuild = (~commit=false, ~cfg: Config.t, plan: Plan.t, f) => {
   let* () = initStoreAt(cfg.localStorePath);
 
   let perform = () => {
-    Logs.app(m => m(">>> perform() 1"));
-    Logs.app(m =>
-      m(">>> Build Path : %s", Fpath.to_string(build.buildPath))
-    );
-    Logs.app(m =>
-      m(">>> Stage Path : %s", Fpath.to_string(build.stagePath))
-    );
-    Logs.app(m => m(">>> Lock Path  : %s", Fpath.to_string(build.lockPath)));
-
     let* () = rm(build.installPath);
     let* () = rm(build.stagePath);
     /* remove buildPath only if we build into a global store, otherwise we keep
@@ -448,8 +432,6 @@ let withBuild = (~commit=false, ~cfg: Config.t, plan: Plan.t, f) => {
     let* () = mkdir(build.buildPath);
     let* () = mkdir(build.buildPath / "_esy");
 
-    Logs.app(m => m(">>> perform() 2"));
-
     let* () =
       if (Path.compare(build.sourcePath, build.rootPath) == 0) {
         ok;
@@ -457,7 +439,6 @@ let withBuild = (~commit=false, ~cfg: Config.t, plan: Plan.t, f) => {
         relocateSourcePath(build.sourcePath, build.rootPath);
       };
 
-    Logs.app(m => m(">>> perform() 3"));
     Ok(build);
   };
 
@@ -576,7 +557,6 @@ let build = (~buildOnly=true, ~cfg: Config.t, plan: Plan.t) => {
   Logs.app(m => m("# esy-build-package: pwd: %a", Fpath.pp, build.rootPath));
 
   let runBuildAndInstall = (build: build) => {
-    Logs.app(m => m(">>> runBuildAndInstall() 1"));
     let enableLinkingOptimization =
       switch (build.plan.sourceType) {
       | Transient => true

--- a/esy-build-package/bin/esyBuildPackageCommand.re
+++ b/esy-build-package/bin/esyBuildPackageCommand.re
@@ -119,6 +119,7 @@ let shell = (copts: commonOpts) => {
   };
 
   let runShell = build => {
+    Logs.app(m => m(">>> runShell()"));
     ppBanner(build);
     let* rcFilename =
       createTmpFile(
@@ -146,7 +147,9 @@ let exec = (copts, command) => {
   let planPath = Option.orDefault(~default=v("build.json"), planPath);
   let* cfg = createConfig(copts);
   let runCommand = build => {
+    Logs.app(m => m(">>> runCommand()"));
     let cmd = Cmd.of_list(command);
+    Logs.app(m => m(">>> runCommand() %s", Cmd.to_string(cmd)));
     Build.runCommandInteractive(build, cmd);
   };
   let* plan = Plan.ofFile(planPath);

--- a/esy-build-package/bin/esyBuildPackageCommand.re
+++ b/esy-build-package/bin/esyBuildPackageCommand.re
@@ -119,7 +119,6 @@ let shell = (copts: commonOpts) => {
   };
 
   let runShell = build => {
-    Logs.app(m => m(">>> runShell()"));
     ppBanner(build);
     let* rcFilename =
       createTmpFile(
@@ -147,9 +146,7 @@ let exec = (copts, command) => {
   let planPath = Option.orDefault(~default=v("build.json"), planPath);
   let* cfg = createConfig(copts);
   let runCommand = build => {
-    Logs.app(m => m(">>> runCommand()"));
     let cmd = Cmd.of_list(command);
-    Logs.app(m => m(">>> runCommand() %s", Cmd.to_string(cmd)));
     Build.runCommandInteractive(build, cmd);
   };
   let* plan = Plan.ofFile(planPath);

--- a/scripts/dev-build.sh
+++ b/scripts/dev-build.sh
@@ -1,0 +1,7 @@
+
+esy
+esy release
+cd _release
+npm pack
+npm install --prefix /tmp/esy esy-0.6.10.tgz
+# export PATH="/tmp/esy/node_modules/esy/bin:$PATH"


### PR DESCRIPTION
If we run 2 long running commands in esy build enviroment
we get an error in the second command

```
esy-build-package: internal error, uncaught exception:
                   Unix.Unix_error(Unix.EAGAIN, "lockf", "")
                   Raised by primitive operation at file "unix.ml" (inlined), line 472, characters 0-73
                   Called from file "esy-build-package/Build.re", line 266, characters 13-47
                   Called from file "esy-build-package/bin/esyBuildPackageCommand.re", line 153, characters 16-55
                   Called from file "esy-build-package/bin/esyBuildPackageCommand.re", line 389, characters 46-65
                   Called from file "cmdliner_term.ml", line 25, characters 19-24
                   Called from file "cmdliner.ml", line 25, characters 27-34
                   Called from file "cmdliner.ml", line 116, characters 32-39
```

because we don't release the lock on the `.lock` file