### PR TITLE
@slowtest Filter out environment entries with "" for var name

### DIFF
--- a/esy-build-package/Sandbox.re
+++ b/esy-build-package/Sandbox.re
@@ -67,7 +67,12 @@ module Darwin = {
 
 let convertEnvToJsonString = env => {
   let json = {
-    let f = (k, v, items) => [(k, `String(v)), ...items];
+    let f = (k, v, items) => {
+      switch (k) {
+      | "" => items
+      | k => [(k, `String(v)), ...items]
+      };
+    };
     let items = Astring.String.Map.fold(f, env, []);
     `Assoc(items);
   };


### PR DESCRIPTION
Environments have been found to contain entries like,

```
=C:
```

where the environment variable name is empty. This was ignored until
newer bash from cygwin starts crashing with error 12.

This PR filters out such environment entries