### PR TITLE
Applying opam's `available` filter

### DIFF
--- a/esy-fetch/Fetch.re
+++ b/esy-fetch/Fetch.re
@@ -1,5 +1,6 @@
 module Override = Override;
 module Overrides = Overrides;
+
 let collectPackagesOfSolution = (fetchDepsSubset, solution) => {
   let root = Solution.root(solution);
 
@@ -14,7 +15,8 @@ let collectPackagesOfSolution = (fetchDepsSubset, solution) => {
     }
   and collectDependencies = ((seen, topo), pkg) => {
     let dependencies =
-      Solution.dependenciesBySpec(solution, fetchDepsSubset, pkg);
+      Solution.dependenciesBySpec(solution, fetchDepsSubset, pkg)
+      |> List.filter(~f=OpamAvailable.eval);
     List.fold_left(~f=collect, ~init=(seen, topo), dependencies);
   };
 

--- a/esy-fetch/JsUtils.re
+++ b/esy-fetch/JsUtils.re
@@ -1,0 +1,18 @@
+/**
+   Makes sure we dont link opam packages in node_modules
+ */
+let getNPMChildren = (~solution, ~fetchDepsSubset, node) => {
+  let f = (pkg: NodeModule.t) => {
+    switch (NodeModule.version(pkg)) {
+    | Source(_)
+    | Opam(_) => false
+    | Npm(_) => true
+    /*
+        Allowing sources here would let us resolve to github urls for
+        npm dependencies. Atleast in theory. TODO: test this
+     */
+    };
+  };
+  Solution.dependenciesBySpec(solution, fetchDepsSubset, node)
+  |> List.filter(~f);
+};

--- a/esy-fetch/JsUtils.rei
+++ b/esy-fetch/JsUtils.rei
@@ -1,0 +1,5 @@
+open EsyPrimitives;
+/** Given the solution and [fetchdepssubset], fetches npm packages of a [node] in the solution graph */
+let getNPMChildren:
+  (~solution: Solution.t, ~fetchDepsSubset: FetchDepsSubset.t, Solution.pkg) =>
+  list(Package.t);

--- a/esy-fetch/NodeModuleLinker.re
+++ b/esy-fetch/NodeModuleLinker.re
@@ -1,24 +1,5 @@
 open RunAsync.Syntax;
 
-/**
-   Makes sure we dont link opam packages in node_modules
- */
-let getNPMChildren = (~solution, ~fetchDepsSubset, node) => {
-  let f = (pkg: NodeModule.t) => {
-    switch (NodeModule.version(pkg)) {
-    | Source(_)
-    | Opam(_) => false
-    | Npm(_) => true
-    /*
-        Allowing sources here would let us resolve to github urls for
-        npm dependencies. Atleast in theory. TODO: test this
-     */
-    };
-  };
-  Solution.dependenciesBySpec(solution, fetchDepsSubset, node)
-  |> List.filter(~f);
-};
-
 let installPkg = (~installation, ~nodeModulesPath, pkg) => {
   let* () =
     RunAsync.ofLwt @@
@@ -134,7 +115,7 @@ let link =
   let destBinWrapperDir /* local sandbox bin dir */ =
     SandboxSpec.binPath(sandbox.Sandbox.spec);
   let taskQueue = RunAsync.createQueue(40);
-  let traverse = getNPMChildren(~fetchDepsSubset, ~solution);
+  let traverse = JsUtils.getNPMChildren(~fetchDepsSubset, ~solution);
   let f = (promises, hoistedGraphNode) => {
     let nodeModulesPath =
       nodeModulesPathFromParent(

--- a/esy-fetch/OpamAvailable.re
+++ b/esy-fetch/OpamAvailable.re
@@ -1,0 +1,59 @@
+let parseOpamFilterString = filterString => {
+  let fakeManifest =
+    Printf.sprintf(
+      {|
+         version: "1.1"
+         opam-version: "2.0"
+         available: %s
+         |},
+      filterString,
+    );
+  let opamFile = OpamFile.OPAM.read_from_string(fakeManifest);
+  opamFile.available;
+};
+
+let evalAvailabilityFilter = filter => {
+  let env = (var: OpamVariable.Full.t) => {
+    let scope = OpamVariable.Full.scope(var);
+    let name = OpamVariable.Full.variable(var);
+    switch (scope, OpamVariable.to_string(name)) {
+    | (OpamVariable.Full.Global, "arch") =>
+      Some(OpamVariable.string(System.Arch.show(System.Arch.host)))
+    | (OpamVariable.Full.Global, "os") =>
+      // We could have avoided the following altogether if the System.Platform implementation
+      // matched opam's. TODO
+      let sys =
+        switch (System.Platform.host) {
+        | Darwin => "macos"
+        | Linux => "linux"
+        | Cygwin => "cygwin"
+        | Unix => "unix"
+        | Windows => "win32"
+        | Unknown => "unknown"
+        };
+      Some(OpamVariable.string(sys));
+    | (OpamVariable.Full.Global, _) => None
+    | (OpamVariable.Full.Package(_), _) => None
+    | (Self, _) => None
+    };
+  };
+
+  OpamFilter.eval_to_bool(~default=true, env, filter);
+};
+
+let eval = pkg => {
+  /*
+      Allowing sources here would let us resolve to github urls for
+      npm dependencies. Atleast in theory. TODO: test this
+   */
+  switch (NodeModule.version(pkg)) {
+  | Source(_)
+  | Opam(_) =>
+    switch (pkg.Package.available) {
+    | None => true
+    | Some(opamAvailabilityFilter) =>
+      parseOpamFilterString(opamAvailabilityFilter) |> evalAvailabilityFilter
+    }
+  | Npm(_) => true
+  };
+};

--- a/esy-fetch/OpamAvailable.rei
+++ b/esy-fetch/OpamAvailable.rei
@@ -1,0 +1,8 @@
+/**
+
+   Evaluates available field (cached in lock file) and determines if the package is available.
+
+   Assumes [available] is currently only an opam filter, which means this function must be a no-op on
+   NPM packages. Atleast till designed takes into account [platform] and [arch] fields in NPM manifests
+ */
+let eval : Package.t => bool;

--- a/esy-fetch/Package.re
+++ b/esy-fetch/Package.re
@@ -10,6 +10,7 @@ type t = {
   devDependencies: PackageId.Set.t,
   installConfig: InstallConfig.t,
   extraSources: list(ExtraSource.t),
+  available: option(string),
 };
 
 let compare = (a, b) => PackageId.compare(a.id, b.id);

--- a/esy-fetch/Package.rei
+++ b/esy-fetch/Package.rei
@@ -9,7 +9,8 @@ type t = {
   dependencies: PackageId.Set.t,
   devDependencies: PackageId.Set.t,
   installConfig: InstallConfig.t, /* currently only tells if pnp is enabled or not */
-  extraSources: list(ExtraSource.t) /* See opam manual */
+  extraSources: list(ExtraSource.t), /* See opam manual */
+  available: option(string),
 };
 
 let id: t => PackageId.t;

--- a/esy-fetch/SolutionLock.re
+++ b/esy-fetch/SolutionLock.re
@@ -33,7 +33,13 @@ type overrides = list(override);
 /* This is checksum of all dependencies/resolutios, used as a checksum. */
 /* Id of the root package. */
 /* Map from ids to nodes. */
-[@deriving yojson]
+[@deriving
+  yojson(
+    {
+      strict : false
+    },
+  )
+]
 type t = {
   [@key "checksum"]
   digest: string,
@@ -52,6 +58,7 @@ and node = {
   installConfig: InstallConfig.t,
   [@default []]
   extraSources: list(ExtraSource.t),
+  available: [@default None] option(string),
 };
 
 let indexFilename = "index.json";
@@ -231,6 +238,7 @@ let writePackage = (sandbox, pkg: Package.t, gitUsername, gitPassword) => {
     devDependencies: pkg.devDependencies,
     installConfig: pkg.installConfig,
     extraSources: pkg.extraSources,
+    available: pkg.available,
   });
 };
 
@@ -258,6 +266,7 @@ let readPackage = (sandbox, node: node) => {
     devDependencies: node.devDependencies,
     installConfig: node.installConfig,
     extraSources: node.extraSources,
+    available: node.available,
   });
 };
 

--- a/esy-package-config/InstallManifest.re
+++ b/esy-package-config/InstallManifest.re
@@ -150,6 +150,7 @@ type t = {
   kind,
   installConfig: InstallConfig.t,
   extraSources: list(ExtraSource.t),
+  available: option(string),
 }
 and kind =
   | Esy

--- a/esy-package-config/InstallManifest.rei
+++ b/esy-package-config/InstallManifest.rei
@@ -43,6 +43,7 @@ type t = {
   kind,
   installConfig: InstallConfig.t,
   extraSources: list(ExtraSource.t),
+  available: option(string) /* contains opam filter serialised to be eval'd later */
 }
 and kind =
   | Esy

--- a/esy-package-config/OfPackageJson.re
+++ b/esy-package-config/OfPackageJson.re
@@ -160,6 +160,18 @@ module InstallManifestV1 = {
       };
 
     let warnings = [];
+
+    /********************************************************************/
+    /* ----                                                             */
+    /* TODO                                                             */
+    /* ----                                                             */
+    /*                                                                  */
+    /* Parse NPM's `cpu` (for cpu architecture) and `os` and persist it */
+    /* in the lock file.                                                */
+    /*                                                                  */
+    /********************************************************************/
+
+    let available = None;
     return((
       {
         InstallManifest.name,
@@ -183,6 +195,7 @@ module InstallManifestV1 = {
           },
         installConfig: pkgJson.installConfig,
         extraSources: [],
+        available,
       },
       warnings,
     ));

--- a/esy-solve/OpamManifest.re
+++ b/esy-solve/OpamManifest.re
@@ -380,7 +380,16 @@ let convertDependencies = manifest => {
          {ExtraSource.url, relativePath, checksum};
        });
 
