### PR TITLE
Add esy's system dependencies in the Alpine docker image

### DIFF
--- a/dockerfiles/alpine.Dockerfile
+++ b/dockerfiles/alpine.Dockerfile
@@ -18,3 +18,4 @@ FROM alpine:latest
 
 COPY --from=builder /usr/local /usr/local
 COPY --from=builder /app/_release /app/_release
+RUN apk add nodejs npm linux-headers curl git perl-utils bash gcc g++ musl-dev make m4 patch


### PR DESCRIPTION
The Alpine image, `esy:nightly-alpine-latest`, doesn't ship with system dependencies needed by esy. This PR adds them so that users downstream don't have to.