### PR TITLE
Build opam folder with just manifests

### DIFF
--- a/esy-lib/Fs.re
+++ b/esy-lib/Fs.re
@@ -139,6 +139,11 @@ let isDir = (path: Path.t) =>
   | Error(_) => RunAsync.return(false)
   };
 
+let isDirSync = path =>
+  try(Sys.is_directory(Path.show(path))) {
+  | _ => false
+  };
+
 let unlink = (path: Path.t) => {
   let path = Path.show(path);
   let%lwt () = Lwt_unix.unlink(path);

--- a/esy-lib/Fs.rei
+++ b/esy-lib/Fs.rei
@@ -19,6 +19,7 @@ let exists: Path.t => RunAsync.t(bool);
 
 /** Check if the path exists and is a directory */
 let isDir: Path.t => RunAsync.t(bool);
+let isDirSync: Path.t => bool;
 
 let unlink: Path.t => RunAsync.t(unit);
 

--- a/esy-package-config/Dist.re
+++ b/esy-package-config/Dist.re
@@ -245,13 +245,16 @@ module Parse = {
     let make = path => {
       let path = Path.(normalizeAndRemoveEmptySeg(v(path)));
       let (path, manifest) =
-        switch (ManifestSpec.ofString(Path.basename(path))) {
-        | Ok(manifest) =>
+        switch (
+          Fs.isDirSync(path),
+          ManifestSpec.ofString(Path.basename(path)),
+        ) {
+        | (true, _) => (path, None)
+        | (false, Ok(manifest)) =>
           let path = Path.(remEmptySeg(parent(path)));
           (path, Some(manifest));
-        | Error(_) => (path, None)
+        | (false, Error(_)) => (path, None)
         };
-
       {path: DistPath.ofPath(path), manifest};
     };
 

--- a/esy-package-config/Source.re
+++ b/esy-package-config/Source.re
@@ -89,11 +89,15 @@ module Parse = {
     let make = path => {
       let path = Path.(normalizeAndRemoveEmptySeg(v(path)));
       let (path, manifest) =
-        switch (ManifestSpec.ofString(Path.basename(path))) {
-        | Ok(manifest) =>
+        switch (
+          Fs.isDirSync(path),
+          ManifestSpec.ofString(Path.basename(path)),
+        ) {
+        | (true, _) => (path, None)
+        | (false, Ok(manifest)) =>
           let path = Path.(remEmptySeg(parent(path)));
           (path, Some(manifest));
-        | Error(_) => (path, None)
+        | (false, Error(_)) => (path, None)
         };
 
       make(DistPath.ofPath(path), manifest);


### PR DESCRIPTION
Like opam, esy needs to be able to build package sandboxes that only contain opam manifests inside `opam` folder. Right now, whenever the parser encounters a path ending with `opam` it assumes its an opam manifest file - it could be a folder!