-  return((dependencies, devDependencies, optDependencies, extraSources));
+  let available =
+    manifest.opam |> OpamFile.OPAM.available |> OpamFilter.to_string;
+
+  return((
+    dependencies,
+    devDependencies,
+    optDependencies,
+    extraSources,
+    available,
+  ));
 };
 
 let toInstallManifest = (~source=?, ~name, ~version, manifest) => {
@@ -389,7 +398,13 @@ let toInstallManifest = (~source=?, ~name, ~version, manifest) => {
   let converted = {
     open Result.Syntax;
     let* source = convertOpamUrl(manifest);
-    let* (dependencies, devDependencies, optDependencies, extraSources) =
+    let* (
+      dependencies,
+      devDependencies,
+      optDependencies,
+      extraSources,
+      available,
+    ) =
       convertDependencies(manifest);
     return((
       source,
@@ -397,6 +412,7 @@ let toInstallManifest = (~source=?, ~name, ~version, manifest) => {
       devDependencies,
       optDependencies,
       extraSources,
+      available,
     ));
   };
 
@@ -408,6 +424,7 @@ let toInstallManifest = (~source=?, ~name, ~version, manifest) => {
       devDependencies,
       optDependencies,
       extraSources,
+      available,
     )) =>
     let opam =
       switch (manifest.opamRepositoryPath) {
@@ -446,6 +463,7 @@ let toInstallManifest = (~source=?, ~name, ~version, manifest) => {
         resolutions: Resolutions.empty,
         installConfig: InstallConfig.empty,
         extraSources,
+        available: Some(available),
       }),
     );
   };

