### PR TITLE
Add nix flake

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,21 @@
+name: "Build nix package"
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: cachix/install-nix-action@v17
+      with:
+        extra_nix_config: |
+          experimental-features = nix-command flakes
+          system-features = nixos-test benchmark big-parallel kvm
+          extra-substituters = https://anmonteiro.nix-cache.workers.dev
+          extra-trusted-public-keys = ocaml.nix-cache.com-1:/xI2h2+56rwFfKyyFVbkJSeGqSIYMC/Je+7XXqGKDIY=
+    - name: Build esy in nix
+      run: nix build .#esy
+    - name: Build FHS environment
+      run: nix build .#fhs

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,80 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nix-filter": {
+      "locked": {
+        "lastModified": 1661201956,
+        "narHash": "sha256-RizGJH/buaw9A2+fiBf9WnXYw4LZABB5kMAZIEE5/T8=",
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "rev": "3b821578685d661a10b563cba30b1861eec05748",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1663021394,
+        "narHash": "sha256-VxSe7wcSbyXZEPhuJGKHKhXFtLqNAdTCVZvB20NqnOU=",
+        "owner": "nix-ocaml",
+        "repo": "nix-overlays",
+        "rev": "f2ce73bb011790a4f5b873b0eea430a7e7191539",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-ocaml",
+        "repo": "nix-overlays",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1662940775,
+        "narHash": "sha256-SIgHTMjM+PqXWaXDzXsy/XmrDuTu7zpPvizgS7C9n+M=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "faa93c4e19e79e7a6de31d6d3492b8f00760ca82",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "faa93c4e19e79e7a6de31d6d3492b8f00760ca82",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nix-filter": "nix-filter",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,34 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nix-ocaml/nix-overlays";
+    nixpkgs.inputs.flake-utils.follows = "flake-utils";
+
+    flake-utils.url = "github:numtide/flake-utils";
+
+    nix-filter.url = "github:numtide/nix-filter";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+    nix-filter,
+    ...
+  }:
+    flake-utils.lib.eachDefaultSystem (
+      system: let
+        pkgs = import nixpkgs {inherit system;};
+        esy-solve-cudf = pkgs.callPackage ./nix/esy-solve-cudf.nix {};
+        esy = pkgs.callPackage ./nix {inherit nix-filter esy-solve-cudf;};
+        fhs = pkgs.callPackage ./nix/fhs.nix {inherit esy;};
+      in {
+        packages = {
+          default = fhs;
+          inherit esy esy-solve-cudf fhs;
+        };
+        devShells = {
+          default = self.packages."${system}".fhs.env;
+        };
+      }
+    );
+}

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,0 +1,115 @@
+{
+  pkgs,
+  lib,
+  nix-filter,
+  stdenv,
+  bash,
+  binutils,
+  coreutils,
+  makeWrapper,
+  esy-solve-cudf,
+}: let
+  esyOcamlPkgs = pkgs.callPackage ./ocamlPackages.nix {};
+in
+  with esyOcamlPkgs;
+    stdenv.mkDerivation {
+      pname = "esy";
+      version = "0.6.13-dev";
+
+      src = with nix-filter.lib;
+        filter {
+          root = ../.;
+          include = [
+            "bin"
+            "esy-build"
+            "esy-build-package"
+            "esy-command-expression"
+            "esy-install"
+            "esy-install-npm-release"
+            "esy-lib"
+            "esy-package-config"
+            "esy-shell-expansion"
+            "esy-solve"
+            "fastreplacestring"
+            "flow-typed"
+            "scripts"
+            "dune"
+            "dune-project"
+            "dune-workspace"
+            "esy.opam"
+          ];
+        };
+
+      nativeBuildInputs = [
+        makeWrapper
+        dune-configurator
+        dune
+        ocaml
+        findlib
+      ];
+
+      propagatedBuildInputs = [
+        coreutils
+        bash
+      ];
+
+      buildInputs = [
+        angstrom
+        cmdliner
+        reason
+        bos
+        fmt
+        fpath
+        lambda-term
+        logs
+        lwt
+        lwt_ppx
+        menhir
+        opam-file-format
+        ppx_deriving
+        ppx_deriving_yojson
+        ppx_expect
+        ppx_inline_test
+        ppx_let
+        ppx_sexp_conv
+        re
+        yojson
+        cudf
+        dose3
+        opam-format
+        opam-core
+        opam-state
+      ];
+      doCheck = false;
+
+      buildPhase = ''
+        dune build -p esy
+      '';
+
+      installPhase = ''
+        dune install --prefix $out
+        mkdir -p $out/lib/esy
+        ln -s ${esy-solve-cudf}/bin/esy-solve-cudf $out/lib/esy/esySolveCudfCommand
+        ls $out/lib/esy
+
+        wrapProgram "$out/bin/esy" \
+          --prefix PATH : ${lib.makeBinPath (with pkgs; [
+          binutils
+          coreutils
+          esy
+          curl
+          git
+          perl
+          gnumake
+          gnupatch
+          gcc
+          bash
+        ])}
+      '';
+
+      meta = {
+        homepage = https://github.com/esy/esy;
+        description = "package.json workflow for native development with Reason/OCaml";
+        license = lib.licenses.bsd2;
+      };
+    }

