### PR TITLE
Multiple opam repository: add more tests

### DIFF
--- a/docs/contributing/running-tests.md
+++ b/docs/contributing/running-tests.md
@@ -26,6 +26,19 @@ These are present in `test-e2e` folder and are written in JS. They're run by `je
 yarn jest
 ```
 
+#### Note
+If you happen to commit anything, even unrelated to esy (say in the README or JS scripts), make sure to
+rebuild esy. This is because some of the tests compare the output against the latest git commit. Otherwise,
+you might see errors like,
+
+```diff
+- Expected  - 1
++ Received  + 1
+- info install 0.7.2-162-ged25563c (using package.json)
++ info install 0.7.2-163-g6ff25127 (using package.json)
+```
+
+
 ## Slow end-to-end tests
 They're present in `test-e2e-slow` and are written in JS. They're supposed to mimick the user's workflow
 as closely as possible.

--- a/site/src/pages/index.js
+++ b/site/src/pages/index.js
@@ -26,10 +26,9 @@ const TerminalController = (props = {}) => {
 };
 
 const quickStart = `npm install -g esy
-
-# Clone example, install dependencies, then build
-git clone https://github.com/esy-ocaml/hello-reason.git
-cd hello-reason
+# Clone example
+cd example
+# Install dependencies, then build
 esy`;
 function Homepage() {
   const {siteConfig} = useDocusaurusContext();

--- a/test-e2e/esy-build/errorneous-build.test.js
+++ b/test-e2e/esy-build/errorneous-build.test.js
@@ -20,7 +20,7 @@ it('Exists with a non-zero exit code if build fails', async () => {
   try {
     await p.esy('build');
   } catch (err) {
-    expect(String(err)).toEqual(expect.stringMatching('command failed'));
+    expect(String(err)).toEqual(helpers.COMMAND_FAILED);
     return;
   }
   expect(true).toBeFalsy();

--- a/test-e2e/esy-install/opam.test.js
+++ b/test-e2e/esy-install/opam.test.js
@@ -352,6 +352,16 @@ describe('installing opam dependencies from multiple registries', () => {
         await p.esy('build');
 
         {
+	  await p.esy('x foo.cmd')
+	    .then(() => Promise.reject(
+	      new Error("Running foo.cmd should have failed but didn't")
+	    ))
+	    .catch(e => {
+	        expect(String(e)).toEqual(helpers.COMMAND_NOT_FOUND);
+            });
+        }
+
+        {
             const { stdout: stdoutHello } = await p.esy('x hello.cmd');
 
             expect(stdoutHello.trim()).toEqual('__hello__');

--- a/test-e2e/test/helpers.js
+++ b/test-e2e/test/helpers.js
@@ -450,4 +450,5 @@ module.exports = {
   isWindows,
   isLinux,
   isMacos,
+  COMMAND_FAILED: expect.stringMatching('command failed')
 };

--- a/test-e2e/test/helpers.js
+++ b/test-e2e/test/helpers.js
@@ -450,5 +450,6 @@ module.exports = {
   isWindows,
   isLinux,
   isMacos,
-  COMMAND_FAILED: expect.stringMatching('command failed')
+  COMMAND_FAILED: expect.stringMatching('command failed'),
+  COMMAND_NOT_FOUND: expect.stringMatching('unable to resolve command'),
 };


### PR DESCRIPTION
Ensures that if a package is available in higher priority repository, it is never looked for in lower repositories - even if lower priority repository contains a newer version.