--- a/esy-solve/Resolver.re
+++ b/esy-solve/Resolver.re
@@ -96,6 +96,7 @@ let emptyLink = (~name, ~path, ~manifest, ~kind, ()) => {
   kind: Esy,
   installConfig: InstallConfig.empty,
   extraSources: [],
+  available: None,
 };
 
 let emptyInstall = (~name, ~source, ()) => {
@@ -113,6 +114,7 @@ let emptyInstall = (~name, ~source, ()) => {
   kind: Esy,
   installConfig: InstallConfig.empty,
   extraSources: [],
+  available: None,
 };
 
 let make = (~cfg, ~sandbox, ()) =>

--- a/esy-solve/Sandbox.re
+++ b/esy-solve/Sandbox.re
@@ -130,6 +130,7 @@ let make = (~gitUsername, ~gitPassword, ~cfg, spec: EsyFetch.SandboxSpec.t) => {
           kind: Npm,
           installConfig: InstallConfig.empty,
           extraSources: [],
+          available: None,
         };
         return({cfg, spec, root, resolutions: root.resolutions, resolver});
       };

--- a/esy-solve/Solver.re
+++ b/esy-solve/Solver.re
@@ -392,6 +392,7 @@ let lockPackage =
     kind: _,
     installConfig,
     extraSources,
+    available,
   } = pkg;
 
   let idsOfDependencies = dependencies =>
