### PR TITLE
CI: No sandboxing wrapper for statically linked linux binary

### DIFF
--- a/.ci/build-platform.yml
+++ b/.ci/build-platform.yml
@@ -78,6 +78,7 @@ jobs:
           vmImage: ${{ parameters.vmImage }}
       - task: PublishBuildArtifacts@1
         displayName: "Publish Artifact: ${{ parameters.platform }}"
+        condition: ne(variables['AGENT.OS'], 'Linux')
         inputs:
           PathtoPublish: "_release"
           ArtifactName: ${{ parameters.platform }}

--- a/.ci/docker.yml
+++ b/.ci/docker.yml
@@ -37,11 +37,18 @@ jobs:
             nightly-alpine-latest
             nightly-alpine
 
+      - script: mkdir -p _container_release/lib _container_release/bin
+        displayName: make directory _container_release
+
       - script: docker container run --pull=never -itd --network=host --name esy-container esydev/esy:nightly-alpine-latest
         displayName: "Run Docker Container"
 
-      - script: docker cp esy-container:/app/_release $PWD/_container_release
-        displayName: "Copy _release from container"
+      - script: |
+          mkdir -p _container_release/lib _container_release/bin
+          docker cp esy-container:/usr/local/lib/esy/ $PWD/_container_release/lib/esy
+          docker cp esy-container:/usr/local/bin/esy $PWD/_container_release/bin
+          docker cp esy-container:/usr/local/bin/esyInstallRelease.js $PWD/_container_release/bin
+        displayName: "Copy esy artifacts from /usr/local/ in the container"
 
       - task: PublishBuildArtifacts@1
         displayName: "Publish Docker built artifact"

--- a/.ci/esy-build-steps.yml
+++ b/.ci/esy-build-steps.yml
@@ -50,9 +50,6 @@ steps:
       git archive --prefix=./esy-version/ --add-file=./esy-version/EsyVersion.re --prefix=./ --format=tgz HEAD -o source.tgz
     displayName: "Create distribution source tarball"
     condition: eq(variables['AGENT.OS'], 'Linux')
-  - script: "esy npm-release --no-env" # Wrapper doesn't contain sandbox environment. This is same as using the esy binary directly, without using npm-release command. We just use the command for convenience of package creation.
-    displayName: "Package esy for NPM"
-    condition: eq(variables['AGENT.OS'], 'Linux')
   - script: "esy npm-release"
     displayName: "Package esy for NPM"
     condition: ne(variables['AGENT.OS'], 'Linux')

--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,7 @@ opam-setup:
 
 # ideally, build-with-opam should depend on opam-setup, but opam-setup cannot be run twice. opam switch create fails when repeated
 build-with-opam:
-	opam exec -- dune build -p esy
-	opam exec -- dune build @install
+	opam exec -- dune build --only-packages=esy --profile release-static @install
 	opam exec -- dune install --prefix $(APP_ESY_INSTALL)
 
 build-with-esy:
@@ -64,6 +63,4 @@ install-esy-artifacts:
 
 docker:
 	make build-with-opam
-	make build-with-esy
-	make dune-cleanup
 	make opam-cleanup

--- a/dockerfiles/alpine.Dockerfile
+++ b/dockerfiles/alpine.Dockerfile
@@ -49,10 +49,8 @@ COPY static.esy.lock /app/static.esy.lock
 COPY ./vendors /app/vendors
 COPY ./fastreplacestring /app/fastreplacestring
 RUN make docker
-RUN make install-esy-artifacts
 
 FROM alpine:latest
 
 COPY --from=builder /usr/local /usr/local
-COPY --from=builder /app/_release /app/_release
 RUN apk add nodejs npm linux-headers curl git perl-utils bash gcc g++ musl-dev make m4 patch

--- a/esy-lib/Path.re
+++ b/esy-lib/Path.re
@@ -59,17 +59,13 @@ let currentPath = () =>
   };
 
 let exePath' = () => {
