### PR TITLE
Not trigger "Individual CI" pipelines for Pull Requests

### DIFF
--- a/.ci/build-release.yml
+++ b/.ci/build-release.yml
@@ -6,22 +6,6 @@ resources:
 variables:
   esy__ci_cache_version: v1    # this is available to all jobs in env as $ESY__CI_CACHE_VERSION or in azure config as $(esy__ci_cache_version)
   
-trigger:
-  branches:
-    include:
-    - master
-    - releases/*
-    - bryphe/*
-    - andreypopp/*
-    - zindel/*
-    - prometheansacrifice/*
-  paths:
-    exclude:
-    - README.html
-    - notes/*
-    - "*.md"
-    - LICENSE
-
 jobs:
   - template: build-platform.yml
     parameters:


### PR DESCRIPTION
Because, likely due to Github - Azure integration bug, PR view shows results of Individual CI results. We dont need those runs anyway AFAIK. This should free up resources too