### PR TITLE
Fix npm binary symlink not getting updated

### DIFF
--- a/esy-install/Fetch.re
+++ b/esy-install/Fetch.re
@@ -627,7 +627,8 @@ module LinkBin = {
     let* () = Fs.chmod(0o777, origPath);
     let destPath = Path.(binPath / name);
     if%bind (Fs.exists(destPath)) {
-      return();
+      let* () = Fs.unlink(destPath);
+      Fs.symlink(~force=true, ~src=origPath, destPath);
     } else {
       Fs.symlink(~force=true, ~src=origPath, destPath);
     };


### PR DESCRIPTION
## Problem
When you download a npm binary package via esy, it creates a symlink in the sandbox `_esy/default/bin`
When you changes the version of the package the symlink does not get updated,
because if the symlink exists we don't update it

## Solution
This PR unlinks the old symlink & creates a new symlink to the updated path


cc: @ManasJayanth @EduardoRFS 