### PR TITLE
Fix sandbox error on Monterey

### DIFF
--- a/esy-build-package/Sandbox.re
+++ b/esy-build-package/Sandbox.re
@@ -29,7 +29,7 @@ module Darwin = {
       );
     let doc =
       [
-        v([I("version"), N(1.0)]),
+        v([I("version"), NI(1)]),
         v([I("allow"), I("default")]),
         v([I("deny"), I("file-write*"), L([I("subpath"), S("/")])]),
         v([

--- a/esy-lib/Sexp.re
+++ b/esy-lib/Sexp.re
@@ -9,6 +9,7 @@ and item =
 and value =
   | S(string)
   | N(float)
+  | NI(int)
   | I(string)
   | L(list(value));
 
@@ -23,6 +24,7 @@ let render = doc => {
         emit("\"");
       }
     | N(v) => emit(string_of_float(v))
+    | NI(v) => emit(string_of_int(v))
     | I(v) => emit(v)
     | L(v) => {
         let f = item => {

--- a/esy-lib/Sexp.rei
+++ b/esy-lib/Sexp.rei
@@ -11,6 +11,7 @@ and item =
 and value =
   | S(string)
   | N(float)
+  | NI(int)
   | I(string)
   | L(list(value));
 


### PR DESCRIPTION
As referenced here: https://github.com/esy/esy/issues/1331

I have no intricate knowledge over the code base, so I can't know if this is the correct way to fix this. However, this seems to compile, and I think this might be the fix, as per the suggestion of https://github.com/kit-ty-kate .

I do have some comments;
The `N(1)` expects a float (in Sexp.re), but the naming seems to be completely arbitrary?
```reason
  | S(string)
  | N(float)
  | I(string)
  | L(list(value));
```

Why not:
```reason
  | E(string) // escaped string
  | S(string)
  | F(float)
  | I(int)
  | L(list(value));
```

That would make a lot more sense to me 🤔. I would be happy to do that refactor, but it will touch a lot of the code. 

I currently moved to:
```reason
  | S(string)
  | N(float)
  | NI(int) // as in NumberInt
  | I(string)
  | L(list(value));
```