### PR TITLE
Use clearer language in global-path docstring

### DIFF
--- a/bin/ProjectConfig.re
+++ b/bin/ProjectConfig.re
@@ -379,7 +379,7 @@ let esyOpamOverrideRemoteArg = {
 };
 
 let globalPathVariableArg = {
-  let doc = "Specifies the PATH variable to look for global utils in the build env.";
+  let doc = "Specifies the shell environment variable to use as $PATH to look for global utils in the build env.";
   let env = Arg.env_var("ESY__GLOBAL_PATH", ~doc);
   Arg.(
     value


### PR DESCRIPTION
I personally found the documentation for this unclear. RE #988 

This is mostly a QoL change especially for NixOS users.