### PR TITLE
Internal: Configures Resolver.t with git credentials when supplied

### DIFF
--- a/bin/esy.re
+++ b/bin/esy.re
@@ -933,8 +933,6 @@ let getSandboxSolution =
   open RunAsync.Syntax;
   let* solution =
     Solver.solve(
-      ~gitUsername=proj.projcfg.gitUsername,
-      ~gitPassword=proj.projcfg.gitPassword,
       ~dumpCudfInput,
       ~dumpCudfOutput,
       solvespec,
@@ -1345,16 +1343,16 @@ let show = (_asJson, req, proj: Project.t) => {
   open RunAsync.Syntax;
   let* req = RunAsync.ofStringError(Req.parse(req));
   let* resolver =
-    Resolver.make(~cfg=proj.solveSandbox.cfg, ~sandbox=proj.spec, ());
+    Resolver.make(
+      ~gitUsername=proj.projcfg.gitUsername,
+      ~gitPassword=proj.projcfg.gitPassword,
+      ~cfg=proj.solveSandbox.cfg,
+      ~sandbox=proj.spec,
+      (),
+    );
   let* resolutions =
     RunAsync.contextf(
-      Resolver.resolve(
-        ~gitUsername=proj.projcfg.gitUsername,
-        ~gitPassword=proj.projcfg.gitPassword,
-        ~name=req.name,
-        ~spec=req.spec,
-        resolver,
-      ),
+      Resolver.resolve(~name=req.name, ~spec=req.spec, resolver),
       "resolving %a",
       Req.pp,
       req,
@@ -1383,12 +1381,7 @@ let show = (_asJson, req, proj: Project.t) => {
     | [resolution, ..._] =>
       let* pkg =
         RunAsync.contextf(
-          Resolver.package(
-            ~gitUsername=proj.projcfg.gitUsername,
-            ~gitPassword=proj.projcfg.gitPassword,
-            ~resolution,
-            resolver,
-          ),
+          Resolver.package(~resolution, resolver),
           "resolving metadata %a",
           Resolution.pp,
           resolution,

--- a/esy-solve/Resolver.rei
+++ b/esy-solve/Resolver.rei
@@ -7,7 +7,14 @@ type t;
 /** Make new resolver */
 
 let make:
-  (~cfg: Config.t, ~sandbox: EsyFetch.SandboxSpec.t, unit) => RunAsync.t(t);
+  (
+    ~gitUsername: option(string),
+    ~gitPassword: option(string),
+    ~cfg: Config.t,
+    ~sandbox: EsyFetch.SandboxSpec.t,
+    unit
+  ) =>
+  RunAsync.t(t);
 
 let setOCamlVersion: (Version.t, t) => unit;
 let setResolutions: (Resolutions.t, t) => unit;
@@ -18,14 +25,7 @@ let getUnusedResolutions: t => list(string);
  */
 
 let resolve:
-  (
-    ~gitUsername: option(string),
-    ~gitPassword: option(string),
-    ~fullMetadata: bool=?,
-    ~name: string,
-    ~spec: VersionSpec.t=?,
-    t
-  ) =>
+  (~fullMetadata: bool=?, ~name: string, ~spec: VersionSpec.t=?, t) =>
   RunAsync.t(list(Resolution.t));
 
 /**
@@ -36,12 +36,7 @@ let resolve:
  */
 
 let package:
-  (
-    ~gitUsername: option(string),
-    ~gitPassword: option(string),
-    ~resolution: Resolution.t,
-    t
-  ) =>
+  (~resolution: Resolution.t, t) =>
   RunAsync.t(result(InstallManifest.t, string));
 
 let versionByNpmDistTag:

--- a/esy-solve/Solver.rei
+++ b/esy-solve/Solver.rei
@@ -8,8 +8,6 @@
 
 let solve:
   (
-    ~gitUsername: option(string),
-    ~gitPassword: option(string),
     ~dumpCudfInput: option(EsyLib.DumpToFile.t)=?,
     ~dumpCudfOutput: option(EsyLib.DumpToFile.t)=?,
     SolveSpec.t,


### PR DESCRIPTION
Reduces noise in the codebase arising out of passing down of git credentials from CLI to Resolver.re