### PR TITLE
CI: Prebuild opam setup as a separate image

### DIFF
--- a/dockerfiles/alpine.Dockerfile
+++ b/dockerfiles/alpine.Dockerfile
@@ -1,11 +1,4 @@
-FROM alpine:latest as builder
-
-RUN apk add pkgconfig yarn make m4 git gcc g++ musl-dev perl perl-utils libbz2 zlib zlib-dev zlib-static autoconf automake bzip2-dev bzip2-static opam bash
-
-RUN mkdir -p /app
-COPY . /app/esy
-COPY esy.opam /app/esy
-
+FROM esydev/esy-dev:alpine as builder
 WORKDIR /app/esy
 
 # This section useful for debugging the image/container
@@ -21,7 +14,7 @@ WORKDIR /app/esy
 # (that also cleans up build cache) takes lesser space.
 RUN env LD_LIBRARY_PATH=/usr/lib make new-docker SUDO=''
 
-# FROM alpine:latest
+FROM alpine:latest
 
-# COPY --from=builder /usr/local /usr/local
-# COPY --from=builder /app/_release /app/_release
+COPY --from=builder /usr/local /usr/local
+COPY --from=builder /app/_release /app/_release

--- a/dockerfiles/alpine.dev.Dockerfile
+++ b/dockerfiles/alpine.dev.Dockerfile
@@ -1,0 +1,9 @@
+FROM alpine:latest
+
+RUN apk add pkgconfig yarn make m4 git gcc g++ musl-dev perl perl-utils libbz2 zlib zlib-dev zlib-static autoconf automake bzip2-dev bzip2-static opam bash
+
+RUN mkdir -p /app
+COPY . /app/esy
+COPY esy.opam /app/esy
+WORKDIR /app/esy
+RUN env LD_LIBRARY_PATH=/usr/lib make opam-setup SUDO=''


### PR DESCRIPTION
By building opam environment as a separate image, we save some time on CI. At the moment, Alpine pipeline is slow and keeps timing out.