### PR TITLE
fix alpine ci

### DIFF
--- a/dockerfiles/alpine.Dockerfile
+++ b/dockerfiles/alpine.Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:latest as builder
 
-RUN apk add pkgconfig yarn make m4 git gcc g++ musl-dev perl perl-utils libbz2 zlib zlib-dev zlib-static autoconf automake bzip2-dev bzip2-static opam
+RUN apk add pkgconfig yarn make m4 git gcc g++ musl-dev perl perl-utils libbz2 zlib zlib-dev zlib-static autoconf automake bzip2-dev bzip2-static opam bash
 
 RUN mkdir -p /app
 COPY . /app/esy


### PR DESCRIPTION
## Problem

Seems like bash is not included as some of the implicit dependencies on alpine.

## Solution

Just add bash explicitly as it's a requirement to esy currently.