### PR TITLE
@slowtest Set OPAM_SWITCH_PREFIX for Dune

### DIFF
--- a/esy-build-package/Build.re
+++ b/esy-build-package/Build.re
@@ -509,7 +509,13 @@ let getEnvAndPath = build => {
 
   let env =
     switch (Bos.OS.Env.var("TERM")) {
-    | Some(term) => Astring.String.Map.add("TERM", term, build.env)
+    | Some(term) =>
+      build.env
+      |> Astring.String.Map.add("TERM", term)
+      |> Astring.String.Map.add(
+           "OPAM_SWITCH_PREFIX",
+           Path.show(build.stagePath),
+         )
     | None => build.env
     };
 


### PR DESCRIPTION
Ever since Dune started relying on `OPAM_SWITCH_PREFIX` to set `mandir`, we have many packages breaking with,

```
    Error: The mandir installation directory is unknown.                                                                                                      
    Hint: It can be specified with --prefix or by setting --mandir                                                                                            
    error: command failed: 'dune' 'install' '-p' 'reason' '--create-install-files' 'reason' (exited with 1)                                                   
```

Thanks @andreypopp for identifying this.

