### PR TITLE
Windows: Workaround EACCES during rename()

### DIFF
--- a/dune
+++ b/dune
@@ -1,4 +1,3 @@
-(dirs
- (:standard \ _esy \ node_modules \ flow-typed \ scripts \ test-e2e \ site))
-
 (vendored_dirs vendor)
+
+(data_only_dirs _esy esy.lock node_modules flow-typed scripts test-e2e site)


### PR DESCRIPTION
This PR retries `rename()` if it encounters an `EACCESS`