### PR TITLE
Windows: enable more e2e tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,7 @@ jobs:
           source-cache-key: 20240515-1
           cache-key: ${{ hashFiles('esy.lock/index.json') }}-20240515-1
           bundle-npm-artifacts-mode: true
+          postinstall-js: .ci/release-postinstall.js
 
       - name: Create tarball
         run: tar cf npm-release.tgz ./_npm-release

--- a/test-e2e/common/ejected-command-env.test.js
+++ b/test-e2e/common/ejected-command-env.test.js
@@ -6,6 +6,12 @@ const fs = require('fs-extra');
 const {createTestSandbox, promiseExec, skipSuiteOnWindows} = require('../test/helpers');
 const fixture = require('./fixture.js');
 
+// This test is not expected to work on Windows
+// because it command-env works only with bash
+// While it's a feature that may help users
+// with MSYS2 or Cygwin, we don't have a validated
+// usecase, where a workaround is not possible.
+// See issue #301 for more details
 skipSuiteOnWindows('#301');
 
 describe('ejected command-env', () => {

--- a/test-e2e/common/scripts.test.js
+++ b/test-e2e/common/scripts.test.js
@@ -4,11 +4,12 @@ const path = require('path');
 const outdent = require('outdent');
 const os = require('os');
 
-const {skipSuiteOnWindows} = require('../test/helpers');
-
-skipSuiteOnWindows('#272');
+const {skipSuiteOnWindows, isWindows} = require('../test/helpers');
 
 const {packageJson, file, dir, createTestSandbox} = require('../test/helpers');
+
+const EOL = isWindows ? "\n": os.EOL;
+const skipOnWindows = isWindows ? it.skip : it;
 
 const fixture = [
   packageJson({
@@ -69,33 +70,33 @@ const fixture = [
   dir('foo'),
 ];
 
-it('executes scripts', async () => {
+skipOnWindows('executes scripts', async () => {
   const p = await createTestSandbox(...fixture);
   await p.esy('install');
   await p.esy('build');
 
   await expect(p.esy('cmd1')).resolves.toEqual(
-    expect.objectContaining({stdout: 'cmd1_result' + os.EOL}),
+    expect.objectContaining({stdout: 'cmd1_result' + EOL}),
   );
   await expect(p.esy('cmd2')).resolves.toEqual(
-    expect.objectContaining({stdout: 'cmd2_result' + os.EOL}),
+    expect.objectContaining({stdout: 'cmd2_result' + EOL}),
   );
   await expect(p.esy('cmd3')).resolves.toEqual(
-    expect.objectContaining({stdout: 'cmd_array_result' + os.EOL}),
+    expect.objectContaining({stdout: 'cmd_array_result' + EOL}),
   );
   await expect(p.esy('cmd4')).resolves.toEqual(
-    expect.objectContaining({stdout: 'script_exec_result' + os.EOL}),
+    expect.objectContaining({stdout: 'script_exec_result' + EOL}),
   );
   await expect(p.esy('cmd5')).resolves.toEqual(
-    expect.objectContaining({stdout: 'script_exec_result' + os.EOL}),
+    expect.objectContaining({stdout: 'script_exec_result' + EOL}),
   );
 
   await expect(p.esy('--build-concurrency 100 echo_cur_jobs')).resolves.toEqual(
-    expect.objectContaining({stdout: '50' + os.EOL}),
+    expect.objectContaining({stdout: '50' + EOL}),
   );
 
   await expect(p.esy('--build-concurrency 100 echo_self_jobs')).resolves.toEqual(
-    expect.objectContaining({stdout: '50' + os.EOL}),
+    expect.objectContaining({stdout: '50' + EOL}),
   );
 
   await expect(p.esy('b cmd1')).rejects.toThrow();
@@ -105,32 +106,32 @@ it('executes scripts', async () => {
     expect.objectContaining({stdout: 'script_exec_result\n'}),
   );
   await expect(p.esy('exec_cmd2')).resolves.toEqual(
-    expect.objectContaining({stdout: 'simple-project' + os.EOL}),
+    expect.objectContaining({stdout: 'simple-project' + EOL}),
   );
   await expect(p.esy('exec_cmd3')).resolves.toEqual(
-    expect.objectContaining({stdout: 'script_exec_result' + os.EOL}),
+    expect.objectContaining({stdout: 'script_exec_result' + EOL}),
   );
   await expect(p.esy('exec_cmd4')).resolves.toEqual(
-    expect.objectContaining({stdout: 'simple-project' + os.EOL}),
+    expect.objectContaining({stdout: 'simple-project' + EOL}),
   );
 
   await expect(p.esy('build_cmd')).resolves.toEqual(
-    expect.objectContaining({stdout: 'build_cmd_result' + os.EOL}),
+    expect.objectContaining({stdout: 'build_cmd_result' + EOL}),
   );
   await expect(p.esy('build_cmd2')).resolves.toEqual(
-    expect.objectContaining({stdout: 'simple-project' + os.EOL}),
+    expect.objectContaining({stdout: 'simple-project' + EOL}),
   );
   await expect(p.esy('build_cmd3')).resolves.toEqual(
-    expect.objectContaining({stdout: 'simple-project' + os.EOL}),
+    expect.objectContaining({stdout: 'simple-project' + EOL}),
   );
   await expect(p.esy('build_cmd4')).resolves.toEqual(
-    expect.objectContaining({stdout: 'build_cmd_result' + os.EOL}),
+    expect.objectContaining({stdout: 'build_cmd_result' + EOL}),
   );
   await expect(p.esy('build_cmd5')).resolves.toEqual(
-    expect.objectContaining({stdout: 'simple-project' + os.EOL}),
+    expect.objectContaining({stdout: 'simple-project' + EOL}),
   );
   await expect(p.esy('build_cmd6')).resolves.toEqual(
-    expect.objectContaining({stdout: 'simple-project' + os.EOL}),
+    expect.objectContaining({stdout: 'simple-project' + EOL}),
   );
 });
 
@@ -139,11 +140,11 @@ it('executes scripts even if sandbox is not built', async () => {
   await p.esy('install');
 
   await expect(p.esy('cmd1')).resolves.toEqual(
-    expect.objectContaining({stdout: 'cmd1_result' + os.EOL}),
+    expect.objectContaining({stdout: 'cmd1_result' + EOL}),
   );
 });
 
-it('does execute scripts in a non-root package scope', async () => {
+skipOnWindows('does execute scripts in a non-root package scope', async () => {
   const p = await createTestSandbox(...fixture);
   await p.esy('install');
   await p.esy('build');

--- a/test-e2e/complete/opam-sandbox.test.js
+++ b/test-e2e/complete/opam-sandbox.test.js
@@ -3,8 +3,6 @@
 const outdent = require('outdent');
 const helpers = require('../test/helpers.js');
 
-helpers.skipSuiteOnWindows();
-
 describe('complete flow for opam sandboxes', () => {
   async function createTestSandbox(...fixture) {
     const p = await helpers.createTestSandbox(...fixture);

--- a/test-e2e/complete/sandbox-overrides.test.js
+++ b/test-e2e/complete/sandbox-overrides.test.js
@@ -4,8 +4,6 @@ const outdent = require('outdent');
 const helpers = require('../test/helpers.js');
 const {file, json, dummyExecutable} = helpers;
 
-helpers.skipSuiteOnWindows("esy-solve-cudf isn't ready");
-
 describe('Sandbox overrides', function() {
   it('allows to override sandbox with dependencies', async function() {
     const p = await helpers.createTestSandbox();

--- a/test-e2e/complete/symlink-workflow.test.js
+++ b/test-e2e/complete/symlink-workflow.test.js
@@ -7,8 +7,6 @@ const helpers = require('../test/helpers');
 
 const {symlink, file, dir, packageJson, dummyExecutable} = helpers;
 
-helpers.skipSuiteOnWindows('Needs investigation');
-
 describe('Symlink workflow', () => {
   async function createTestSandbox() {
     const p = await helpers.createTestSandbox();

--- a/test-e2e/esy-build-CMD.test.js
+++ b/test-e2e/esy-build-CMD.test.js
@@ -4,9 +4,9 @@ const os = require('os');
 const path = require('path');
 
 const helpers = require('./test/helpers');
-const {packageJson, dir, file, dummyExecutable, buildCommand} = helpers;
+const {packageJson, dir, file, dummyExecutable, isWindows, buildCommand} = helpers;
 
-helpers.skipSuiteOnWindows();
+const EOL = isWindows ? '\n': os.EOL;
 
 function createPackage(p, {name, dependencies}: {name: string, dependencies?: Object}) {
   return dir(
@@ -85,7 +85,7 @@ describe(`'esy build CMD' invocation`, () => {
     await p.esy('build');
 
     await expect(p.esy('build dep.cmd')).resolves.toEqual({
-      stdout: '__dep__' + os.EOL,
+      stdout: '__dep__' + EOL,
       stderr: '',
     });
   });
@@ -96,12 +96,12 @@ describe(`'esy build CMD' invocation`, () => {
     await p.esy('build');
 
     await expect(p.esy('build -p linkedDep echo "#{self.name}"')).resolves.toEqual({
-      stdout: 'linkedDep' + os.EOL,
+      stdout: 'linkedDep' + EOL,
       stderr: '',
     });
 
     await expect(p.esy('build --package linkedDep echo "#{self.name}"')).resolves.toEqual({
-      stdout: 'linkedDep' + os.EOL,
+      stdout: 'linkedDep' + EOL,
       stderr: '',
     });
   });
@@ -112,7 +112,7 @@ describe(`'esy build CMD' invocation`, () => {
     await p.esy('build');
 
     await expect(p.esy('build devDep.cmd')).resolves.toMatchObject({
-      stdout: '__devDep__' + os.EOL,
+      stdout: '__devDep__' + EOL,
       stderr: '',
     });
   });
@@ -148,12 +148,12 @@ describe(`'esy build CMD' invocation`, () => {
     await p.esy('build');
 
     await expect(p.esy('b dep.cmd')).resolves.toEqual({
-      stdout: '__dep__' + os.EOL,
+      stdout: '__dep__' + EOL,
       stderr: '',
     });
 
     await expect(p.esy('b -p linkedDep echo "#{self.name}"')).resolves.toEqual({
-      stdout: 'linkedDep' + os.EOL,
+      stdout: 'linkedDep' + EOL,
       stderr: '',
     });
   });
@@ -163,8 +163,9 @@ describe(`'esy build CMD' invocation`, () => {
     await p.esy('install');
     await p.esy('build');
 
-    await expect(p.esy(`b bash -c 'echo $root__buildvar'`)).resolves.toEqual({
-      stdout: 'root__buildvar__value' + os.EOL,
+    const cmd = isWindows ? `b bash -c "echo $root__buildvar"`: `b bash -c 'echo $root__buildvar'`;
+    await expect(p.esy(cmd)).resolves.toEqual({
+      stdout: 'root__buildvar__value' + EOL,
       stderr: '',
     });
   });
@@ -175,10 +176,10 @@ describe(`'esy build CMD' invocation`, () => {
     await p.esy('build');
 
     // make sure exit code is preserved
-    await expect(p.esy("b bash -c 'exit 1'")).rejects.toEqual(
+    await expect(p.esy(`b bash -c "exit 1"`)).rejects.toEqual(
       expect.objectContaining({code: 1}),
     );
-    await expect(p.esy("b bash -c 'exit 7'")).rejects.toEqual(
+    await expect(p.esy(`b bash -c "exit 7"`)).rejects.toEqual(
       expect.objectContaining({code: 7}),
     );
   });
@@ -241,7 +242,7 @@ describe(`'esy build CMD' invocation ("buildDev" config at the root)`, () => {
     await p.esy('build');
 
     await expect(p.esy('build dep.cmd')).resolves.toEqual({
-      stdout: '__dep__' + os.EOL,
+      stdout: '__dep__' + EOL,
       stderr: '',
     });
   });
@@ -252,7 +253,7 @@ describe(`'esy build CMD' invocation ("buildDev" config at the root)`, () => {
     await p.esy('build');
 
     await expect(p.esy('build dep.cmd')).resolves.toEqual({
-      stdout: '__dep__' + os.EOL,
+      stdout: '__dep__' + EOL,
       stderr: '',
     });
   });
@@ -263,7 +264,7 @@ describe(`'esy build CMD' invocation ("buildDev" config at the root)`, () => {
     await p.esy('build');
 
     await expect(p.esy('build devDep.cmd')).resolves.toEqual({
-      stdout: '__devDep__' + os.EOL,
+      stdout: '__devDep__' + EOL,
       stderr: '',
     });
   });

--- a/test-e2e/esy-build-dependencies.test.js
+++ b/test-e2e/esy-build-dependencies.test.js
@@ -5,9 +5,9 @@ const fs = require('fs-extra');
 const os = require('os');
 
 const helpers = require('./test/helpers');
-const {packageJson, dir, file, dummyExecutable, buildCommand} = helpers;
+const {packageJson, dir, file, isWindows, dummyExecutable, buildCommand} = helpers;
 
-helpers.skipSuiteOnWindows();
+const EOL = isWindows ? "\n": os.EOL;
 
 describe(`'esy build-dependencies' command`, () => {
   let prevEnv = {...process.env};
@@ -74,7 +74,7 @@ describe(`'esy build-dependencies' command`, () => {
     await p.esy('build-dependencies');
     const env = await getCommandEnv(p);
     await expect(p.run('dep.cmd', env)).resolves.toEqual({
-      stdout: '__dep__' + os.EOL,
+      stdout: '__dep__' + EOL,
       stderr: '',
     });
   });
@@ -85,7 +85,7 @@ describe(`'esy build-dependencies' command`, () => {
     await p.esy('build-dependencies');
     const env = await getCommandEnv(p);
     await expect(p.run('linkedDep.cmd', env)).rejects.toMatchObject({
-      code: 127,
+      code: isWindows ? 1 : 127,
     });
   });
 
@@ -95,7 +95,7 @@ describe(`'esy build-dependencies' command`, () => {
     await p.esy('build-dependencies');
     const env = await getCommandEnv(p);
     await expect(p.run('devDep.cmd', env)).resolves.toMatchObject({
-      stdout: '__devDep__' + os.EOL,
+      stdout: '__devDep__' + EOL,
       stderr: '',
     });
   });
@@ -106,7 +106,7 @@ describe(`'esy build-dependencies' command`, () => {
     await p.esy('build-dependencies --release');
     const env = await getCommandEnv(p);
     await expect(p.run('devDep.cmd', env)).rejects.toMatchObject({
-      code: 127
+      code: isWindows ? 1 : 127
     });
   });
 
@@ -116,7 +116,7 @@ describe(`'esy build-dependencies' command`, () => {
     await p.esy('build-dependencies --all');
     const env = await getCommandEnv(p);
     await expect(p.run('linkedDep.cmd', env)).resolves.toEqual({
-      stdout: '__linkedDep__' + os.EOL,
+      stdout: '__linkedDep__' + EOL,
       stderr: '',
     });
   });

--- a/test-e2e/esy-build/has-build-time-deps.test.js
+++ b/test-e2e/esy-build/has-build-time-deps.test.js
@@ -4,8 +4,6 @@ const os = require('os');
 const outdent = require('outdent');
 const helpers = require('../test/helpers');
 
-helpers.skipSuiteOnWindows('Needs investigation');
-
 function makeFixture(p) {
   return [
     helpers.packageJson({

--- a/test-e2e/esy-build/multiple-sandbox.test.js
+++ b/test-e2e/esy-build/multiple-sandbox.test.js
@@ -4,8 +4,6 @@ const helpers = require('../test/helpers.js');
 
 const {file, dir, packageJson} = helpers;
 
-helpers.skipSuiteOnWindows();
-
 function makePackage(
   p,
   {

--- a/test-e2e/esy-build/opam-sandbox.test.js
+++ b/test-e2e/esy-build/opam-sandbox.test.js
@@ -2,8 +2,6 @@
 
 const helpers = require('../test/helpers.js');
 
-helpers.skipSuiteOnWindows();
-
 describe('build opam sandbox', () => {
   it('builds an opam sandbox with a single opam file', async () => {
     const p = await helpers.createTestSandbox();

--- a/test-e2e/esy-exec-env.test.js
+++ b/test-e2e/esy-exec-env.test.js
@@ -6,6 +6,11 @@ const fs = require('fs-extra');
 const {createTestSandbox, promiseExec, skipSuiteOnWindows} = require('./test/helpers');
 const fixture = require('./common/fixture.js');
 
+// This test is not expected to work on Windows
+// because it command-env works only with bash
+// While it's a feature that may help users
+// with MSYS2 or Cygwin, we don't have a validated
+// usecase, where a workaround is not possible.
 skipSuiteOnWindows('#301');
 
 describe('esy exec-env', () => {

--- a/test-e2e/esy-install/mutliple-sandbox.test.js
+++ b/test-e2e/esy-install/mutliple-sandbox.test.js
@@ -6,8 +6,6 @@ const helpers = require('../test/helpers.js');
 
 const {file, packageJson} = helpers;
 
-helpers.skipSuiteOnWindows();
-
 describe('projects with multiple sandboxes', function() {
   it('run installs different deps dependening on a sandbox config', async () => {
     const fixture = [

--- a/test-e2e/esy-show.test.js
+++ b/test-e2e/esy-show.test.js
@@ -7,8 +7,6 @@ const os = require('os');
 const helpers = require('./test/helpers');
 const fixture = require('./common/fixture.js');
 
-helpers.skipSuiteOnWindows();
-
 describe('esy show', () => {
   it('shows info about packages hosted on npm', async () => {
     const p = await helpers.createTestSandbox();

--- a/test-e2e/esy.test.js
+++ b/test-e2e/esy.test.js
@@ -3,8 +3,6 @@
 const helpers = require('./test/helpers');
 const {file, dir, packageJson, dummyExecutable} = helpers;
 
-helpers.skipSuiteOnWindows('Needs esyi to work');
-
 it('Build - default command', async () => {
   let p = await helpers.createTestSandbox();
 


### PR DESCRIPTION
More notes later as I explore.

### Update

#### Fixes for windows that need to be reviewed later

Because,

1. Why is it just \n and not os.EOL
2. Why does using double quotes for bash -c ... tests fix the issue?

Without ", we see
```
    root__buildvar__value': -c: line 1: unexpected EOF while looking for matching `''
```

and

```
    - Expected  - 2
    + Received  + 8

    - ObjectContaining {
    -   "code": 1,
    + Error {
    +   "cmd": "C:\\Users\\username\\development\\esy\\esy\\_build\\install\\default\\bin\\esy.exe b bash -c 'exit 1'",
    +   "code": 2,
    +   "killed": false,
    +   "signal": null,
    +   "stderr": "1': -c: line 1: unexpected EOF while looking for matching `''
    + ",
    +   "stdout": "",
      }
```

Adds notes on why ejected-command-env.test.js is skipped on Windows

#### Following tests needed no modifications in the source. 
```
esy.test.js 
esy-install/mutliple-sandbox.test.js
esy-build/multiple-sandbox.test.js
esy-build/opam-sandbox.test.js 
complete/opam-sandbox.test.js
complete/symlink-workflow.test.js
complete/sandbox-overrides.test.js
esy-show.test.js
```

#### Others
Enable with-dev-dep.test.js and fix EOL related failures.
enable and fix EOL issues in esy-build-dependencies.test.js
Fixes with-dev-dep.test.js with windir missing in
exitcode for missing command on Windows isn't 127

esy-build/has-build-time-deps.test.js is skipped on non Windows too

This commit conditionally checks for appropriate exit code
Fixes EOL issues but skips two tests in scripts.test.js
```

  ○ skipped executes scripts
  ○ skipped does execute scripts in a non-root package scope

```

Fixes cmd invocation issues in macos vs windows
