### PR TITLE
CI: restore e2e tests task on macos

### DIFF
--- a/.ci/esy-build-steps.yml
+++ b/.ci/esy-build-steps.yml
@@ -35,7 +35,6 @@ steps:
     displayName: 'esy b dune runtest test'
   - script: 'node ./node_modules/jest-cli/bin/jest.js'
     displayName: 'esy test:e2e'
-    condition: ne(variables['AGENT.OS'], 'Darwin')
   - script: 'npm install'
     workingDirectory: './test-e2e-re/lib/verdaccio/'
     continueOnError: true


### PR DESCRIPTION
We have temporarily disabled these tests because nightly pipeline was broken and needed commits in a certain order. See #1540  for more details why. This PR restore macos tests on the CI