### PR TITLE
Normalize paths in wrapper bin's environment

### DIFF
--- a/bin/NpmReleaseCommand.re
+++ b/bin/NpmReleaseCommand.re
@@ -258,7 +258,7 @@ let makeBinWrapper =
     {|
     let windows = Sys.os_type = "Win32";;
     let cwd = Sys.getcwd ();;
-    let path_sep = if windows then '\\' else '/';;
+    let path_sep = '/';;
     let path_sep_str = String.make 1 path_sep;;
 
     let caseInsensitiveEqual i j = String.lowercase_ascii i = String.lowercase_ascii j;;
@@ -370,7 +370,7 @@ let makeBinWrapper =
         EnvHashtbl.replace curEnvMap name value
       in
       Array.iter f env;
-      let f name value items = (name ^ "=" ^ value)::items in
+      let f name value items = (name ^ "=" ^ (normalize value))::items in
       Array.of_list (EnvHashtbl.fold f curEnvMap [])
     ;;
 


### PR DESCRIPTION
We started seeing the following error after it was necessary to export esy-zlib in esy's exportedEnv.

```
        ../../libtool: line 7502: cd:
	C:npmprefixnode_modules@esy-nightlyesy3/i/esy_zlib-8f8db659/lib:
	No such file or directory
```

Clearly, the '\' path separator was getting escaped. This broke all paths that got exported as a result of including esy-zlib in the packages to be exported along with esy binary.

This commit normalises all paths with '/' character even on Windows