-  switch (Sys.getenv_opt("_")) {
-  | Some(p) => p
-  | None =>
-    switch (System.Platform.host) {
-    | Linux => Unix.readlink("/proc/self/exe")
-    | Darwin
-    | Cygwin
-    | Windows
-    | Unix
-    | Unknown => Sys.argv[0]
-    }
+  switch (System.Platform.host) {
+  | Linux => Unix.readlink("/proc/self/exe")
+  | Darwin
+  | Cygwin
+  | Windows
+  | Unix
+  | Unknown => Sys.argv[0]
   // TODO cross-platform solution to getting full path of the current executable.
   // Linux has /proc/self/exe. Macos ?? Windows GetModuleFileName()
   // https://stackoverflow.com/a/1024937

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,26 +1,40 @@
 var isCi = require('is-ci');
 var path = require('path');
-
+var fs = require('fs');
 var reporters = ['default'];
 
 // Perhaps a bug in Jest - but resolution fails if
 // we give it ["jest-junit"], so we'll resolve
 // the complete path directly and pass it in.
-let junitPath  = require.resolve("jest-junit");
+let junitPath = require.resolve('jest-junit');
 const isWindows = process.platform === 'win32';
 
 if (isCi) {
   reporters = reporters.concat([junitPath]);
 }
 
-var __ESY__base = path.join(__dirname, '_build', 'install', 'default', 'bin');
-var __ESY__ = path.join(__ESY__base, 'esy');
-
-if (isWindows) {
-  __ESY__ += ".exe";
+var __ESY__;
+if (process.platform !== 'linux') {
+  var __ESY__base = path.join(__dirname, '_build', 'install', 'default', 'bin');
+  __ESY__ = path.join(__ESY__base, 'esy');
+} else {
+  const testEsyPrefix = path.join(__dirname, '.test-esy');
+  if (process.platform === 'linux') {
+    fs.rmSync(testEsyPrefix, {force: true, recursive: true});
+    fs.mkdirSync(testEsyPrefix, {recursive: true});
+    fs.cpSync(path.join(__dirname, '_build', 'install', 'default'), testEsyPrefix, {
+      recursive: true,
+      dereference: true,
+    });
+  }
+  __ESY__ = path.join(testEsyPrefix, 'bin', 'esy');
 }
 
-process.env.PATH = __ESY__base + (isWindows ? ';': ':') + process.env.PATH;
+if (isWindows) {
+  __ESY__ += '.exe';
+}
+
+process.env.PATH = __ESY__base + (isWindows ? ';' : ':') + process.env.PATH;
 
 module.exports = {
   displayName: 'e2e:fast',
@@ -34,5 +48,5 @@ module.exports = {
   coverageReporters: ['text-summary', 'json', 'html', 'cobertura'],
   reporters: reporters,
   collectCoverage: isCi,
-  globals: {__ESY__: __ESY__}
+  globals: {__ESY__: __ESY__},
 };


### PR DESCRIPTION
This PR removes the binary wrapper around linux pipeline artifacts as they're not worth the trouble. The trick has outlived it's purpose now.

### Context

CI pipeline used `--no-env` for Linux pipeline and re-used most of the setup for other platforms. It was a convenient escape hatch for statically-linked artifacts while using the exisiting pipeline setup.

However, a bug in the wrapper program caused the artifacts to still be wrapped in sandbox environment. With the recent change making zlib a runtime dependency of esy, it affected LD_LIBRARY_PATH. This affected child proceses of esy (git and curl) which could not see the global environment and therefore fail with dynamic linking errors

With the fix (using execv instead of execve for --no-env), the running esy binary directly assumes the bash processes environment variables.

```
bash --(fork/exec)--> esy wrapper --(exec)--> real binary +
  |                                                       |
  +-------(exec)----+--------(exec)-----------------------+
```

This breaks how we resolve `esySolveCudfCommand` and other executables - (we resolve them relative to `$_` -> `/proc/self/exe` -> `Sys.argv`)

More importantly, --no-env has no purpose with the wrapper program. It would make the wrapper a no-op binary wrapper. 

This tells us, we have to be careful while providing sandbox environment (TODO document this)

If all the dependencies of esy are not present in the sandbox (git and curl are not), then things may not work reliably. We saw this when we were using esy release ourselves the wrapped esy, curl spawned by esy needed `musl`  library but was of course not available in the environment (because we didn't package it). It looks as if --no-env is not the best trick to be able to use the existing pipeline infrastructure at the same time ship static binaries.

All this could be real pain points for users coming on to Reason/OCaml and not being familiar with native compilation and devops associated. esy should ideally provide better guidelines and framework for CI setups
