### PR TITLE
@slowtest EACCES: Check if dest exists before copying in esy-build-package

### DIFF
--- a/esy-build-package/Run.re
+++ b/esy-build-package/Run.re
@@ -144,14 +144,29 @@ let copyFile = (~perm=?, srcPath, dstPath) => {
       loop(ic, oc, ());
     };
   };
+  let dstExists =
+    switch (exists(dstPath)) {
+    | Error(_) => false
+    | Ok(exists) => exists
+    };
   let* res =
-    Bos.OS.File.with_ic(
-      srcPath,
-      (ic, ()) =>
-        Bos.OS.File.with_oc(~mode=?perm, dstPath, oc => loop(ic, oc), ()),
-      (),
-    );
-  let* res = res;
+    if (!dstExists) {
+      let* res =
+        Bos.OS.File.with_ic(
+          srcPath,
+          (ic, ()) =>
+            Bos.OS.File.with_oc(
+              ~mode=?perm,
+              dstPath,
+              oc => loop(ic, oc),
+              (),
+            ),
+          (),
+        );
+      res;
+    } else {
+      Ok(Ok());
+    };
   res;
 };
 


### PR DESCRIPTION
Bos.with_oc fails to rename the tmp files it creates if the
files intended to be created (ie the internal rename's destination
file). Giving us,

````
esy-build-package: rename
                   C:\Users\manas\.esy\3________________________________________________________________\s\opam__s__ocaml_migrate_parsetree-opam__c__1.8.0-ecff3088\lib\ocaml-migrate-parsetree\bos-030bbf.tmp
                   to
                   C:\Users\manas\.esy\3________________________________________________________________\s\opam__s__ocaml_migrate_parsetree-opam__c__1.8.0-ecff3088\lib\ocaml-migrate-parsetree\ast_402.ml:
                   Permission denied
```

This commit worksaround by only copying if needed