### PR TITLE
esy-build-package: acquire blocking lock on build environment

### DIFF
--- a/esy-build-package/Build.re
+++ b/esy-build-package/Build.re
@@ -263,7 +263,13 @@ let withLock = (lockPath: Path.t, f) => {
     UnixLabels.(lockf(fd, ~mode=F_ULOCK, ~len=0));
     Unix.close(fd);
   };
-  UnixLabels.(lockf(fd, ~mode=F_TLOCK, ~len=0));
+  try(UnixLabels.(lockf(fd, ~mode=F_TEST, ~len=0))) {
+  | _ =>
+    Logs.app(m =>
+      m("# esy-build-package: waiting for other process to finish building")
+    )
+  };
+  UnixLabels.(lockf(fd, ~mode=F_LOCK, ~len=0));
   let res =
     try({
       let res = f();

--- a/scripts/dev-build.sh
+++ b/scripts/dev-build.sh
@@ -1,0 +1,6 @@
+esy
+esy release
+cd _release
+npm pack
+npm install --prefix /tmp/esy esy-$(esy version).tgz
+# export PATH="/tmp/esy/node_modules/esy/bin:$PATH" 


### PR DESCRIPTION
Currently If we want to run 2 separate long running processes in esy build environment (`esy b <command>`)
The first process locks the build environment, when the second process tries to lock the build environment it crashes 
because we acquire the lock using `F_TLOCK` mode which fails if build env is already locked

This PR tries to improve the experience by acquiring a lock using `F_LOCK` mode which blocks if the build env is already locked
and resumes when the lock is released

Screen-cast demonstrating this condition 

https://user-images.githubusercontent.com/14284762/127770959-1c1ab36c-01ed-43c5-a47f-cc4fe802cb49.mp4

