### PR TITLE
Fix OPAM dependency causes inconsistent solver state + @slowtest

### DIFF
--- a/esy-solve/Universe.re
+++ b/esy-solve/Universe.re
@@ -105,10 +105,9 @@ module CudfVersionMap: {
   };
 
   let make = (~size=100, ()) => {
-    let versionToCudfVersion = VersionToCudfVersionMap.empty;
     {
       cudfVersionToVersion: Hashtbl.create(size),
-      versionToCudfVersion,
+      versionToCudfVersion: VersionToCudfVersionMap.empty,
       versions: Hashtbl.create(size),
     };
   };

--- a/esy-solve/Universe.re
+++ b/esy-solve/Universe.re
@@ -79,6 +79,12 @@ let findVersions = (~name, univ: t) =>
     versions |> Version.Map.bindings |> List.map(~f=((_, pkg)) => pkg)
   };
 
+module VersionToCudfVersionMap =
+  Map.Make({
+    [@deriving ord]
+    type t = (string, Version.t);
+  });
+
 module CudfVersionMap: {
   type t;
 
@@ -94,18 +100,26 @@ module CudfVersionMap: {
 } = {
   type t = {
     cudfVersionToVersion: Hashtbl.t((CudfName.t, int), Version.t),
-    versionToCudfVersion: Hashtbl.t((string, Version.t), int),
+    mutable versionToCudfVersion: VersionToCudfVersionMap.t(int),
     versions: Hashtbl.t(string, Version.Set.t),
   };
 
   let make = (~size=100, ()) => {
-    cudfVersionToVersion: Hashtbl.create(size),
-    versionToCudfVersion: Hashtbl.create(size),
-    versions: Hashtbl.create(size),
+    let versionToCudfVersion = VersionToCudfVersionMap.empty;
+    {
+      cudfVersionToVersion: Hashtbl.create(size),
+      versionToCudfVersion,
+      versions: Hashtbl.create(size),
+    };
   };
 
   let update = (map, name, version, cudfVersion) => {
-    Hashtbl.replace(map.versionToCudfVersion, (name, version), cudfVersion);
+    map.versionToCudfVersion =
+      VersionToCudfVersionMap.update(
+        (name, version),
+        t => Some(cudfVersion),
+        map.versionToCudfVersion,
+      );
     Hashtbl.replace(
       map.cudfVersionToVersion,
       (CudfName.encode(name), cudfVersion),
@@ -134,7 +148,9 @@ module CudfVersionMap: {
     };
 
   let findCudfVersion = (~name, ~version, map) =>
-    switch (Hashtbl.find(map.versionToCudfVersion, (name, version))) {
+    switch (
+      VersionToCudfVersionMap.find((name, version), map.versionToCudfVersion)
+    ) {
     | exception Not_found => None
     | version => Some(version)
     };

--- a/test-e2e-slow/build-top-100-opam.test.js
+++ b/test-e2e-slow/build-top-100-opam.test.js
@@ -127,6 +127,7 @@ let cases = [
    { name: 'libtorch', toolchains: [ocamlVersion] },
    { name: 'cloudi', toolchains: [ocamlVersion] },
    { name: 'dune-deps', version: "1.3.0", toolchains: [ocamlVersion] },
+   { name: 'pgocaml', version: "4.3.0", toolchains: [ocamlVersion] },
 ];
 
 let reposUpdated = false;


### PR DESCRIPTION
Fixes #1385 

Problem
---
The [`versionToCudfVersion`](https://github.com/esy/esy/blob/master/esy-solve/Universe.re#L97) in `CudfVersionMap.t` is a  `Hashtbl.t((string, Version.t), int)`, when we try to `find` things in the hashtbl ([`findCudfVersion`](https://github.com/esy/esy/blob/master/esy-solve/Universe.re#L136-L140)) the generic compare (`"%compare"`) function is used, which leads to wrong result when 2 versions are same e.g. `2.00` & `2.0`

Solution
---
The `versionToCudfVersion` field has been changed to a `Map` which will use the correct compare `Version.compare` to check if 2 version are same

Also added `pgocaml` to @slowtest which shows this behaviour

cc: @ManasJayanth @EduardoRFS 