--- a/nix/esy-solve-cudf.nix
+++ b/nix/esy-solve-cudf.nix
@@ -1,0 +1,48 @@
+{
+  pkgs,
+  lib,
+  fetchFromGitHub,
+  stdenv,
+}: let
+  ocamlPackages = pkgs.callPackage ./ocamlPackages.nix {};
+in
+  with ocamlPackages;
+    stdenv.mkDerivation rec {
+      pname = "esy-solve-cudf";
+      version = "0.1.10";
+
+      src = fetchFromGitHub {
+        owner = "andreypopp";
+        repo = pname;
+        rev = "v${version}";
+        sha256 = "1ky2mkyl676bxphyx0d3vqr58za185nq46h0lai89631g94ia1d7";
+      };
+
+      buildInputs = [
+        ocaml
+        findlib
+        dune
+      ];
+      propagatedBuildInputs = [
+        cmdliner
+        cudf
+        mccs
+        ocaml_extlib
+      ];
+
+      buildPhase = ''
+        runHook preBuild
+        dune build -p ${pname}
+        runHook postBuild
+      '';
+
+      installPhase = ''
+        dune install --prefix $out
+      '';
+
+      meta = {
+        homepage = https://github.com/andreypopp/esy-solve-cudf;
+        description = "package.json workflow for native development with Reason/OCaml";
+        license = lib.licenses.gpl3;
+      };
+    }

--- a/nix/fhs.nix
+++ b/nix/fhs.nix
@@ -1,0 +1,31 @@
+{
+  pkgs,
+  esy,
+}:
+pkgs.buildFHSUserEnv {
+  name = "esy-fhs";
+  targetPkgs = pkgs: (with pkgs; [
+    binutils
+    coreutils
+    esy
+    curl
+    git
+    perl
+    gnumake
+    gnupatch
+    gcc
+    bash
+
+    # Do we need this?
+    glib.dev
+    gmp
+    gnum4
+    linuxHeaders
+    pkgconfig
+    unzip
+    which
+    nodePackages.npm
+    nodejs
+  ]);
+  runScript = "${esy}/bin/esy";
+}

--- a/nix/ocamlPackages.nix
+++ b/nix/ocamlPackages.nix
@@ -1,0 +1,45 @@
+{
+  ocamlPackages,
+  fetchFromGitLab,
+}:
+ocamlPackages.overrideScope' (self: super: rec {
+  alcotest = super.alcotest.overrideAttrs (_: {
+    src = builtins.fetchurl {
+      url = https://github.com/mirage/alcotest/releases/download/1.4.0/alcotest-mirage-1.4.0.tbz;
+      sha256 = "1h9yp44snb6sgm5g1x3wg4gwjscic7i56jf0j8jr07355pxwrami";
+    };
+  });
+
+  cmdliner = super.cmdliner.overrideAttrs (_: {
+    src = builtins.fetchurl {
+      url = https://github.com/esy-ocaml/cmdliner/archive/e9316bc.tar.gz;
+      sha256 = "1g0shk5ahc6byhx79ry6vdyf89a1ncq5bsgykkxa05xabvlr09ji";
+    };
+    createFindlibDestdir = true;
+  });
+
+  fmt = super.fmt.overrideAttrs (_: {
+    src = builtins.fetchurl {
+      url = https://github.com/dbuenzli/fmt/archive/refs/tags/v0.8.10.tar.gz;
+      sha256 = "0xnnrhp45p5vj1wzjn39w0j29blxrqj2dn42qcxzplp2j9mn76b9";
+    };
+  });
+
+  uuidm = super.uuidm.overrideAttrs (_: {
+    src = builtins.fetchurl {
+      url = "https://erratique.ch/software/uuidm/releases/uuidm-0.9.7.tbz";
+      sha256 = "1ivxb3hxn9bk62rmixx6px4fvn52s4yr1bpla7rgkcn8981v45r8";
+    };
+  });
+
+  menhirLib = super.menhirLib.overrideAttrs (_: {
+    version = "20211012";
+    src = fetchFromGitLab {
+      domain = "gitlab.inria.fr";
+      owner = "fpottier";
+      repo = "menhir";
+      rev = "20211012";
+      sha256 = "sha256-gHw9LmA4xudm6iNPpop4VDi988ge4pHZFLaEva4qbiI=";
+    };
+  });
+})


### PR DESCRIPTION
Adds a nix flake to build and use esy.

Usage:
```
nix run github:esy/esy
```

Heavily based on @anmonteiro's work in https://github.com/nix-ocaml/nix-overlays
Also inspired by @d4hines' work in https://github.com/d4hines/esy-fhs