### PR TITLE
CI: Organise docker commands as scripts

### DIFF
--- a/.ci/docker.yml
+++ b/.ci/docker.yml
@@ -26,6 +26,18 @@ jobs:
           echo "##vso[task.setvariable variable=esy__project_version]$ESY__PROJECT_VERSION"
 
       - task: Docker@2
+        displayName: 'Build esydev/esy-builder:nightly-alpine-latest'
+        inputs:
+          containerRegistry: 'Docker Esy (nightly)'
+          repository: 'esydev/esy-builder'
+          command: "build"
+          buildContext: '.'
+          Dockerfile: 'dockerfiles/alpine.dev.Dockerfile'
+          tags: |
+            nightly-alpine-latest
+            nightly-alpine
+
+      - task: Docker@2
         displayName: 'Push esydev/esy:nightly-alpine-latest to Docker Hub'
         inputs:
           containerRegistry: 'Docker Esy (nightly)'
@@ -37,17 +49,9 @@ jobs:
             nightly-alpine-latest
             nightly-alpine
 
-      - script: mkdir -p _container_release/lib _container_release/bin
-        displayName: make directory _container_release
-
-      - script: docker container run --pull=never -itd --network=host --name esy-container esydev/esy:nightly-alpine-latest
-        displayName: "Run Docker Container"
-
       - script: |
-          mkdir -p _container_release/lib _container_release/bin
-          docker cp esy-container:/usr/local/lib/esy/ $PWD/_container_release/lib/esy
-          docker cp esy-container:/usr/local/bin/esy $PWD/_container_release/bin
-          docker cp esy-container:/usr/local/bin/esyInstallRelease.js $PWD/_container_release/bin
+          ./scripts/docker.sh run-container
+          ./scripts/docker.sh cp "_container_release"
         displayName: "Copy esy artifacts from /usr/local/ in the container"
 
       - task: PublishBuildArtifacts@1

--- a/dockerfiles/alpine.Dockerfile
+++ b/dockerfiles/alpine.Dockerfile
@@ -1,14 +1,10 @@
-FROM alpine:latest as builder
+FROM esydev/esy-builder:nightly-alpine-latest as builder
 
 WORKDIR /app
-
-RUN apk add pkgconfig yarn make m4 git gcc g++ musl-dev perl perl-utils libbz2 zlib zlib-dev zlib-static autoconf automake bzip2-dev bzip2-static opam bash
-
 COPY esy.opam /app
 COPY esy.opam.locked /app
-COPY Makefile /app
-WORKDIR /app
-RUN make opam-setup
+COPY ./scripts /app/scripts
+RUN /app/scripts/opam.sh install
 
 # This section useful for debugging the image/container
 # RUN env LD_LIBRARY_PATH=/usr/lib make opam-setup SUDO=''
@@ -48,9 +44,9 @@ COPY static.json /app/static.json
 COPY static.esy.lock /app/static.esy.lock
 COPY ./vendors /app/vendors
 COPY ./fastreplacestring /app/fastreplacestring
-RUN make docker
+RUN /app/scripts/opam.sh build
+RUN /app/scripts/opam.sh install-artifacts
 
 FROM alpine:latest
-
 COPY --from=builder /usr/local /usr/local
 RUN apk add nodejs npm linux-headers curl git perl-utils bash gcc g++ musl-dev make m4 patch

--- a/dockerfiles/alpine.dev.Dockerfile
+++ b/dockerfiles/alpine.dev.Dockerfile
@@ -1,10 +1,9 @@
-FROM alpine:latest
+# Image must be named esydev/esy-builder
+FROM alpine:latest as builder
 
 RUN apk add pkgconfig yarn make m4 git gcc g++ musl-dev perl perl-utils libbz2 zlib zlib-dev zlib-static autoconf automake bzip2-dev bzip2-static opam bash
+WORKDIR /app-builder
+COPY ./scripts/opam.sh /app-builder/opam.sh
+RUN /app-builder/opam.sh init
 
-RUN mkdir -p /app
-COPY esy.opam /app
-COPY esy.opam.locked /app
-COPY Makefile /app
-WORKDIR /app
-RUN make opam-setup
+

