### PR TITLE
Support overrides on version resolutions

### DIFF
--- a/bin/esy.re
+++ b/bin/esy.re
@@ -1417,7 +1417,8 @@ let show = (_asJson, req, proj: Project.t) => {
   | VersionSpec.Opam([[OpamPackageVersion.Constraint.ANY]]) =>
     let f = (res: Resolution.t) =>
       switch (res.resolution) {
-      | Version(v) => `String(Version.showSimple(v))
+      | VersionOverride({version, override: _}) =>
+        `String(Version.showSimple(version))
       | _ => failwith("unreachable")
       };
 

--- a/esy-package-config/Resolution.rei
+++ b/esy-package-config/Resolution.rei
@@ -3,7 +3,10 @@ type t = {
   resolution,
 }
 and resolution =
-  | Version(Version.t)
+  | VersionOverride({
+      version: Version.t,
+      override: option(Json.t),
+    })
   | SourceOverride({
       source: Source.t,
       override: Json.t,

--- a/esy-package-config/Resolutions.re
+++ b/esy-package-config/Resolutions.re
@@ -45,7 +45,10 @@ let of_yojson = {
         | _ => Version.parse(v)
         };
 
-      return({Resolution.name, resolution: Resolution.Version(version)});
+      return({
+        Resolution.name,
+        resolution: VersionOverride({version, override: None}),
+      });
     | `Assoc(_) =>
       let* resolution = Resolution.resolution_of_yojson(json);
       return({Resolution.name, resolution});

--- a/esy-solve/Sandbox.re
+++ b/esy-solve/Sandbox.re
@@ -10,7 +10,7 @@ type t = {
 
 let makeResolution = source => {
   Resolution.name: "root",
-  resolution: Version(Version.Source(source)),
+  resolution: VersionOverride({version: Source(source), override: None}),
 };
 
 let ofResolution =
@@ -82,7 +82,11 @@ let make = (~gitUsername, ~gitPassword, ~cfg, spec: EsyInstall.SandboxSpec.t) =>
                 };
 
               let resolutions = {
-                let resolution = Resolution.Version(Version.Source(source));
+                let resolution =
+                  Resolution.VersionOverride({
+                    version: Source(source),
+                    override: None,
+                  });
                 Resolutions.add(name, resolution, resolutions);
               };
 
@@ -218,11 +222,14 @@ let digest = (solvespec, sandbox) => {
     let f = (digest, resolution) => {
       let resolution =
         switch (resolution.Resolution.resolution) {
-        | SourceOverride({source: Source.Link(_), override: _}) =>
+        | SourceOverride({source: Source.Link(_), override: _})
+        | VersionOverride({
+            version: Version.Source(Source.Link(_)),
+            override: _,
+          }) =>
           Some(resolution)
+        | VersionOverride(_)
         | SourceOverride(_) => None
-        | Version(Version.Source(Source.Link(_))) => Some(resolution)
-        | Version(_) => None
         };
 
       switch (resolution) {

--- a/esy-solve/Solver.re
+++ b/esy-solve/Solver.re
@@ -351,7 +351,7 @@ let rec findResolutionForRequest = (resolver, req) =>
   | [res, ...rest] => {
       let version =
         switch (res.Resolution.resolution) {
-        | Version(version) => version
+        | VersionOverride({version, override: _}) => version
         | SourceOverride({source, _}) => Version.Source(source)
         };
 


### PR DESCRIPTION
## Problem

Currently esy support's version resolutions but not overrides on those resolutions, this is non ideal sometimes you just want to add a patch on a package coming from opam or npm without destroying the  version constraint.

## Solution

Here I add a `{ version, override }` field on the resolutions values, this will act the same as just having `"pkg": "opam:version"` but will also override some configs of it.

## Why

It's always annoying to test opam overrides, and they provide more power than what we have today, so as an example of resolution the following works with this patch.

```json
{
  "resolutions": {
    "@opam/llvm": {
      "version": "opam:11.0.0",
      "override": {
        "install": [
          [
            "bash",
            "-ex",
            "install.sh",
            "llvm-config",
            "$cur__lib",
            "cmake",
            "make"
          ]
        ]
      }
    }
  }
  ```