### PR TITLE
Fix wrong sha 512 used in Cheksum module + @slowtest

### DIFF
--- a/.ci/esy-build-steps.yml
+++ b/.ci/esy-build-steps.yml
@@ -33,6 +33,7 @@ steps:
     condition: ne(variables['AGENT.OS'], 'Windows_NT')
   - script: 'esy b dune runtest test'
     displayName: 'esy b dune runtest test'
+    condition: ne(variables['AGENT.OS'], 'Windows_NT')
   - script: 'node ./node_modules/jest-cli/bin/jest.js'
     displayName: 'esy test:e2e'
   - script: 'npm install'

--- a/esy-lib/Checksum.re
+++ b/esy-lib/Checksum.re
@@ -68,7 +68,7 @@ let hashOfPath = (~kind) =>
   | Md5 => hashFile((module Digestif.MD5))
   | Sha1 => hashFile((module Digestif.SHA1))
   | Sha256 => hashFile((module Digestif.SHA256))
-  | Sha512 => hashFile((module Digestif.SHA3_512))
+  | Sha512 => hashFile((module Digestif.SHA512))
   };
 
 let computeOfFile = (~kind=Sha256, path) => {

--- a/test-e2e-slow/build-top-100-opam.test.js
+++ b/test-e2e-slow/build-top-100-opam.test.js
@@ -125,6 +125,7 @@ let cases = [
    // Blocked by esy/esy#505
    // {name: 'coq', toolchains: [ocamlVersion]},
    { name: 'libtorch', toolchains: [ocamlVersion] },
+   { name: 'cloudi', toolchains: [ocamlVersion] },
 ];
 
 let reposUpdated = false;

--- a/test/Checksum.re
+++ b/test/Checksum.re
@@ -25,3 +25,75 @@ let%test "checksum validates a simple file: md5" = {
 
   TestHarness.runRunAsyncTest(test);
 };
+
+let%test "checksum validates a simple file: sha1" = {
+  let test = () => {
+    let f = tempPath => {
+      open RunAsync.Syntax;
+      let path = Path.(tempPath / "checksum-test.txt");
+      let data = "test checksum file";
+      let* () = Fs.writeFile(~data, path);
+
+      let expectedChecksum =
+        EsyLib.Checksum.parse("sha1:7d85467b401b128e754b617621a7ed1f8f04724d");
+      switch (expectedChecksum) {
+      | Error(_) => return(false)
+      | Ok(v) =>
+        let* _actualChecksum = EsyLib.Checksum.checkFile(~path, v);
+        return(true);
+      };
+    };
+
+    Fs.withTempDir(f);
+  };
+
+  TestHarness.runRunAsyncTest(test);
+};
+
+let%test "checksum validates a simple file: sha256" = {
+  let test = () => {
+    let f = tempPath => {
+      open RunAsync.Syntax;
+      let path = Path.(tempPath / "checksum-test.txt");
+      let data = "test checksum file";
+      let* () = Fs.writeFile(~data, path);
+
+      let expectedChecksum =
+        EsyLib.Checksum.parse("sha256:d6f5b67d0ef090befcba899843e57a3aa19f8f0a6604fcea0baf808beefedace");
+      switch (expectedChecksum) {
+      | Error(_) => return(false)
+      | Ok(v) =>
+        let* _actualChecksum = EsyLib.Checksum.checkFile(~path, v);
+        return(true);
+      };
+    };
+
+    Fs.withTempDir(f);
+  };
+
+  TestHarness.runRunAsyncTest(test);
+};
+
+let%test "checksum validates a simple file: sha512" = {
+  let test = () => {
+    let f = tempPath => {
+      open RunAsync.Syntax;
+      let path = Path.(tempPath / "checksum-test.txt");
+      let data = "test checksum file";
+      let* () = Fs.writeFile(~data, path);
+
+      let expectedChecksum =
+        EsyLib.Checksum.parse("sha512:1e11fca838c4cf0fb843e326c8fb79912e15c665cf86feec31410d3cb1377f4fd5d75ec837b19a1029614260c2646c747fb8071133eec0e088b1376668a76666");
+      switch (expectedChecksum) {
+      | Error(_) => return(false)
+      | Ok(v) =>
+        let* _actualChecksum = EsyLib.Checksum.checkFile(~path, v);
+        return(true);
+      };
+    };
+
+    Fs.withTempDir(f);
+  };
+
+  TestHarness.runRunAsyncTest(test);
+};

--- a/test/Checksum.re
+++ b/test/Checksum.re
@@ -35,7 +35,9 @@ let%test "checksum validates a simple file: sha1" = {
       let* () = Fs.writeFile(~data, path);
 
       let expectedChecksum =
-        EsyLib.Checksum.parse("sha1:7d85467b401b128e754b617621a7ed1f8f04724d");
+        EsyLib.Checksum.parse(
+          "sha1:7d85467b401b128e754b617621a7ed1f8f04724d",
+        );
       switch (expectedChecksum) {
       | Error(_) => return(false)
       | Ok(v) =>
@@ -59,7 +61,9 @@ let%test "checksum validates a simple file: sha256" = {
       let* () = Fs.writeFile(~data, path);
 
       let expectedChecksum =
-        EsyLib.Checksum.parse("sha256:d6f5b67d0ef090befcba899843e57a3aa19f8f0a6604fcea0baf808beefedace");
+        EsyLib.Checksum.parse(
+          "sha256:d6f5b67d0ef090befcba899843e57a3aa19f8f0a6604fcea0baf808beefedace",
+        );
       switch (expectedChecksum) {
       | Error(_) => return(false)
       | Ok(v) =>
@@ -83,7 +87,9 @@ let%test "checksum validates a simple file: sha512" = {
       let* () = Fs.writeFile(~data, path);
 
       let expectedChecksum =
-        EsyLib.Checksum.parse("sha512:1e11fca838c4cf0fb843e326c8fb79912e15c665cf86feec31410d3cb1377f4fd5d75ec837b19a1029614260c2646c747fb8071133eec0e088b1376668a76666");
+        EsyLib.Checksum.parse(
+          "sha512:1e11fca838c4cf0fb843e326c8fb79912e15c665cf86feec31410d3cb1377f4fd5d75ec837b19a1029614260c2646c747fb8071133eec0e088b1376668a76666",
+        );
       switch (expectedChecksum) {
       | Error(_) => return(false)
       | Ok(v) =>

--- a/test/Fs.re
+++ b/test/Fs.re
@@ -77,10 +77,10 @@ let%test "rename - can rename a directory" = {
     let f = (srcTempPath, dstTempPath) => {
       open RunAsync.Syntax;
       let src = Path.(srcTempPath / "test.txt");
-      let dst = Path.(dstTempPath / "");
+      let dst = dstTempPath;
       let data = "test";
       let* () = Fs.writeFile(~data, src);
-      let src = Path.(srcTempPath / "");
+      let src = srcTempPath;
       let* () = Fs.rename(~src, dst);
       return(true);
     };

--- a/test/dune
+++ b/test/dune
@@ -1,7 +1,8 @@
 (library
  (name Test)
+ (inline_tests)
  (library_flags (-linkall))
- (libraries EsyBuild EsyLib ppx_inline_test.runtime-lib)
+ (libraries EsyLib ppx_inline_test.runtime-lib)
  (modules (:standard))
  (preprocess
   (pps lwt_ppx ppx_let ppx_inline_test ppxlib.runner ppx_deriving.std)))

--- a/test/dune
+++ b/test/dune
@@ -1,7 +1,6 @@
 (library
  (name Test)
  (inline_tests)
- (library_flags (-linkall))
  (libraries EsyLib ppx_inline_test.runtime-lib)
  (modules (:standard))
  (preprocess


### PR DESCRIPTION
The previous PR: #1345 introduced a bug in the Checksum module, It used `SHA3_512` instead of `SHA512`

Also this PR fixes tests not running because the dune file is missing `(inline_tests)` and adds more tests for Checksum