### PR TITLE
CI: Adds Docker@2 publish task

### DIFF
--- a/.ci/build-release.yml
+++ b/.ci/build-release.yml
@@ -78,6 +78,8 @@ jobs:
           ArtifactName: AlpineLinuxDockerBuiltNPM
 
       - task: Docker@2
+        displayName: 'Push esydev/esy:nightly-alpine-latest to Docker Hub'
+        condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
         inputs:
           containerRegistry: 'Docker Esy (nightly)'
           repository: 'esydev/esy'


### PR DESCRIPTION
With [Docker@2](https://docs.microsoft.com/en-us/azure/devops/pipelines/ecosystems/containers/push-image?view=azure-devops), we can now publish docker images automatically for every dev build.