### PR TITLE
@slowtest Fix: Deep opam manifest paths

### DIFF
--- a/esy-build/ReadBuildManifest.re
+++ b/esy-build/ReadBuildManifest.re
@@ -223,10 +223,10 @@ let ofPath = (~manifest=?, path: Path.t) => {
     | Some(spec) =>
       switch (spec) {
       | (ManifestSpec.Esy, fname) =>
-        let path = Path.(path / fname);
+        let path = Path.(path / Filename.basename(fname));
         ofPackageJson(path);
       | (ManifestSpec.Opam, fname) =>
-        let path = Path.(path / fname);
+        let path = Path.(path / Filename.basename(fname));
         OpamBuild.ofFile(path);
       }
     };


### PR DESCRIPTION
* Use file base name while looking for opam manifests
* Copy/move only relevant subtree of the git source for a package (not
the entire git source tree)