### PR TITLE
Revert "Internal: System.Platform.Windows -> Windows_mingw"

### DIFF
--- a/.ci/utils/use-esy.yml
+++ b/.ci/utils/use-esy.yml
@@ -1,7 +1,7 @@
 # steps to install esy globally
 
 steps:
-- script: "yarn global add @esy-nightly/esy"
+- script: "yarn global add esy"
   displayName: "Install esy (via yarn)"
   condition: ne(variables['AGENT.OS'], 'Windows_NT')
   
@@ -16,7 +16,7 @@ steps:
   displayName: "Ensure yarn install global tools are available on $PATH"
   condition: ne(variables['AGENT.OS'], 'Windows_NT')
 - script: |
-    npm i -g @esy-nightly/esy
+    npm i -g esy
   displayName: "Install esy (via npm)"
   condition: eq(variables['AGENT.OS'], 'Windows_NT')
 

--- a/bin/NpmReleaseCommand.re
+++ b/bin/NpmReleaseCommand.re
@@ -682,7 +682,7 @@ let make =
           ) /* Needs to have ocaml in environment */;
         let* env =
           switch (System.Platform.host) {
-          | Windows_mingw =>
+          | Windows =>
             let currentPath = Sys.getenv("PATH");
             let userPath = EsyBash.getBinPath();
             let normalizedOcamlPath =
@@ -707,7 +707,7 @@ let make =
       let (origPrefix, destPrefix) = {
         let destPrefix =
           switch (releaseCfg.rewritePrefix, System.Platform.host) {
-          | (Rewrite, Windows_mingw) =>
+          | (Rewrite, Windows) =>
             /* Keep the slashes segments in the path.  It's important for doing
              * replacement of double backslashes in artifacts.  */
             String.split_on_char('\\', cfg.storePath |> Path.show)
@@ -774,7 +774,7 @@ let make =
                 let f = ((publicName, _innerName)) => {
                   let binName =
                     switch (System.Platform.host) {
-                    | Windows_mingw =>
+                    | Windows =>
                       if (Path.hasExt("exe", Path.v(publicName))) {
                         publicName;
                       } else {

--- a/bin/Project.re
+++ b/bin/Project.re
@@ -472,12 +472,12 @@ let writeAuxCache = proj => {
     let writeCommandExec = binPath => {
       let filename =
         switch (System.Platform.host) {
-        | Windows_mingw => "command-exec.bat"
+        | Windows => "command-exec.bat"
         | _ => "command-exec"
         };
       let data =
         switch (System.Platform.host) {
-        | Windows_mingw =>
+        | Windows =>
           Format.asprintf(
             "@ECHO OFF\r\n@SETLOCAL\r\n\"%a\" exec-command --include-npm-bin --include-current-env --include-build-env --project \"%a\" %%*\r\n",
             Path.pp,

--- a/esy-build-package/Build.re
+++ b/esy-build-package/Build.re
@@ -18,7 +18,7 @@ let exePath = () => {
   | Linux => Unix.readlink("/proc/self/exe")
   | Darwin
   | Cygwin
-  | Windows_mingw
+  | Windows
   | Unix
   | Unknown => Sys.argv[0]
   // TODO cross-platform solution to getting full path of the current executable.

--- a/esy-build-package/Install.re
+++ b/esy-build-package/Install.re
@@ -8,7 +8,7 @@ let shouldTryAddExeIfNotExist =
     Sys.getenv_opt("ESY_INSTALLER__FORCE_EXE"),
     EsyLib.System.Platform.host,
   ) {
-  | (None | Some("false"), Windows_mingw) => true
+  | (None | Some("false"), Windows) => true
   | (None | Some("false"), Linux | Darwin | Unix | Cygwin) => false
   | (None | Some("false"), Unknown) => true /* won't make it worse, I guess */
   | (Some(_), _) => true
@@ -67,7 +67,7 @@ let installFile =
       let* () =
         if (enableLinkingOptimization && origPerm == perm) {
           switch (EsyLib.System.Platform.host) {
-          | Windows_mingw => Run.link(~force=true, ~target=srcPath, dstPath)
+          | Windows => Run.link(~force=true, ~target=srcPath, dstPath)
           | _ => Run.symlink(~force=true, ~target=srcPath, dstPath)
           };
         } else {

--- a/esy-build-package/Run.re
+++ b/esy-build-package/Run.re
@@ -64,8 +64,7 @@ let rm = path =>
     Bos.OS.Path.delete(~must_exist=false, ~recurse=true, path)
   | Ok({Unix.st_kind: S_LNK, _}) =>
     switch (System.Platform.host) {
-    | Windows_mingw =>
-      Bos.OS.Path.delete(~must_exist=false, ~recurse=true, path)
+    | Windows => Bos.OS.Path.delete(~must_exist=false, ~recurse=true, path)
     | _ =>
       switch (Bos.OS.U.unlink(path)) {
       | Ok () => ok
@@ -110,7 +109,7 @@ let symlink = (~force=?, ~target, dest) => {
      */
   (
     switch (System.Platform.host) {
-    | Windows_mingw =>
+    | Windows =>
       let errorRegex =
         Str.regexp(".*?The operation completed successfully.*?");
       switch (result) {

--- a/esy-build-package/Sandbox.re
+++ b/esy-build-package/Sandbox.re
@@ -131,7 +131,7 @@ let init = (config: config, ~noSandbox) =>
     NoSandbox.sandboxExec(config);
   } else {
     switch (EsyLib.System.Platform.host) {
-    | Windows_mingw => Windows.sandboxExec(config)
+    | Windows => Windows.sandboxExec(config)
     | Darwin => Darwin.sandboxExec(config)
     | _ => NoSandbox.sandboxExec(config)
     };

--- a/esy-build-package/bin/esyRewritePrefixCommand.re
+++ b/esy-build-package/bin/esyRewritePrefixCommand.re
@@ -10,7 +10,7 @@ let rewritePrefixInFile' = (~origPrefix, ~destPrefix, path) =>
 let rewritePrefixesInFile = (~origPrefix, ~destPrefix, path) => {
   Result.Syntax.(
     switch (System.Platform.host) {
-    | Windows_mingw =>
+    | Windows =>
       let* _ =
         Result.List.map(
           ~f=

--- a/esy-build/BuildSandbox.re
+++ b/esy-build/BuildSandbox.re
@@ -1025,7 +1025,7 @@ let exec =
     let env = Scope.SandboxEnvironment.render(sandbox.cfg, env);
 
     switch (System.Platform.host) {
-    | System.Platform.Windows_mingw =>
+    | System.Platform.Windows =>
       /*
        * `esy-bash` takes an optional `--env` parameter with the
        * environment variables that should be used for the bash session.
@@ -1229,7 +1229,7 @@ let buildTask =
       Solution.isRoot(sandbox.solution, task.pkg),
       System.Platform.host,
     ) {
-    | (_, System.Platform.Windows_mingw) => return()
+    | (_, System.Platform.Windows) => return()
     | (true, _) => makeSymlinksToStore(sandbox, task)
     | (false, _) => return()
     };
@@ -1512,7 +1512,7 @@ let exportBuild = (cfg, ~outputPrefixPath, buildPath) => {
       Fs.readFile(Path.(buildPath / "_esy" / "storePrefix"));
     let nextStorePrefix =
       switch (System.Platform.host) {
-      | Windows_mingw =>
+      | Windows =>
         /* Keep the slashes segments in the path.  It's important for doing
          * replacement of double backslashes in artifacts.  */
         String.split_on_char('\\', prevStorePrefix)

--- a/esy-build/Scope.re
+++ b/esy-build/Scope.re
@@ -401,10 +401,10 @@ let make =
     finalEnv: {
       let defaultPath =
         switch (platform, globalPathVariable) {
-        | (Windows_mingw, Some(pathVar)) =>
+        | (Windows, Some(pathVar)) =>
           let esyGlobalPath = Sys.getenv(pathVar);
           "$PATH;" ++ esyGlobalPath;
-        | (Windows_mingw, None) =>
+        | (Windows, None) =>
           let windir = Sys.getenv("WINDIR") ++ "/System32";
           let windir = Path.normalizePathSepOfFilename(windir);
           "$PATH;/usr/local/bin;/usr/bin;/bin;/usr/sbin;/sbin;" ++ windir;
@@ -502,7 +502,7 @@ let render =
     | System.Platform.Darwin
     | System.Platform.Linux
     | System.Platform.Unix
-    | System.Platform.Windows_mingw
+    | System.Platform.Windows
     | System.Platform.Cygwin => "/"
     };
 
@@ -732,7 +732,7 @@ let toOpamEnv = (~buildIsInProgress, scope: t, name: OpamVariable.Full.t) => {
     | System.Platform.Darwin => "macos"
     | System.Platform.Linux => "linux"
     | System.Platform.Cygwin => "cygwin"
-    | System.Platform.Windows_mingw => "win32"
+    | System.Platform.Windows => "win32"
     | System.Platform.Unix => "unix"
     | System.Platform.Unknown => "unknown"
     };

--- a/esy-fetch/Js.re
+++ b/esy-fetch/Js.re
@@ -34,7 +34,7 @@ module LinkBin: {
   let installNodeBinWrapper = (destBinWrapperDir, (name, origPath)) => {
     let (data, binWrapperPath) =
       switch (System.Platform.host) {
-      | Windows_mingw =>
+      | Windows =>
         let data =
           Format.asprintf(
             {|@ECHO off
@@ -107,7 +107,7 @@ module LinkBin: {
         installNodeBinWrapper(destBinWrapperDir, (name, origPath));
       } else {
         switch (System.Platform.host) {
-        | Windows_mingw =>
+        | Windows =>
           installBinWrapperAsBatch(destBinWrapperDir, (name, origPath))
         | _ =>
           installBinWrapperAsSymlink(destBinWrapperDir, (name, origPath))
@@ -153,7 +153,7 @@ let installNodeWrapper = (~binPath, ~pnpJsPath, ()) =>
 
       let* () =
         switch (System.Platform.host) {
-        | Windows_mingw =>
+        | Windows =>
           let data =
             Format.asprintf(
               {|@ECHO off
@@ -217,7 +217,7 @@ module Lifecycle = {
     try%lwt({
       let installationPath =
         switch (System.Platform.host) {
-        | Windows_mingw => Path.show(sourcePath)
+        | Windows => Path.show(sourcePath)
         | _ => Filename.quote(Path.show(sourcePath))
         };
 
@@ -225,7 +225,7 @@ module Lifecycle = {
       /* We'll add the /d flag to allow switching drives - */
       let changeDirCommand =
         switch (System.Platform.host) {
-        | Windows_mingw => "/d"
+        | Windows => "/d"
         | _ => ""
         };
 
@@ -239,7 +239,7 @@ module Lifecycle = {
 
       let cmd =
         switch (System.Platform.host) {
-        | Windows_mingw => ("", [|"cmd.exe", "/c " ++ script|])
+        | Windows => ("", [|"cmd.exe", "/c " ++ script|])
         | _ => ("/bin/bash", [|"/bin/bash", "-c", script|])
         };
 

--- a/esy-lib/Checksum.re
+++ b/esy-lib/Checksum.re
@@ -57,7 +57,7 @@ let md5sum =
   | System.Platform.Darwin => Cmd.(v("md5") % "-q")
   | System.Platform.Linux
   | System.Platform.Cygwin
-  | System.Platform.Windows_mingw
+  | System.Platform.Windows
   | System.Platform.Unknown => Cmd.(v("md5sum"))
   };
 let sha1sum = Cmd.(v("shasum") % "--algorithm" % "1");

--- a/esy-lib/Cmd.re
+++ b/esy-lib/Cmd.re
@@ -49,7 +49,7 @@ let getToolAndLine = ((tool, args)) => {
   /* On Windows, we need the tool to be the empty string to use path resolution */
   /* More info here: http://ocsigen.org/lwt/3.2.1/api/Lwt_process */
   switch (System.Platform.host) {
-  | Windows_mingw => ("", Array.of_list([tool, ...args]))
+  | Windows => ("", Array.of_list([tool, ...args]))
   | _ => (tool, Array.of_list([tool, ...args]))
   };
 };
@@ -89,13 +89,13 @@ let isExecutable = (stats: Unix.stats) => {
  */
 let getAdditionalResolvePaths = path =>
   switch (System.Platform.host) {
-  | Windows_mingw => path @ ["/bin", "/usr/bin"]
+  | Windows => path @ ["/bin", "/usr/bin"]
   | _ => path
   };
 
 let getPotentialExtensions =
   switch (System.Platform.host) {
-  | Windows_mingw =>
+  | Windows =>
     /* TODO(andreypopp): Consider using PATHEXT env variable here. */
     ["", ".exe", ".cmd"]
   | _ => [""]
@@ -107,7 +107,7 @@ let checkIfExecutable = path =>
     /* Windows has a different file policy model than Unix - matching with the Unix permissions won't work */
     /* In particular, the Unix.stat implementation emulates this on Windows by checking the extension for `exe`/`com`/`cmd`/`bat` */
     /* But in our case, since we're deferring to the Cygwin layer, it's possible to have executables that don't confirm to that rule */
-    | Windows_mingw =>
+    | Windows =>
       let* exists = Bos.OS.Path.exists(path);
       switch (exists) {
       | true => Ok(Some(path))

--- a/esy-lib/Environment.re
+++ b/esy-lib/Environment.re
@@ -215,7 +215,7 @@ module Make =
         let name = String.sub(item, 0, idx);
         let name =
           switch (System.Platform.host) {
-          | System.Platform.Windows_mingw => String.uppercase_ascii(name)
+          | System.Platform.Windows => String.uppercase_ascii(name)
           | _ => name
           };
 

--- a/esy-lib/EsyBash.re
+++ b/esy-lib/EsyBash.re
@@ -47,7 +47,7 @@ let getMingwRuntimePath = () => {
 */
 let normalizePathForCygwin = path =>
   switch (System.Platform.host) {
-  | System.Platform.Windows_mingw =>
+  | System.Platform.Windows =>
     let rootPath = getCygPath();
     let binary = Fpath.to_string(rootPath);
     let ic = Unix.open_process_args_in(binary, [|binary, path|]);
@@ -65,7 +65,7 @@ let toEsyBashCommand = (~env=None, cmd) => {
     };
 
   switch (System.Platform.host) {
-  | Windows_mingw =>
+  | Windows =>
     let commands = Bos.Cmd.to_list(cmd);
     let esyBashPath = getEsyBashPath();
     let allCommands = List.append(environmentFilePath, commands);
@@ -81,7 +81,7 @@ let toEsyBashCommand = (~env=None, cmd) => {
 */
 let normalizePathForWindows = (path: Fpath.t) =>
   switch (System.Platform.host) {
-  | System.Platform.Windows_mingw =>
+  | System.Platform.Windows =>
     let pathAsString = Fpath.to_string(path);
     switch (pathAsString.[0]) {
     /* We assume that if the path coming in to normalize is a leading slash,
@@ -111,7 +111,7 @@ let normalizePathForWindows = (path: Fpath.t) =>
 let currentEnvWithMingwInPath = {
   let current = System.Environment.current;
   switch (System.Platform.host) {
-  | System.Platform.Windows_mingw =>
+  | System.Platform.Windows =>
     let mingw = getMingwRuntimePath();
     let path = [Path.show(mingw), ...System.Environment.path];
     StringMap.add("PATH", System.Environment.join(path), current);

--- a/esy-lib/Fs.re
+++ b/esy-lib/Fs.re
@@ -277,7 +277,7 @@ let traverse = (~skipTraverse=?, ~f, path) => {
 
 let copyStatLwt = (~stat, path) =>
   switch (System.Platform.host) {
-  | Windows_mingw => Lwt.return() /* copying these stats is not necessary on Windows, and can cause Permission Denied errors */
+  | Windows => Lwt.return() /* copying these stats is not necessary on Windows, and can cause Permission Denied errors */
   | _ =>
     let path = Path.show(path);
     let%lwt () =

--- a/esy-lib/NodeResolution.re
+++ b/esy-lib/NodeResolution.re
@@ -84,7 +84,7 @@ let rec realpath = (p: Fpath.t) => {
   let p =
     // on win we can get path swith \??\ prefix, remove it
     switch (System.Platform.host) {
-    | Windows_mingw =>
+    | Windows =>
       let p = Path.show(p);
       let len = String.length(p);
       if (len >= 4 && String.sub(p, 0, 4) == "\\??\\") {

--- a/esy-lib/Path.re
+++ b/esy-lib/Path.re
@@ -39,14 +39,14 @@ let homePath = () =>
   Fpath.v(
     switch (Sys.getenv_opt("HOME"), System.Platform.host) {
     | (Some(dir), _) => dir
-    | (None, System.Platform.Windows_mingw) => Sys.getenv("USERPROFILE")
+    | (None, System.Platform.Windows) => Sys.getenv("USERPROFILE")
     | (None, _) => failwith("Could not find HOME dir")
     },
   );
 let dataPath = () =>
   Fpath.v(
     switch (System.Platform.host) {
-    | System.Platform.Windows_mingw => Sys.getenv("LOCALAPPDATA")
+    | System.Platform.Windows => Sys.getenv("LOCALAPPDATA")
     | _ => Sys.getenv("HOME")
     },
   );

--- a/esy-lib/Store.re
+++ b/esy-lib/Store.re
@@ -36,7 +36,7 @@ let getPadding =
       prefixPath,
     ) =>
   switch (system, longPaths) {
-  | (Windows_mingw, false) => Ok("_")
+  | (Windows, false) => Ok("_")
   | _ =>
     let prefixPathLength = String.length(Fpath.to_string(prefixPath));
     let paddingLength =

--- a/esy-lib/System.re
+++ b/esy-lib/System.re
@@ -4,7 +4,7 @@ module Platform = {
     | Darwin
     | Linux
     | Cygwin
-    | Windows_mingw /* Mingw. MSVC will be a separate one.*/
+    | Windows /* mingw msvc */
     | Unix /* all other unix-y systems */
     | Unknown;
 
@@ -14,7 +14,7 @@ module Platform = {
     | Linux => "linux"
     | Cygwin => "cygwin"
     | Unix => "unix"
-    | Windows_mingw => "windows-mingw"
+    | Windows => "windows"
     | Unknown => "unknown";
 
   let pp = (fmt, v) => Fmt.string(fmt, show(v));
@@ -26,7 +26,7 @@ module Platform = {
     | `String("linux") => Ok(Linux)
     | `String("cygwin") => Ok(Cygwin)
     | `String("unix") => Ok(Unix)
-    | `String("windows-mingw") => Ok(Windows_mingw)
+    | `String("windows") => Ok(Windows)
     | `String("unknown") => Ok(Unknown)
     | `String(v) => Result.errorf("unknown platform: %s", v)
     | _json => Result.error("System.Platform.t: expected string");
@@ -45,7 +45,7 @@ module Platform = {
 
     switch (Sys.os_type) {
     | "Unix" => uname()
-    | "Win32" => Windows_mingw // This could be MSVC too.
+    | "Win32" => Windows
     | "Cygwin" => Cygwin
     | _ => Unknown
     };
@@ -53,7 +53,7 @@ module Platform = {
 
   let isWindows =
     switch (host) {
-    | Windows_mingw => true
+    | Windows => true
     | _ => false
     };
 };
@@ -121,7 +121,7 @@ module Arch = {
 
     switch (Platform.host) {
     // Should be defined at session statup globally
-    | Windows_mingw => convert(Sys.getenv("PROCESSOR_ARCHITECTURE"))
+    | Windows => convert(Sys.getenv("PROCESSOR_ARCHITECTURE"))
     | _ => convert(uname())
     };
   };
@@ -156,9 +156,9 @@ module Environment = {
     switch (name, platform) {
     /* a special case for cygwin + OCAMLPATH: it is expected to use ; as separator */
     | (Some("OCAMLPATH"), Platform.Linux | Darwin | Unix | Unknown) => ":"
-    | (Some("OCAMLPATH"), Cygwin | Windows_mingw) => ";"
+    | (Some("OCAMLPATH"), Cygwin | Windows) => ";"
     | (_, Linux | Darwin | Unix | Unknown | Cygwin) => ":"
-    | (_, Windows_mingw) => ";"
+    | (_, Windows) => ";"
     };
 
   let split = (~platform=?, ~name=?, value) => {
@@ -177,7 +177,7 @@ module Environment = {
       let name = String.sub(item, 0, idx);
       let name =
         switch (Platform.host) {
-        | Platform.Windows_mingw => String.uppercase_ascii(name)
+        | Platform.Windows => String.uppercase_ascii(name)
         | _ => name
         };
 

--- a/esy-lib/System.rei
+++ b/esy-lib/System.rei
@@ -12,7 +12,7 @@ module Platform: {
     | Darwin
     | Linux
     | Cygwin
-    | Windows_mingw
+    | Windows
     | Unix
     | Unknown;
 

--- a/esy-runtime/EsyRuntime.re
+++ b/esy-runtime/EsyRuntime.re
@@ -11,7 +11,7 @@ let detect_concurrency_from_env = () => {
 
   switch (System.Platform.host) {
   /* only Win32, as cygwin will have getconf */
-  | Windows_mingw => Sys.getenv_opt("NUMBER_OF_PROCESSORS") |> to_int
+  | Windows => Sys.getenv_opt("NUMBER_OF_PROCESSORS") |> to_int
   | _ =>
     let cmd = Bos.Cmd.(v("getconf") % "_NPROCESSORS_ONLN");
     Bos.OS.Cmd.(run_out(cmd) |> to_string)
@@ -34,7 +34,7 @@ let exePath = () => {
   | Linux => Unix.readlink("/proc/self/exe")
   | Darwin
   | Cygwin
-  | Windows_mingw
+  | Windows
   | Unix
   | Unknown => Sys.argv[0]
   // TODO cross-platform solution to getting full path of the current executable.

--- a/test-e2e-re/lib/Shared.re
+++ b/test-e2e-re/lib/Shared.re
@@ -13,7 +13,7 @@ Random.self_init();
 let randBound = 20000;
 let isWindows =
   switch (System.Platform.host) {
-  | Windows_mingw => true
+  | Windows => true
   | _ => false
   };
 

--- a/test/Store.re
+++ b/test/Store.re
@@ -8,7 +8,7 @@ let%test "Validate padding length on Windows is always 1, if long paths aren't s
     getPadding(
       ~ocamlPkgName="ocaml",
       ~ocamlVersion="4.10.1000",
-      ~system=System.Platform.Windows_mingw,
+      ~system=System.Platform.Windows,
       ~longPaths=false,
       prefixPath,
     );
@@ -24,7 +24,7 @@ let%test "Validate padding length on Windows is not 1, if long paths are support
     getPadding(
       ~ocamlPkgName="ocaml",
       ~ocamlVersion="4.10.1000",
-      ~system=System.Platform.Windows_mingw,
+      ~system=System.Platform.Windows,
       ~longPaths=true,
       prefixPath,
     );


### PR DESCRIPTION
Reverts esy/esy#1578

It was meant to be an intermediate step before trying MSVC inside esy, but is too disruptive and will hold back the next release. MSVC experiements could be continued parallely, instead of blocking current development.