### PR TITLE
NodeModulesLinker is no longer run on source packages

### DIFF
--- a/esy-fetch/NodeModuleLinker.re
+++ b/esy-fetch/NodeModuleLinker.re
@@ -6,9 +6,9 @@ open RunAsync.Syntax;
 let getNPMChildren = (~solution, ~fetchDepsSubset, node) => {
   let f = (pkg: NodeModule.t) => {
     switch (NodeModule.version(pkg)) {
+    | Source(_)
     | Opam(_) => false
-    | Npm(_)
-    | Source(_) => true
+    | Npm(_) => true
     /*
         Allowing sources here would let us resolve to github urls for
         npm dependencies. Atleast in theory. TODO: test this


### PR DESCRIPTION
We accept =Source= packages to see if we could handle npm package hosted git/github and used directly.

While it's nice to consider such cases, they're a minority. And they need careful filtering. Something like,

```reason
    | Source(Github({manifest: Some(Esy) ...})) => true
```

Tabled for later. Tracked here: https://github.com/esy/esy/issues/1604