### PR TITLE
Fixes clang warning -Wreturn-type

### DIFF
--- a/esy-lib/win32_path.c
+++ b/esy-lib/win32_path.c
@@ -55,4 +55,5 @@ esy_move_file(value src, value dst) {
 #else
   MoveFileExA(String_val(src), String_val(dst), MOVEFILE_COPY_ALLOWED | MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH);
 #endif
+  return Val_unit;
 }  


### PR DESCRIPTION
```
win32_path.c:58:1: warning: non-void function does not return a value [-Wreturn-type]
```