@@ -472,6 +473,7 @@ let lockPackage =
     devDependencies,
     installConfig,
     extraSources,
+    available,
   });
 };
 
@@ -657,6 +659,7 @@ let solveDependencies =
     kind: Esy,
     installConfig: InstallConfig.empty,
     extraSources: [],
+    available: None,
   };
 
   let universe = Universe.add(~pkg=dummyRoot, solver.universe);

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "optionalDependencies": {
     "@prometheansacrifice/esy-bash": "0.1.0-dev-f2e419601a34c3ce53cbe1f025f490276b9e879f"
   },
+  "scripts": {
+    "test": "jest test-e2e"
+  },
   "devDependencies": {
     "esy-solve-cudf": "^0.1.10",
     "is-ci": "^1.2.1",

--- a/test-e2e/esy-install/opam.test.js
+++ b/test-e2e/esy-install/opam.test.js
@@ -44,6 +44,36 @@ async function defineOpamPackageOfFixture(sandbox, packageName, packageVersion, 
     }
 }
 
+describe('opam available filter tests', () => {
+
+    it('ensure available field is present in the lock file', async () => {
+        const p = await helpers.createTestSandbox();
+
+        await p.fixture(
+            helpers.packageJson({
+                name: 'root',
+                dependencies: {
+                    '@opam/pkg1': '*',
+                }
+            }),
+        );
+
+        await p.defineNpmPackage({
+            name: '@esy-ocaml/substs',
+            version: '0.0.0',
+            esy: {},
+        });
+
+        await defineOpamPackageOfFixture(p, 'pkg1', '1.0.0', 'hello');
+        await p.esy('install');
+      const solution = await helpers.readSolution(p.projectPath);
+
+      expect(JSON.stringify(solution, null, 2)).toEqual('__hello__');
+
+
+    });
+});
+
 describe('installing opam dependencies from multiple registries', () => {
 
     it('fetch & builds opam dependencies from primary opam repo', async () => {

--- a/test-e2e/test/PackageGraph.js
+++ b/test-e2e/test/PackageGraph.js
@@ -209,4 +209,4 @@ async function read(directory: string, sandbox?: string = 'default'): Promise<?P
   return make(solution.root);
 }
 
-module.exports = {crawl, read};
+module.exports = {crawl, read, readSolution};

--- a/test-e2e/test/helpers.js
+++ b/test-e2e/test/helpers.js
@@ -433,6 +433,7 @@ module.exports = {
   getPackageArchivePath: NpmRegistryMock.getPackageArchivePath,
   crawlLayout: PackageGraph.crawl,
   readInstalledPackages: PackageGraph.read,
+  readSolution: PackageGraph.readSolution,
   makeFakeBinary: fsUtils.makeFakeBinary,
   exists: fs.exists,
   readdir: fs.readdir,


### PR DESCRIPTION
This PR tries to work with platform specific packages. Eg: `@opam/eio_windows` which is only available on Windows. (`os == "win32"`)

**Earlier attempt**
Before this, we had https://github.com/esy/esy/pull/1349/files where @phated explored filtering out packages that aren't available on the machine, before even handing it as an available option to the solver. It led to different solutions on different os/architectures.

**Version specified as formulas**
Dependencies could also be specified as follows,

```
pkga {2 & os = "linux" | 3 & os = "macos"}
```

As one can see, solver would see different acceptable/available version of `pkga` on different OSes.

**Too many variables in the matrix**
Along with `os` and `arch`, there's also `os-distribution` and other variables that could affect the solution.

As we see, solutions can look drastically different and one solution per file could lead to too many of them considering the inputs that affect them. Example lock file could look like `win32-cygwin-x86_64-flambda-lock.json`. The files could be  duplicating information and likely cause confusion.

This PR doesn't address all of these problems, but is the first step. It,

1. uses one lock file containing the union of the transitive closures.
2. Persists `available` field and delays evaluation to fetch phase. This itself can go a long way supporting platform specific packages. Things can be improved further if a suggestion like [this](https://github.com/ocaml/opam-repository/issues/26818) is welcomed at the repository.

In future, each possible combination of the global variables in the opam formula could be explored (perhaps, suggested by the user) and solutions could be merged in one lock file. The formulas like the following would work too

```
eio_linux {os=linux & =version}
eio_macos {os=macos & =version}
```

This fixes projects that need packages like `eio`. They're currently broken and need overrides.