### PR TITLE
opam setup: Fix missing pin-depends needed for non-release dune profile

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -41,6 +41,10 @@ Easy package management for native Reason, OCaml and more
     logs  
     lwt  
     reason
+    (rely (= dev))
+    (cli (= dev))
+    (pastel (= dev))
+    (file-context-printer (= dev))
     lwt_ppx
     junit
     (menhir (= 20210419)) 

--- a/esy.opam
+++ b/esy.opam
@@ -34,6 +34,10 @@ depends: [
   "logs"
   "lwt"
   "reason"
+  "rely" {= "dev"}
+  "cli" {= "dev"}
+  "pastel" {= "dev"}
+  "file-context-printer" {= "dev"}
   "lwt_ppx"
   "junit"
   "menhir" {= "20210419"}

--- a/esy.opam.locked
+++ b/esy.opam.locked
@@ -101,6 +101,10 @@ depends: [
   "re" {= "1.11.0"}
   "react" {= "1.2.2"}
   "reason" {= "3.8.2"}
+  "rely" {= "dev"}
+  "cli" {= "dev"}
+  "pastel" {= "dev"}
+  "file-context-printer" {= "dev"}
   "result" {= "1.5"}
   "rresult" {= "0.7.0"}
   "seq" {= "base"}
@@ -133,6 +137,11 @@ build: [
 ]
 dev-repo: "git+https://github.com/esy/esy.git"
 pin-depends: [
-  ["bos.dev" "git+https://github.com/esy-ocaml/bos.git#90364d00"]
+  ["camlbz2.dev" "git+https://gitlab.com/irill/camlbz2.git#588e186c"]
   ["cmdliner.dev" "git+https://github.com/esy-ocaml/cmdliner.git#e9316bc3"]
+  ["bos.dev" "git+https://github.com/esy-ocaml/bos.git#90364d00"]
+  ["cli.dev" "git+https://github.com/reasonml/reason-native.git#aec0ac68"]
+  ["file-context-printer.dev" "git+https://github.com/reasonml/reason-native.git#aec0ac68"]
+  ["pastel.dev" "git+https://github.com/reasonml/reason-native.git#aec0ac68"]
+  ["rely.dev" "git+https://github.com/reasonml/reason-native.git#aec0ac68"]
 ]


### PR DESCRIPTION
These dependencies are needed for non-release dune profiles