### PR TITLE
Dune: Ignore non Reason/OCaml folders

### DIFF
--- a/dune
+++ b/dune
@@ -1,4 +1,3 @@
-(dirs
- (:standard \ _esy \ node_modules \ flow-typed \ scripts \ test-e2e \ site))
-
 (vendored_dirs vendor)
+
+(data_only_dirs _esy esy.lock node_modules flow-typed scripts test-e2e site)


### PR DESCRIPTION
Marking them as data_folders makes Dune scan for fewer folders.