### PR TITLE
Use buildConcurrency for `jobs` variable in opam env + @slowtest

### DIFF
--- a/bin/EsyRuntime.re
+++ b/bin/EsyRuntime.re
@@ -3,22 +3,26 @@ let currentExecutable = Path.v(Sys.executable_name);
 
 let version = "0.6.13-dev";
 
-let concurrency = userDefinedValue => {
+let detect_concurrency_from_env = () => {
   let to_int =
     Option.bind(~f=n_str => n_str |> String.trim |> int_of_string_opt);
-  let detect_concurrency_from_env = () =>
-    switch (System.Platform.host) {
-    /* only Win32, as cygwin will have getconf */
-    | Windows => Sys.getenv_opt("NUMBER_OF_PROCESSORS") |> to_int
-    | _ =>
-      let cmd = Bos.Cmd.(v("getconf") % "_NPROCESSORS_ONLN");
-      Bos.OS.Cmd.(run_out(cmd) |> to_string)
-      |> Stdlib.Result.to_option
-      |> to_int;
-    };
 
+  switch (System.Platform.host) {
+  /* only Win32, as cygwin will have getconf */
+  | Windows => Sys.getenv_opt("NUMBER_OF_PROCESSORS") |> to_int
+  | _ =>
+    let cmd = Bos.Cmd.(v("getconf") % "_NPROCESSORS_ONLN");
+    Bos.OS.Cmd.(run_out(cmd) |> to_string)
+    |> Stdlib.Result.to_option
+    |> to_int;
+  };
+};
+
+let env_concurrency = detect_concurrency_from_env();
+
+let concurrency = userDefinedValue => {
   switch (userDefinedValue) {
   | Some(n) => n
-  | None => detect_concurrency_from_env() |> Option.orDefault(~default=1)
+  | None => env_concurrency |> Option.orDefault(~default=1)
   };
 };

--- a/bin/EsyRuntime.rei
+++ b/bin/EsyRuntime.rei
@@ -1,0 +1,8 @@
+let currentWorkingDir: Path.t;
+let currentExecutable: Path.t;
+
+let version: string;
+
+let env_concurrency: option(int);
+
+let concurrency: option(int) => int;

--- a/bin/NpmReleaseCommand.re
+++ b/bin/NpmReleaseCommand.re
@@ -488,7 +488,13 @@ let make =
 
   let* plan =
     RunAsync.ofRun(
-      BuildSandbox.makePlan(~forceImmutable=true, buildspec, Build, sandbox),
+      BuildSandbox.makePlan(
+        ~forceImmutable=true,
+        ~concurrency,
+        buildspec,
+        Build,
+        sandbox,
+      ),
     );
   let tasks = BuildSandbox.Plan.all(plan);
 

--- a/bin/Project.rei
+++ b/bin/Project.rei
@@ -67,6 +67,10 @@ let buildDependencies:
   ) =>
   RunAsync.t(unit);
 
+let buildShell:
+  (project, BuildSpec.mode, BuildSandbox.t, Package.t) =>
+  RunAsync.t(Unix.process_status);
+
 let renderSandboxPath: (SandboxPath.ctx, SandboxPath.t) => Path.t;
 
 let buildPackage:

--- a/bin/esy.re
+++ b/bin/esy.re
@@ -497,13 +497,7 @@ let buildShell = (mode, pkgarg, proj: Project.t) => {
         pkg,
       );
 
