### PR TITLE
Internal: Removed unused export: checkIfZip

### DIFF
--- a/esy-lib/Tarball.rei
+++ b/esy-lib/Tarball.rei
@@ -17,5 +17,3 @@ let unpack:
 
 let create:
   (~filename: Path.t, ~outpath: string=?, Path.t) => RunAsync.t(unit);
-
-let checkIfZip: Path.t => Lwt.t(bool);


### PR DESCRIPTION
This function is exported but not used anywhere outside `Tarball.re`