### PR TITLE
Publishes Alpine dev environment on every CI run

### DIFF
--- a/.ci/build-release.yml
+++ b/.ci/build-release.yml
@@ -43,8 +43,41 @@ jobs:
       platform: macOS
       vmImage: macOS-latest
 
+  # The alpine tasks here matter only on the master/main branch. On
+  # pull requests they use older/stale docker images. TODO Disable these
+  # jobs on Alpine.
+  # This is why a separate Linux (non-alpine) matters for us because thats
+  # where the source is actually built and tested end-to-end.
+  - job: Alpine_Dev_Environment
+    displayName: Setting up Alpine Dev Environment
+    pool:
+      vmImage: ubuntu-18.04
+    steps:
+      - checkout: self
+        submodules: true
+      - template: utils/use-node.yml
+      - script: sudo apt install jq gzip
+        displayName: Install deps
+      - bash: |
+          ESY__PROJECT_NAME=$(jq -r .name package.json)
+          ESY__PROJECT_VERSION=$(jq -r .version package.json)
+          echo "##vso[task.setvariable variable=esy__project_name]$ESY__PROJECT_NAME"
+          echo "##vso[task.setvariable variable=esy__project_version]$ESY__PROJECT_VERSION"
+      - task: Docker@2
+        displayName: 'Build and push esydev/esy-dev:alpine to Docker Hub'
+        condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
+        inputs:
+          buildContext: '$(Build.SourcesDirectory)'
+          containerRegistry: 'Docker Esy (nightly)'
+          repository: 'esydev/esy-dev'
+          command: 'buildAndPush'
+          Dockerfile: 'dockerfiles/alpine.dev.Dockerfile'
+          tags: 'alpine'
+
   - job: Alpine_Build
     displayName: Alpine Build
+    dependsOn:
+      - Alpine_Dev_Environment
     pool:
       vmImage: ubuntu-18.04
     steps:

--- a/dockerfiles/alpine.dev.Dockerfile
+++ b/dockerfiles/alpine.dev.Dockerfile
@@ -4,6 +4,5 @@ RUN apk add pkgconfig yarn make m4 git gcc g++ musl-dev perl perl-utils libbz2 z
 
 RUN mkdir -p /app
 COPY . /app/esy
-COPY esy.opam /app/esy
 WORKDIR /app/esy
 RUN env LD_LIBRARY_PATH=/usr/lib make opam-setup SUDO=''


### PR DESCRIPTION
In #1372 , we split the docker image into two to workaround the disk space and timeout issues. However, the dev environment isn't published to docker hub often, causing esy docker images to remain stale.

This PR publishes the dev docker image in a separate job and depends on it in the `Alpine_Build` job.