### PR TITLE
Fix slow test and make them mandatory

### DIFF
--- a/.ci/esy-build-steps.yml
+++ b/.ci/esy-build-steps.yml
@@ -44,7 +44,6 @@ steps:
   #   displayName: 'esy test:e2e-re'
   - script: 'node ./test-e2e-slow/run-slow-tests.js'
     displayName: 'esy test:e2e-slow'
-    continueOnError: true
   - ${{ if eq(parameters.platform,  'Ubuntu_16_04') }}:
     - script: "esy release"
       displayName: "esy release"

--- a/test-e2e-slow/install-npm.test.js
+++ b/test-e2e-slow/install-npm.test.js
@@ -46,10 +46,12 @@ const cases = [
   {
     name: 'char-regex',
     test: `
-      require('char-regex');
+      // noop since char-regex@2.0.0 is an esm. This test is just
+      // to make sure the package is fetched correctly.
+      // require('char-regex');
     `,
-    version: '2.0.0'
-  }
+    version: '2.0.0',
+  },
 ];
 
 // All of these tests are blocked by issue #506 on Windows


### PR DESCRIPTION
We remove `require('char-regex')` as it is an ESM and the pnp.js file doesn't support esm loading easily.