### PR TITLE
NodeModuleLinker: use full file copy

### DIFF
--- a/esy-fetch/NodeModuleLinker.re
+++ b/esy-fetch/NodeModuleLinker.re
@@ -90,7 +90,7 @@ let link = (~installation, ~solution, ~projectPath, ~fetchDepsSubset) => {
   };
   let link = ((src, dest)) => {
     let* () = Fs.createDir(Path.parent(dest));
-    let* () = Fs.hardlinkPath(~src, ~dst=dest);
+    let* () = Fs.copyPath(~src, ~dst=dest);
     let* () =
       RunAsync.ofLwt @@
       Esy_logs_lwt.debug(m =>


### PR DESCRIPTION
hardlinks need more care while crafting the node_modules directory layout. This will be revisited later.