### PR TITLE
Macos M1: improve codesigning

### DIFF
--- a/esy-build-package/BigSurArm.re
+++ b/esy-build-package/BigSurArm.re
@@ -68,10 +68,15 @@ let sign' = path => {
   Run.try_(~catch, codesign(path));
 };
 
-let rec sign =
-  fun
-  | [] => return()
-  | [h, ...rest] => {
-      let* () = sign'(h);
-      sign(rest);
-    };
+let rec signAcc = (binariesToSign, failures) => {
+  switch (binariesToSign) {
+  | [] => failures
+  | [h, ...rest] =>
+    switch (sign'(h)) {
+    | Ok () => signAcc(rest, failures)
+    | Error(_) => signAcc(rest, [h, ...failures])
+    }
+  };
+};
+
+let sign = binariesToSign => signAcc(binariesToSign, []);

--- a/esy-build-package/BigSurArm.re
+++ b/esy-build-package/BigSurArm.re
@@ -52,15 +52,20 @@ let codesign = fpath => {
 };
 
 let sign' = path => {
-  let* () = codesign(path);
-  let tmpDir = Filename.get_temp_dir_name();
-  let fileBeingCopied = path |> Fpath.to_string |> Filename.basename;
-  let workAroundFilePath = Fpath.(v(tmpDir) / "workaround" / fileBeingCopied);
-  let* () = mkdir(Fpath.(v(tmpDir) / "workaround"));
-  let* () = copyFile(path, workAroundFilePath);
-  let* () = rm(path);
-  let* () = copyFile(~perm=0o775, workAroundFilePath, path);
-  codesign(path);
+  let catch = _e => {
+    let tmpDir = Filename.get_temp_dir_name();
+    let fileBeingCopied = path |> Fpath.to_string |> Filename.basename;
+    Random.self_init();
+    let suffix = Random.bits() |> string_of_int;
+    let workaroundDir = Fpath.(v(tmpDir) / ("workaround-" ++ suffix));
+    let workAroundFilePath = Fpath.(workaroundDir / fileBeingCopied);
+    let* () = mkdir(workaroundDir);
+    let* () = copyFile(path, workAroundFilePath);
+    let* () = rm(path);
+    let* () = copyFile(~perm=0o775, workAroundFilePath, path);
+    codesign(path);
+  };
+  Run.try_(~catch, codesign(path));
 };
 
 let rec sign =

--- a/esy-build-package/Build.re
+++ b/esy-build-package/Build.re
@@ -390,9 +390,19 @@ let commitBuildToStore = (config: Config.t, build: build) => {
       if (isBigSurArm) {
         /* Fix for codesigning issues on BigSur on M1 mac.
            See BigSurArm.re for more details */
-        BigSurArm.sign(
-          entries,
-        );
+        let binariesThatFailedToSign = BigSurArm.sign(entries);
+        if (List.length(binariesThatFailedToSign) > 0) {
+          Esy_logs.warn(m =>
+            m("# esy-build-package: Failed to sign the following binaries")
+          );
+          let f = binary => {
+            ignore @@ Esy_logs.warn(m => m("  %a", Path.pp, binary));
+          };
+          List.iter(f, binariesThatFailedToSign);
+          return();
+        } else {
+          return();
+        };
       } else {
         return();
       };

--- a/esy-build-package/Run.re
+++ b/esy-build-package/Run.re
@@ -359,3 +359,10 @@ module type T = {
       t(list(Fpath.t), [> | `Msg(string)]);
   };
 };
+
+let try_ = (~catch, computation) => {
+  switch (computation) {
+  | Ok(value) => return(value)
+  | Error(error) => catch(error)
+  };
+};

--- a/esy-build-package/Run.rei
+++ b/esy-build-package/Run.rei
@@ -150,3 +150,5 @@ module type T = {
       t(list(Fpath.t), [> | `Msg(string)]);
   };
 };
+
+let try_: (~catch: err('e) => t('v, 'e), t('v, 'e)) => t('v, 'e);


### PR DESCRIPTION
We have noticed a couple of issues

1. codesigning workaround is run regardless of the failure to sign the first time
2. workaround temp paths are collide during different sandbox builds
3. some binaries fail to sign but work just fine. Eg: `coqproofworker.byte`

This MR fixes all of the above. #3 is addressed by failing codesigning operations softly. Perhaps, this should be optin? (TODO)