### PR TITLE
CI: Use nightly esy since it has long paths enabled.

### DIFF
--- a/.ci/utils/use-esy.yml
+++ b/.ci/utils/use-esy.yml
@@ -1,7 +1,7 @@
 # steps to install esy globally
 
 steps:
-- script: "yarn global add esy@beta"
+- script: "yarn global add @esy-nightly/esy"
   displayName: "Install esy (via yarn)"
   condition: ne(variables['AGENT.OS'], 'Windows_NT')
   
@@ -16,7 +16,7 @@ steps:
   displayName: "Ensure yarn install global tools are available on $PATH"
   condition: ne(variables['AGENT.OS'], 'Windows_NT')
 - script: |
-    npm i -g esy@beta
+    npm i -g @esy-nightly/esy
   displayName: "Install esy (via npm)"
   condition: eq(variables['AGENT.OS'], 'Windows_NT')
 


### PR DESCRIPTION
This is necessary so that esy itself is manifested with the longPathsAware element. At the moment, ie at last commit, esy only installs the longPathsAware manifest in the Cygwin sandbox