### PR TITLE
Fixes symlink exists error at the end of esy build

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -28,10 +28,11 @@ Easy package management for native Reason, OCaml and more
 ")
  (depends
     angstrom
-    cmdliner
-    bos 
+    (uuseg (= 14.0.0))
+    (cmdliner (= dev))
+    (bos (= dev))
     (cudf (= 0.9))
-    (dose3 (= 6.1))
+    (dose3 (= 7.0.0))
     (ocamlgraph (= 2.0.0))
     dune  
     fmt  

--- a/esy.opam
+++ b/esy.opam
@@ -21,10 +21,11 @@ homepage: "https://github.com/esy/esy"
 bug-reports: "https://github.com/esy/esy/issues"
 depends: [
   "angstrom"
-  "cmdliner"
-  "bos"
+  "uuseg" {= "14.0.0"}
+  "cmdliner" {= "dev"}
+  "bos" {= "dev"}
   "cudf" {= "0.9"}
-  "dose3" {= "6.1"}
+  "dose3" {= "7.0.0"}
   "ocamlgraph" {= "2.0.0"}
   "dune"
   "fmt"
@@ -69,7 +70,9 @@ build: [
 ]
 dev-repo: "git+https://github.com/esy/esy.git"
 pin-depends: [
-  ["bos.dev" "git+https://github.com/esy-ocaml/bos.git"]
+  ["camlbz2.dev" "git+https://gitlab.com/irill/camlbz2.git#588e186c"]
+  ["cmdliner.dev" "git+https://github.com/esy-ocaml/cmdliner.git#e9316bc3"]
+  ["bos.dev" "git+https://github.com/esy-ocaml/bos.git#90364d00"]
   ["cli.dev" "git+https://github.com/reasonml/reason-native.git#aec0ac68"]
   ["file-context-printer.dev" "git+https://github.com/reasonml/reason-native.git#aec0ac68"]
   ["pastel.dev" "git+https://github.com/reasonml/reason-native.git#aec0ac68"]

--- a/esy.opam.locked
+++ b/esy.opam.locked
@@ -14,121 +14,125 @@ authors: [
   "Bryan Phelps <bryphe@outrunlabs.com>"
   "Eduardo Rafael <theeduardorfs@gmail.com>"
 ]
-license: "MIT"
+license: "BSD-2-Clause"
 homepage: "https://github.com/esy/esy"
 bug-reports: "https://github.com/esy/esy/issues"
 depends: [
   "angstrom" {= "0.15.0"}
   "astring" {= "0.8.5"}
-  "base" {= "v0.15.1"}
+  "base" {= "v0.14.3"}
   "base-bigarray" {= "base"}
   "base-bytes" {= "base"}
   "base-threads" {= "base"}
   "base-unix" {= "base"}
   "base64" {= "3.5.1"}
-  "bigstringaf" {= "0.9.1"}
-  "bos" {= "0.2.1"}
-  "camlbz2" {= "0.7.0"}
-  "camlzip" {= "1.11"}
-  "cmdliner" {= "1.2.0"}
-  "conf-aclocal" {= "2"}
-  "conf-autoconf" {= "0.1"}
-  "conf-automake" {= "1"}
-  "conf-libbz2" {= "1"}
-  "conf-pkg-config" {= "2"}
-  "conf-which" {= "1"}
-  "conf-zlib" {= "1"}
+  "bigstringaf" {= "0.9.0"}
+  "bos" {= "dev"}
+  "camomile" {= "1.0.2"}
+  "charInfo_width" {= "1.1.0"}
+  "cmdliner" {= "dev"}
+  "conf-pkg-config" {= "3"}
   "cppo" {= "1.6.9"}
-  "csexp" {= "1.5.2"}
-  "cudf" {= "0.10"}
-  "dose3" {= "6.1"}
-  "dune" {= "3.7.1"}
-  "dune-configurator" {= "3.7.1"}
-  "extlib" {= "1.7.9"}
+  "csexp" {= "1.5.1"}
+  "cudf" {= "0.9"}
+  "dose3" {= "7.0.0"}
+  "dune" {= "2.9.3"}
+  "dune-build-info" {= "2.9.3"}
+  "dune-configurator" {= "2.9.3"}
+  "extlib" {= "1.7.8"}
   "fix" {= "20230505"}
   "fmt" {= "0.9.0"}
   "fpath" {= "0.7.3"}
-  "jane-street-headers" {= "v0.15.0"}
-  "jst-config" {= "v0.15.1"}
+  "jane-street-headers" {= "v0.14.0"}
+  "jst-config" {= "v0.14.1"}
   "junit" {= "2.0.2"}
-  "lambda-term" {= "3.3.1"}
+  "lambda-term" {= "3.2.0"}
   "logs" {= "0.7.0"}
-  "lwt" {= "5.6.1"}
+  "lwt" {= "5.7.0"}
+  "lwt_log" {= "1.1.2"}
   "lwt_ppx" {= "2.1.0"}
   "lwt_react" {= "1.2.0"}
-  "mccs" {= "1.1+14"}
+  "mccs" {= "1.1+16"}
   "menhir" {= "20210419"}
   "menhirLib" {= "20210419"}
   "menhirSdk" {= "20210419"}
   "merlin-extend" {= "0.6.1"}
   "mew" {= "0.1.0"}
   "mew_vi" {= "0.5.0"}
+  "mtime" {= "2.0.0"}
   "ocaml" {= "4.12.0"}
   "ocaml-compiler-libs" {= "v0.12.4"}
   "ocaml-config" {= "2"}
+  "ocaml-migrate-parsetree" {= "2.4.0"}
   "ocaml-option-flambda" {= "1"}
   "ocaml-syntax-shims" {= "1.0.0"}
   "ocaml-variants" {= "4.12.0+options"}
+  "ocaml-version" {= "3.5.0"}
   "ocamlbuild" {= "0.14.2"}
   "ocamlfind" {= "1.9.6"}
+  "ocamlformat" {= "0.18.0"}
   "ocamlgraph" {= "2.0.0"}
   "ocplib-endian" {= "1.2"}
-  "opam-core" {= "2.1.4"}
+  "octavius" {= "1.2.2"}
+  "odoc" {= "1.5.3"}
+  "opam-core" {= "2.1.5"}
   "opam-file-format" {= "2.1.6"}
-  "opam-format" {= "2.1.4"}
-  "opam-repository" {= "2.1.4"}
-  "opam-state" {= "2.1.4"}
-  "parmap" {= "1.2.5"}
-  "ppx_assert" {= "v0.15.0"}
-  "ppx_base" {= "v0.15.0"}
-  "ppx_cold" {= "v0.15.0"}
-  "ppx_compare" {= "v0.15.0"}
+  "opam-format" {= "2.1.5"}
+  "opam-repository" {= "2.1.5"}
+  "opam-state" {= "2.1.5"}
+  "ppx_assert" {= "v0.14.0"}
+  "ppx_base" {= "v0.14.0"}
+  "ppx_cold" {= "v0.14.0"}
+  "ppx_compare" {= "v0.14.0"}
   "ppx_derivers" {= "1.2.1"}
   "ppx_deriving" {= "5.2.1"}
-  "ppx_deriving_yojson" {= "3.7.0"}
-  "ppx_enumerate" {= "v0.15.0"}
-  "ppx_expect" {= "v0.15.1"}
-  "ppx_hash" {= "v0.15.0"}
-  "ppx_here" {= "v0.15.0"}
-  "ppx_inline_test" {= "v0.15.1"}
-  "ppx_let" {= "v0.15.0"}
-  "ppx_optcomp" {= "v0.15.0"}
-  "ppx_sexp_conv" {= "v0.15.1"}
-  "ppxlib" {= "0.29.1"}
+  "ppx_deriving_yojson" {= "3.6.1"}
+  "ppx_enumerate" {= "v0.14.0"}
+  "ppx_expect" {= "v0.14.2"}
+  "ppx_hash" {= "v0.14.0"}
+  "ppx_here" {= "v0.14.0"}
+  "ppx_inline_test" {= "v0.14.1"}
+  "ppx_js_style" {= "v0.14.1"}
+  "ppx_let" {= "v0.14.0"}
+  "ppx_optcomp" {= "v0.14.3"}
+  "ppx_sexp_conv" {= "v0.14.3"}
+  "ppxlib" {= "0.22.2"}
   "ptime" {= "1.1.0"}
-  "re" {= "1.10.4"}
+  "re" {= "1.11.0"}
   "react" {= "1.2.2"}
   "reason" {= "3.8.2"}
   "result" {= "1.5"}
   "rresult" {= "0.7.0"}
   "seq" {= "base"}
-  "sexplib0" {= "v0.15.1"}
-  "stdio" {= "v0.15.0"}
+  "sexplib0" {= "v0.14.0"}
+  "stdio" {= "v0.14.0"}
   "stdlib-shims" {= "0.3.0"}
-  "time_now" {= "v0.15.0"}
+  "time_now" {= "v0.14.0"}
   "topkg" {= "1.0.7"}
   "trie" {= "1.0.0"}
-  "tyxml" {= "4.5.0"}
-  "uchar" {= "0.0.2"}
+  "tyxml" {= "4.6.0"}
   "uucp" {= "14.0.0"}
   "uuseg" {= "14.0.0"}
   "uutf" {= "1.0.3"}
-  "yojson" {= "2.1.0"}
-  "zed" {= "3.2.1"}
+  "yojson" {= "2.1.2"}
+  "zed" {= "3.1.0"}
 ]
 build: [
-  "dune"
-  "build"
-  "-p"
-  name
-  "-j"
-  jobs
-  "@install"
-  "@runtest" {with-test}
-  "@doc" {with-doc}
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
 ]
 dev-repo: "git+https://github.com/esy/esy.git"
 pin-depends: [
-  "cmdliner.1.2.0"
-  "https://erratique.ch/software/cmdliner/releases/cmdliner-1.2.0.tbz"
+  ["bos.dev" "git+https://github.com/esy-ocaml/bos.git#90364d00"]
+  ["cmdliner.dev" "git+https://github.com/esy-ocaml/cmdliner.git#e9316bc3"]
 ]

--- a/esy.opam.template
+++ b/esy.opam.template
@@ -1,5 +1,7 @@
 pin-depends: [
-  ["bos.dev" "git+https://github.com/esy-ocaml/bos.git"]
+  ["camlbz2.dev" "git+https://gitlab.com/irill/camlbz2.git#588e186c"]
+  ["cmdliner.dev" "git+https://github.com/esy-ocaml/cmdliner.git#e9316bc3"]
+  ["bos.dev" "git+https://github.com/esy-ocaml/bos.git#90364d00"]
   ["cli.dev" "git+https://github.com/reasonml/reason-native.git#aec0ac68"]
   ["file-context-printer.dev" "git+https://github.com/reasonml/reason-native.git#aec0ac68"]
   ["pastel.dev" "git+https://github.com/reasonml/reason-native.git#aec0ac68"]


### PR DESCRIPTION
This was because we don't pin bos to our fork in the opam manifest. Our fork contains all the fixes we need for esy to run on Windows etc which may or may not make sense to upstream

Fixes,
```
error: symlink /home/username/development/esy/esy/_esy/default/store/b/esy-30229c90 -> /home/username/development/esy/esy/_esy/default/build: File exists
 
esy: exiting due to errors above
```