### PR TITLE
Fix Windows CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,8 @@ jobs:
         name: "Generate EsyVersion.re"
       - uses: esy/github-action@v2-beta.8
         with:
+          setup-esy-version: '0.7.2'
+          setup-esy-npm-package: 'esy'
           source-cache-key: 20240713-1
           cache-key: ${{ hashFiles('esy.lock/index.json') }}-20240713-1
       # TODO


### PR DESCRIPTION
Use esy 0.7.2 to address the backslash issue on Windows
```
    ../../libtool: line 7502: cd: C:hostedtoolcachewindowsesy0.7.3x643/i/esy_zlib-8f8db659/lib: No such file or directory
```