### PR TITLE
Set CYGWIN=winsymlinks:nativestrict in Windows buildenv

### DIFF
--- a/esy-build-package/Sandbox.re
+++ b/esy-build-package/Sandbox.re
@@ -92,6 +92,8 @@ module Windows = {
        * Just passing the env directly to esy-bash doesn't work,
        * because we need the current PATH/env to pick up node and run the shell
        */
+      let env =
+        Astring.String.Map.add("CYGWIN", "winsymlinks:nativestrict", env);
       let jsonString = convertEnvToJsonString(env);
       let* environmentTempFile = createTmpFile(jsonString);
       let commandAsList = Cmd.to_list(command);


### PR DESCRIPTION
This is necessary after the recent cygwin upgrade. Without this `ln` command dont create usable symlinks. Seen when building packages like `bzip2`, `help2man` etc