### PR TITLE
@slowtest Use os.tmpdir() instead of /tmp

### DIFF
--- a/test-e2e-slow/setup.js
+++ b/test-e2e-slow/setup.js
@@ -24,7 +24,7 @@ function getTempDir() {
   // The appveyor temp folder has some permission issues -
   // so in that environment, we'll run these tests from a root folder.
   const appVeyorTempFolder = "C:/esy-ci-temp";
-  return isWindows ? (isCi ? appVeyorTempFolder : os.tmpdir()) : '/tmp';
+  return isWindows && isCi ? appVeyorTempFolder : os.tmpdir();
 }
 
 const esyPrefixPath =


### PR DESCRIPTION
Otherwise, we see

esyBuildPackageCommand: [ERROR] /tmp/0c65008bc29df61b/source/i/opam__s__dune_deps__opam__c__1.3.0__cb1cddae/test/proj/empty/dune: No such file or directory
esy-build-package: create temporary file
                   /tmp/0c65008bc29df61b/3/b/opam__s__dune_deps-opam__c__1.3.0-81ca801c/test/proj/link-to-foo/test/bos-e9610a.tmp:
                   No such file or directory

This happens before even the build is initiated. Probably, during the
source copying phase