-    let p =
-      BuildSandbox.buildShell(
-        proj.Project.workflow.buildspec,
-        mode,
-        fetched.Project.sandbox,
-        pkg.id,
-      );
+    let p = Project.buildShell(proj, mode, fetched.Project.sandbox, pkg);
 
     switch%bind (p) {
     | Unix.WEXITED(0) => return()

--- a/esy-build/BuildSandbox.re
+++ b/esy-build/BuildSandbox.re
@@ -657,7 +657,7 @@ module Plan = {
   let mode = plan => plan.mode;
 };
 
-let makePlan = (~forceImmutable=false, buildspec, mode, sandbox) => {
+let makePlan = (~forceImmutable=false, ~concurrency, buildspec, mode, sandbox) => {
   open Run.Syntax;
 
   let cache = Hashtbl.create(100);
@@ -679,7 +679,8 @@ let makePlan = (~forceImmutable=false, buildspec, mode, sandbox) => {
         );
       };
 
-      let opamEnv = Scope.toOpamEnv(~buildIsInProgress=true, scope);
+      let opamEnv =
+        Scope.toOpamEnv(~buildIsInProgress=true, ~concurrency, scope);
 
       let* buildCommands = {
         let commands = BuildSpec.buildCommands(mode, pkg, build);
@@ -781,18 +782,19 @@ let makePlan = (~forceImmutable=false, buildspec, mode, sandbox) => {
   return({Plan.mode, tasks, buildspec});
 };
 
-let task = (buildspec, mode, sandbox, id) => {
+let task = (~concurrency, buildspec, mode, sandbox, id) => {
   open RunAsync.Syntax;
-  let* tasks = RunAsync.ofRun(makePlan(buildspec, mode, sandbox));
+  let* tasks =
+    RunAsync.ofRun(makePlan(~concurrency, buildspec, mode, sandbox));
   switch (Plan.get(tasks, id)) {
   | None => errorf("no build found for %a", PackageId.pp, id)
   | Some(task) => return(task)
   };
 };
 
-let buildShell = (buildspec, mode, sandbox, id) => {
+let buildShell = (~concurrency, buildspec, mode, sandbox, id) => {
   open RunAsync.Syntax;
-  let* task = task(buildspec, mode, sandbox, id);
+  let* task = task(~concurrency, buildspec, mode, sandbox, id);
   let plan = Task.plan(task);
   EsyBuildPackageApi.buildShell(sandbox.cfg, plan);
 };
@@ -925,6 +927,7 @@ let env = (~forceImmutable=?, envspec, buildspec, mode, sandbox, id) => {
 let exec =
     (
       ~changeDirectoryToPackageRoot=false,
+      ~concurrency,
       envspec,
       buildspec,
       mode,
@@ -968,7 +971,7 @@ let exec =
     );
 
   if (envspec.EnvSpec.buildIsInProgress) {
-    let* task = task(buildspec, mode, sandbox, id);
+    let* task = task(~concurrency, buildspec, mode, sandbox, id);
     let plan = Task.plan(~env, task);
     EsyBuildPackageApi.buildExec(sandbox.cfg, plan, cmd);
   } else {

--- a/esy-build/BuildSandbox.rei
+++ b/esy-build/BuildSandbox.rei
@@ -42,6 +42,7 @@ let env:
 let exec:
   (
     ~changeDirectoryToPackageRoot: bool=?,
+    ~concurrency: int,
     EnvSpec.t,
     BuildSpec.t,
     BuildSpec.mode,
@@ -84,12 +85,19 @@ module Plan: {
 };
 
 let makePlan:
-  (~forceImmutable: bool=?, BuildSpec.t, BuildSpec.mode, t) => Run.t(Plan.t);
+  (
+    ~forceImmutable: bool=?,
+    ~concurrency: int,
+    BuildSpec.t,
+    BuildSpec.mode,
+    t
+  ) =>
+  Run.t(Plan.t);
 
 /** [shell task ()] shells into [task]'s build environment. */
 
 let buildShell:
-  (BuildSpec.t, BuildSpec.mode, t, PackageId.t) =>
+  (~concurrency: int, BuildSpec.t, BuildSpec.mode, t, PackageId.t) =>
   RunAsync.t(Unix.process_status);
 
 /** [build task ()] builds the [task]. */

--- a/esy-build/Scope.re
+++ b/esy-build/Scope.re
@@ -699,7 +699,8 @@ let ocamlVersion = scope => {
   return(toOCamlVersion(PackageScope.version(ocaml.self)));
 };
 
-let toOpamEnv = (~buildIsInProgress, scope: t, name: OpamVariable.Full.t) => {
+let toOpamEnv =
+    (~buildIsInProgress, ~concurrency, scope: t, name: OpamVariable.Full.t) => {
   open OpamVariable;
 
   let ocamlVersion = ocamlVersion(scope);
@@ -813,7 +814,10 @@ let toOpamEnv = (~buildIsInProgress, scope: t, name: OpamVariable.Full.t) => {
   | (Full.Global, "arch") => Some(string(opamArch))
   | (Full.Global, "opam-version") => Some(string("2"))
   | (Full.Global, "make") => Some(string("make"))
-  | (Full.Global, "jobs") => Some(string("4"))
+  | (Full.Global, "jobs") =>
+    let jobs = max(concurrency / 2, 4);
+    let jobs = string_of_int(jobs);
+    Some(string(jobs));
   | (Full.Global, "pinned") => Some(bool(false))
   | (Full.Global, "dev") =>
     Some(

--- a/esy-build/Scope.rei
+++ b/esy-build/Scope.rei
@@ -62,7 +62,8 @@ let render:
   ) =>
   Run.t(SandboxValue.t);
 
-let toOpamEnv: (~buildIsInProgress: bool, t) => OpamFilter.env;
+let toOpamEnv:
+  (~buildIsInProgress: bool, ~concurrency: int, t) => OpamFilter.env;
 
 let exposeUserEnvWith:
   (


### PR DESCRIPTION
This `jobs` opam variable is hard coded to 4 in [Scope.re](https://github.com/esy/esy/blob/master/esy-build/Scope.re#L816)
```reason
 | (Full.Global, "jobs") => Some(string("4"))
```
This PR uses the `buildConcurrency` from the `ProjectConfig.t` (passed to esy via the `--build-concurrency` argument)
If `--build-concurrency` is not passed, then the value of `jobs` = `max(number_of_processors/2, 4)`
