### PR TITLE
CI Improvements

### DIFF
--- a/.ci/build-release.yml
+++ b/.ci/build-release.yml
@@ -52,7 +52,7 @@ jobs:
   - template: build-platform.yml
     parameters:
       platform: macOS
-      vmImage: macOS-11 # Because newer macos run solver verbosely for some reason
+      vmImage: macOS-latest
 
   - template: docker.yml
     parameters:

--- a/.ci/docker.yml
+++ b/.ci/docker.yml
@@ -51,10 +51,3 @@ jobs:
 
       - script: docker save $(esy__project_name) | gzip > $(esy__project_name)-docker-image.tar.gz
         displayName: "Save Docker image as tarball"
-
-      - task: PublishBuildArtifacts@1
-        displayName: "Upload Docker production image (as Azure artifacts)"
-        inputs:
-          PathtoPublish: "$(esy__project_name)-docker-image.tar.gz"
-          ArtifactName: AlpineLinuxDockerBuiltNPM
-


### PR DESCRIPTION
1. We can go back to using newer macos vmImage
2. We dont need to save docker image and upload as Azure Pipelines artifacts. Saves us time (and space)