### PR TITLE
Completes extra-sources support all source kinds

### DIFF
--- a/esy-fetch/DistStorage.rei
+++ b/esy-fetch/DistStorage.rei
@@ -22,15 +22,7 @@ let ofCachedTarball: Path.t => fetchedDist;
 let ofDir: Path.t => fetchedDist;
 
 let fetch:
-  (
-    Config.t,
-    SandboxSpec.t,
-    Dist.t,
-    option(string),
-    option(string),
-    ~extraSources: list(ExtraSource.t)=?,
-    unit
-  ) =>
+  (Config.t, SandboxSpec.t, Dist.t, option(string), option(string), unit) =>
   RunAsync.t(fetchedDist);
 
 let unpack: (fetchedDist, Path.t) => RunAsync.t(unit);

--- a/esy-fetch/ExtraSources.re
+++ b/esy-fetch/ExtraSources.re
@@ -1,0 +1,23 @@
+open EsyPackageConfig;
+open RunAsync.Syntax;
+let fetch = (~cachedSourcesPath, ~stagePath, extraSources) => {
+  let* () = Fs.createDir(cachedSourcesPath);
+  let%bind () = Fs.createDir(stagePath);
+  RunAsync.List.mapAndWait(
+    ~f=
+      ({ExtraSource.url, checksum, relativePath}) => {
+        open RunAsync.Syntax;
+        let downloadPath = Path.(stagePath / relativePath);
+        let* _ = Curl.download(~output=downloadPath, url);
+        let* _ = Checksum.checkFile(~path=downloadPath, checksum);
+        let* _ =
+          Fs.rename(
+            ~skipIfExists=true,
+            ~src=downloadPath,
+            Path.(cachedSourcesPath / relativePath),
+          );
+        RunAsync.return();
+      },
+    extraSources,
+  );
+};

--- a/esy-fetch/FetchPackage.re
+++ b/esy-fetch/FetchPackage.re
@@ -11,13 +11,11 @@ let fetch' = (sandbox, pkg, dists, gitUsername, gitPassword) => {
   let rec fetchAny = (errs, alternatives) =>
     switch (alternatives) {
     | [dist, ...rest] =>
-      let extraSources = Package.extraSources(pkg);
       let fetched =
         DistStorage.fetch(
           sandbox.Sandbox.cfg,
           sandbox.spec,
           dist,
-          ~extraSources,
           gitUsername,
           gitPassword,
           (),
@@ -130,6 +128,12 @@ let copyFiles = (sandbox, pkg, path) => {
       pkg.Package.overrides,
     );
 
+  let extraSources = Package.extraSources(pkg);
+  let tempPath = SandboxSpec.tempPath(sandbox.spec);
+  let* () =
+    Fs.withTempDir(~tempPath, stagePath => {
+      ExtraSources.fetch(~cachedSourcesPath=path, ~stagePath, extraSources)
+    });
   RunAsync.List.mapAndWait(
     ~f=EsyPackageConfig.File.placeAt(path),
     filesOfOpam @ filesOfOverride,

--- a/esy-package-config/PackageSource.rei
+++ b/esy-package-config/PackageSource.rei
@@ -1,3 +1,9 @@
+/**
+
+   [t] represents the entries in the lock files. That's why this
+   module can be serialised to JSON.
+
+ */
 type t =
   | Link({
       path: DistPath.t,


### PR DESCRIPTION
Previously we supported it only for no-source: case With the recent policy change at the opam repository and packages moving away from `extra-files` to `extra-sources`, it's necessary to fully support it.

This PR adds complete support for `extra-sources`.