--- a/scripts/docker.sh
+++ b/scripts/docker.sh
@@ -1,0 +1,87 @@
+#! /bin/sh
+
+del_container() {
+    IMAGE="$1"
+    TAG="$2"
+    CONTAINER_NAME="$3"
+    docker container stop "$CONTAINER_NAME" && docker container rm "$CONTAINER_NAME"
+}
+# TODO explain the differences and purpose of *-builder image.
+build_dev() {
+    IMAGE="$1"
+    TAG="$2"
+    docker build . -f ./dockerfiles/alpine.dev.Dockerfile -t "$IMAGE-builder:$TAG"
+}
+
+build() {
+    IMAGE="$1"
+    TAG="$2"
+    docker build . -f ./dockerfiles/alpine.dev.Dockerfile -t "$IMAGE-builder:$TAG"
+    docker build . -f ./dockerfiles/alpine.Dockerfile -t "$IMAGE:$TAG"
+}
+
+run_container() {
+    IMAGE="$1"
+    TAG="$2"
+    CONTAINER_NAME="$3"
+    docker container run --pull=never -itd --network=host --name "$CONTAINER_NAME" "$IMAGE:$TAG"
+}
+
+run_container_dev() {
+    IMAGE="$1"
+    TAG="$2"
+    CONTAINER_NAME="$3"
+    DEV_PATH="$4"
+    del_container "$IMAGE_NAME" "$TAG" "$CONTAINER_NAME"
+    docker container run  --pull=never -itd --network=host --name "$CONTAINER_NAME" -v "$PWD:$DEV_PATH" "$IMAGE-builder:$TAG"
+    docker exec -it -w "$DEV_PATH" "$CONTAINER_NAME" ./scripts/opam.sh install # Because the image doesn't contain opam dependencies installed. Only contains a switch
+}
+
+cp() {
+    IMAGE="$1"
+    TAG="$2"
+    CONTAINER_NAME="$3"
+    DEV_PATH="$4"
+    HOST_RELEASE_PATH="$5"
+    mkdir -p "$HOST_RELEASE_PATH/lib" "$HOST_RELEASE_PATH/bin"
+    docker exec -it -w "$DEV_PATH" "$CONTAINER_NAME" ./scripts/opam.sh build
+    docker exec -it -w "$DEV_PATH" "$CONTAINER_NAME" ./scripts/opam.sh install-artifacts
+    docker cp "$CONTAINER_NAME:/usr/local/lib/esy" "$HOST_RELEASE_PATH/lib/esy"
+    docker cp "$CONTAINER_NAME:/usr/local/bin/esy" "$HOST_RELEASE_PATH/bin"
+    docker cp "$CONTAINER_NAME:/usr/local/bin/esyInstallRelease.js" "$HOST_RELEASE_PATH/bin"
+}
+
+IMAGE_NAME="esydev/esy"
+TAG="nightly-alpine-latest"
+CONTAINER_NAME="esy-container"
+DEV_PATH="/root/app"
+
+case "$1" in
+    "build")
+	build "$IMAGE_NAME" "$TAG"
+	;;
+    "build:dev")
+	build_dev "$IMAGE_NAME" "$TAG"
+	;;
+    "run-container")
+	run_container "$IMAGE_NAME" "$TAG" "$CONTAINER_NAME"
+	;;
+    "run-container:dev")
+	run_container_dev "$IMAGE_NAME" "$TAG" "$CONTAINER_NAME" "$DEV_PATH"
+	;;
+    "cp")
+	HOST_RELEASE_PATH="$2"
+	if [ -z "$HOST_RELEASE_PATH" ]
+	then
+	    HOST_RELEASE_PATH="$PWD/_container_release"
+	fi
+	cp "$IMAGE_NAME" "$TAG" "$CONTAINER_NAME" "$DEV_PATH" "$HOST_RELEASE_PATH"
+	;;
+    "exec")
+	shift
+	docker exec -it -w "$DEV_PATH" "$CONTAINER_NAME"  $*
+	;;
+    "del-container")
+	del_container "$IMAGE_NAME" "$TAG" "$CONTAINER_NAME"
+	;;
+esac

--- a/scripts/opam.sh
+++ b/scripts/opam.sh
@@ -1,0 +1,38 @@
+#! /bin/sh
+
+init() {
+    OPAM_COMPILER_BASE_PACKAGES="$1"
+    PACKAGES="$2"
+    opam init -y --disable-sandboxing --bare
+    opam switch create esy-dev "$OPAM_COMPILER_BASE_PACKAGES$PACKAGES" -y --no-install
+}
+
+build() {
+    opam exec -- dune build --only-packages=esy --profile release-static @install
+}
+
+install_artifacts() {
+    PREFIX="$1"
+    opam exec -- dune install --prefix "$PREFIX"
+}
+
+OPAM_COMPILER_BASE_PACKAGES="--packages=ocaml-variants.4.12.0+options,ocaml-option-flambda"
+# MUSL_STATIC_PACKAGES=",ocaml-option-musl,ocaml-option-static"
+
+case "$1" in
+    "init")
+	init "$OPAM_COMPILER_BASE_PACKAGES" "$MUSL_STATIC_PACKAGES"
+	;;
+    "install")
+	opam install . --locked --deps-only -y
+	;;
+    "lock")
+	opam lock .
+	;;
+    "build")
+	build
+	;;
+    "install-artifacts")
+	install_artifacts /usr/local
+	;;
+esac


### PR DESCRIPTION
It was difficult to test and debug Docker image, static build pipeline
without convenient scripts or a documented workflow. This PR extracts
out useful commands from the CI pipeline, and commonly run commands
into scripts/docker.sh that can be used locally as well as on the CI

Developers hacking on esy can now easily produce statically linked esy locally