### PR TITLE
Windows: fix c++ linking in fastreplace inline test runner

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,8 +1,6 @@
-(lang dune 2.0)
+(lang dune 3.16)
 (using menhir 2.0)
 (name esy)
-
-(allow_approximate_merlin)
 
 (license BSD-2-Clause)
 (maintainers

--- a/dune-project
+++ b/dune-project
@@ -39,14 +39,12 @@ Easy package management for native Reason, OCaml and more
     logs  
     lwt  
     reason
-    (rely (= dev))
     (cli (= dev))
     (pastel (= dev))
     (file-context-printer (= dev))
     lwt_ppx
     junit
     (menhir (= 20210419)) 
-    (ocamlformat (= 0.18.0)) 
     opam-core  
     opam-file-format  
     opam-format  

--- a/esy-build-package/bin/esyBuildPackageCommand.re
+++ b/esy-build-package/bin/esyBuildPackageCommand.re
@@ -3,11 +3,6 @@ module Option = EsyLib.Option;
 module File = Bos.OS.File;
 module Dir = Bos.OS.Dir;
 
-type verb =
-  | Normal
-  | Quiet
-  | Verbose;
-
 type commonOpts = {
   ocamlPkgName: string,
   ocamlVersion: string,

--- a/esy-fetch/dune
+++ b/esy-fetch/dune
@@ -10,5 +10,5 @@
    cudf ppx_deriving_yojson.runtime yojson esy_logs esy_logs_lwt dose3.algo
    opam-format opam-state opam-file-format)
  (preprocess
-  (pps lwt_ppx ppx_let ppx_deriving.std ppx_deriving_yojson ppxlib ppx_expect
+  (pps lwt_ppx ppx_let ppx_deriving.std ppx_deriving_yojson ppx_expect
     ppx_inline_test ppx_sexp_conv)))

--- a/esy-lib/NodeResolution.re
+++ b/esy-lib/NodeResolution.re
@@ -1,3 +1,4 @@
+[@ocaml.warning "-69"]; // Because of dune runtest
 module PackageJson = {
   type t = {
     name: string,

--- a/esy-package-config/OfPackageJson.re
+++ b/esy-package-config/OfPackageJson.re
@@ -1,3 +1,4 @@
+[@ocaml.warning "-69"]; // Because of dune runtest
 type warning = string;
 
 module BuildType = {

--- a/esy-package-config/dune
+++ b/esy-package-config/dune
@@ -9,5 +9,5 @@
  (libraries EsyLib angstrom str ppx_deriving_yojson.runtime yojson esy_logs
    opam-format opam-file-format)
  (preprocess
-  (pps lwt_ppx ppx_let ppx_deriving.std ppx_deriving_yojson ppxlib ppx_expect
+  (pps lwt_ppx ppx_let ppx_deriving.std ppx_deriving_yojson ppx_expect
     ppx_inline_test ppx_sexp_conv)))

--- a/esy-solve/dune
+++ b/esy-solve/dune
@@ -10,5 +10,5 @@
    ppx_deriving_yojson.runtime yojson esy_logs esy_logs_lwt dose3.algo
    opam-format opam-state opam-file-format)
  (preprocess
-  (pps lwt_ppx ppx_let ppx_deriving.std ppx_deriving_yojson ppxlib ppx_expect
+  (pps lwt_ppx ppx_let ppx_deriving.std ppx_deriving_yojson ppx_expect
     ppx_inline_test ppx_sexp_conv)))

--- a/esy.opam
+++ b/esy.opam
@@ -41,7 +41,6 @@ depends: [
   "lwt_ppx"
   "junit"
   "menhir" {= "20210419"}
-  "ocamlformat" {= "0.18.0"}
   "opam-core"
   "opam-file-format"
   "opam-format"
@@ -81,5 +80,4 @@ pin-depends: [
   ["cli.dev" "git+https://github.com/reasonml/reason-native.git#aec0ac68"]
   ["file-context-printer.dev" "git+https://github.com/reasonml/reason-native.git#aec0ac68"]
   ["pastel.dev" "git+https://github.com/reasonml/reason-native.git#aec0ac68"]
-  ["rely.dev" "git+https://github.com/reasonml/reason-native.git#aec0ac68"]
 ]

--- a/esy.opam
+++ b/esy.opam
@@ -27,7 +27,7 @@ depends: [
   "cudf" {= "0.9"}
   "dose3" {= "7.0.0"}
   "ocamlgraph" {= "2.0.0"}
-  "dune"
+  "dune" {>= "3.16"}
   "fmt"
   "fpath"
   "lambda-term"
@@ -57,9 +57,10 @@ depends: [
   "yojson"
   "ocaml" {= "4.12.0"}
   "extlib" {= "1.7.8"}
+  "odoc" {with-doc}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/esy.opam.locked
+++ b/esy.opam.locked
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "esy"
-version: "~dev"
+version: "dev"
 synopsis: "A package.json driven package manager for Reason and OCaml"
 description: "Easy package management for native Reason, OCaml and more"
 maintainer: [
@@ -17,112 +17,8 @@ authors: [
 license: "BSD-2-Clause"
 homepage: "https://github.com/esy/esy"
 bug-reports: "https://github.com/esy/esy/issues"
-depends: [
-  "angstrom" {= "0.15.0"}
-  "astring" {= "0.8.5"}
-  "base" {= "v0.14.3"}
-  "base-bigarray" {= "base"}
-  "base-bytes" {= "base"}
-  "base-threads" {= "base"}
-  "base-unix" {= "base"}
-  "base64" {= "3.5.1"}
-  "bigstringaf" {= "0.9.0"}
-  "bos" {= "dev"}
-  "camomile" {= "1.0.2"}
-  "charInfo_width" {= "1.1.0"}
-  "cmdliner" {= "dev"}
-  "conf-pkg-config" {= "3"}
-  "cppo" {= "1.6.9"}
-  "csexp" {= "1.5.1"}
-  "cudf" {= "0.9"}
-  "dose3" {= "7.0.0"}
-  "dune" {= "2.9.3"}
-  "dune-build-info" {= "2.9.3"}
-  "dune-configurator" {= "2.9.3"}
-  "extlib" {= "1.7.8"}
-  "fix" {= "20230505"}
-  "fmt" {= "0.9.0"}
-  "fpath" {= "0.7.3"}
-  "jane-street-headers" {= "v0.14.0"}
-  "jst-config" {= "v0.14.1"}
-  "junit" {= "2.0.2"}
-  "lambda-term" {= "3.2.0"}
-  "logs" {= "0.7.0"}
-  "lwt" {= "5.7.0"}
-  "lwt_log" {= "1.1.2"}
-  "lwt_ppx" {= "2.1.0"}
-  "lwt_react" {= "1.2.0"}
-  "mccs" {= "1.1+16"}
-  "menhir" {= "20210419"}
-  "menhirLib" {= "20210419"}
-  "menhirSdk" {= "20210419"}
-  "merlin-extend" {= "0.6.1"}
-  "mew" {= "0.1.0"}
-  "mew_vi" {= "0.5.0"}
-  "mtime" {= "2.0.0"}
-  "ocaml" {= "4.12.0"}
-  "ocaml-compiler-libs" {= "v0.12.4"}
-  "ocaml-config" {= "2"}
-  "ocaml-migrate-parsetree" {= "2.4.0"}
-  "ocaml-option-flambda" {= "1"}
-  "ocaml-syntax-shims" {= "1.0.0"}
-  "ocaml-variants" {= "4.12.0+options"}
-  "ocaml-version" {= "3.5.0"}
-  "ocamlbuild" {= "0.14.2"}
-  "ocamlfind" {= "1.9.6"}
-  "ocamlformat" {= "0.18.0"}
-  "ocamlgraph" {= "2.0.0"}
-  "ocplib-endian" {= "1.2"}
-  "octavius" {= "1.2.2"}
-  "odoc" {= "1.5.3"}
-  "opam-core" {= "2.1.5"}
-  "opam-file-format" {= "2.1.6"}
-  "opam-format" {= "2.1.5"}
-  "opam-repository" {= "2.1.5"}
-  "opam-state" {= "2.1.5"}
-  "ppx_assert" {= "v0.14.0"}
-  "ppx_base" {= "v0.14.0"}
-  "ppx_cold" {= "v0.14.0"}
-  "ppx_compare" {= "v0.14.0"}
-  "ppx_derivers" {= "1.2.1"}
-  "ppx_deriving" {= "5.2.1"}
-  "ppx_deriving_yojson" {= "3.6.1"}
-  "ppx_enumerate" {= "v0.14.0"}
-  "ppx_expect" {= "v0.14.2"}
-  "ppx_hash" {= "v0.14.0"}
-  "ppx_here" {= "v0.14.0"}
-  "ppx_inline_test" {= "v0.14.1"}
-  "ppx_js_style" {= "v0.14.1"}
-  "ppx_let" {= "v0.14.0"}
-  "ppx_optcomp" {= "v0.14.3"}
-  "ppx_sexp_conv" {= "v0.14.3"}
-  "ppxlib" {= "0.22.2"}
-  "ptime" {= "1.1.0"}
-  "re" {= "1.11.0"}
-  "react" {= "1.2.2"}
-  "reason" {= "3.8.2"}
-  "rely" {= "dev"}
-  "cli" {= "dev"}
-  "pastel" {= "dev"}
-  "file-context-printer" {= "dev"}
-  "result" {= "1.5"}
-  "rresult" {= "0.7.0"}
-  "seq" {= "base"}
-  "sexplib0" {= "v0.14.0"}
-  "stdio" {= "v0.14.0"}
-  "stdlib-shims" {= "0.3.0"}
-  "time_now" {= "v0.14.0"}
-  "topkg" {= "1.0.7"}
-  "trie" {= "1.0.0"}
-  "tyxml" {= "4.6.0"}
-  "uucp" {= "14.0.0"}
-  "uuseg" {= "14.0.0"}
-  "uutf" {= "1.0.3"}
-  "yojson" {= "2.1.2"}
-  "zed" {= "3.1.0"}
-]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"
@@ -137,11 +33,110 @@ build: [
 ]
 dev-repo: "git+https://github.com/esy/esy.git"
 pin-depends: [
-  ["camlbz2.dev" "git+https://gitlab.com/irill/camlbz2.git#588e186c"]
-  ["cmdliner.dev" "git+https://github.com/esy-ocaml/cmdliner.git#e9316bc3"]
   ["bos.dev" "git+https://github.com/esy-ocaml/bos.git#90364d00"]
   ["cli.dev" "git+https://github.com/reasonml/reason-native.git#aec0ac68"]
+  ["cmdliner.dev" "git+https://github.com/esy-ocaml/cmdliner.git#e9316bc3"]
   ["file-context-printer.dev" "git+https://github.com/reasonml/reason-native.git#aec0ac68"]
   ["pastel.dev" "git+https://github.com/reasonml/reason-native.git#aec0ac68"]
   ["rely.dev" "git+https://github.com/reasonml/reason-native.git#aec0ac68"]
+]
+depends: [
+  "angstrom" {= "0.16.1"}
+  "astring" {= "0.8.5"}
+  "base" {= "v0.15.1"}
+  "base-bigarray" {= "base"}
+  "base-bytes" {= "base"}
+  "base-threads" {= "base"}
+  "base-unix" {= "base"}
+  "base64" {= "3.5.1"}
+  "bigstringaf" {= "0.10.0"}
+  "bos" {= "dev"}
+  "cli" {= "dev"}
+  "cmdliner" {= "dev"}
+  "conf-c++" {= "1.0"}
+  "cppo" {= "1.7.0"}
+  "csexp" {= "1.5.2"}
+  "cudf" {= "0.9"}
+  "dose3" {= "7.0.0"}
+  "dune" {= "3.16.1"}
+  "dune-build-info" {= "3.16.1"}
+  "dune-configurator" {= "3.16.1"}
+  "extlib" {= "1.7.8"}
+  "file-context-printer" {= "dev"}
+  "fix" {= "20230505"}
+  "fmt" {= "0.9.0"}
+  "fpath" {= "0.7.3"}
+  "jane-street-headers" {= "v0.15.0"}
+  "jsonm" {= "1.0.2"}
+  "jst-config" {= "v0.15.1"}
+  "junit" {= "2.0.2"}
+  "lambda-term" {= "3.3.2"}
+  "logs" {= "0.7.0"}
+  "lwt" {= "5.9.0"}
+  "lwt_ppx" {= "5.8.0"}
+  "lwt_react" {= "1.2.0"}
+  "mccs" {= "1.1+18"}
+  "menhir" {= "20210419"}
+  "menhirLib" {= "20210419"}
+  "menhirSdk" {= "20210419"}
+  "merlin-extend" {= "0.6.2"}
+  "mew" {= "0.1.0"}
+  "mew_vi" {= "0.5.0"}
+  "mtime" {= "2.1.0"}
+  "ocaml" {= "4.12.0"}
+  "ocaml-variants" {= "4.12.0+options"}
+  "ocaml-option-flambda" {= "1"}
+  "ocaml-compiler-libs" {= "v0.12.4"}
+  "ocaml-config" {= "2"}
+  "ocaml-syntax-shims" {= "1.0.0"}
+  "ocaml-version" {= "3.5.0"}
+  "ocamlbuild" {= "0.15.0"}
+  "ocamlfind" {= "1.9.6"}
+  "ocamlgraph" {= "2.0.0"}
+  "ocplib-endian" {= "1.2"}
+  "opam-core" {= "2.3.0"}
+  "opam-file-format" {= "2.1.6"}
+  "opam-format" {= "2.3.0"}
+  "opam-repository" {= "2.3.0"}
+  "opam-state" {= "2.3.0"}
+  "pastel" {= "dev"}
+  "ppx_assert" {= "v0.15.0"}
+  "ppx_base" {= "v0.15.0"}
+  "ppx_cold" {= "v0.15.0"}
+  "ppx_compare" {= "v0.15.0"}
+  "ppx_derivers" {= "1.2.1"}
+  "ppx_deriving" {= "6.0.3"}
+  "ppx_deriving_yojson" {= "3.9.0"}
+  "ppx_enumerate" {= "v0.15.0"}
+  "ppx_expect" {= "v0.15.1"}
+  "ppx_hash" {= "v0.15.0"}
+  "ppx_here" {= "v0.15.0"}
+  "ppx_inline_test" {= "v0.15.1"}
+  "ppx_let" {= "v0.15.0"}
+  "ppx_optcomp" {= "v0.15.0"}
+  "ppx_sexp_conv" {= "v0.15.1"}
+  "ppxlib" {= "0.33.0"}
+  "ptime" {= "1.2.0"}
+  "re" {= "1.12.0"}
+  "react" {= "1.2.2"}
+  "reason" {= "3.13.0"}
+  "result" {= "1.5"}
+  "rresult" {= "0.7.0"}
+  "seq" {= "base"}
+  "sexplib0" {= "v0.15.1"}
+  "sha" {= "1.15.4"}
+  "spdx_licenses" {= "1.2.0"}
+  "stdio" {= "v0.15.0"}
+  "stdlib-shims" {= "0.3.0"}
+  "swhid_core" {= "0.1"}
+  "time_now" {= "v0.15.0"}
+  "topkg" {= "1.0.7"}
+  "trie" {= "1.0.0"}
+  "tyxml" {= "4.6.0"}
+  "uchar" {= "0.0.2"}
+  "uucp" {= "14.0.0"}
+  "uuseg" {= "14.0.0"}
+  "uutf" {= "1.0.3"}
+  "yojson" {= "2.2.2"}
+  "zed" {= "3.2.3"}
 ]

--- a/fastreplacestring/config/discover.re
+++ b/fastreplacestring/config/discover.re
@@ -24,4 +24,14 @@ let () =
       };
 
     C.Flags.write_sexp("dune.cxx_flags", cxx_flags);
+
+
+    let inline_test_flags =
+      switch (C.ocaml_config_var(c, "system")) {
+      /* link statically on windows so we don't have to ship mingw64.dll */
+      | Some("mingw64") => ["-cclib", "-link -static-libstdc++"]
+      | _ => []
+      };
+
+    C.Flags.write_sexp("inline_test.link_flags", inline_test_flags);
   });

--- a/fastreplacestring/config/dune
+++ b/fastreplacestring/config/dune
@@ -4,6 +4,6 @@
  (libraries dune.configurator))
 
 (rule
- (targets dune.flags dune.cflags dune.cxx_flags)
+ (targets inline_test.link_flags dune.flags dune.cflags dune.cxx_flags)
  (action
   (run ./discover.exe)))

--- a/fastreplacestring/test/dune
+++ b/fastreplacestring/test/dune
@@ -1,6 +1,7 @@
 (library
  (name fastreplacestringTest)
- (inline_tests)
+ (inline_tests
+  (executable (link_flags -cclib "-link -static-libstdc++")))
  (libraries fastreplacestring)
  (preprocess
   (pps ppx_expect)))

--- a/fastreplacestring/test/dune
+++ b/fastreplacestring/test/dune
@@ -1,7 +1,7 @@
 (library
  (name fastreplacestringTest)
  (inline_tests
-  (executable (link_flags -cclib "-link -static-libstdc++")))
+  (executable (link_flags (:include ../config/inline_test.link_flags))))
  (libraries fastreplacestring)
  (preprocess
   (pps ppx_expect)))

--- a/test-e2e-re/lib/dune
+++ b/test-e2e-re/lib/dune
@@ -4,7 +4,7 @@
  (libraries EsyLib EsyPackageConfig rely.lib esy_logs esy_logs_cli
    esy_cmdliner bos esy_fmt esy_fmt_cli esy_fmt_tty rresult)
  (preprocess
-  (pps lwt_ppx ppx_let ppx_deriving.std ppx_deriving_yojson ppxlib ppx_expect
+  (pps lwt_ppx ppx_let ppx_deriving.std ppx_deriving_yojson ppx_expect
     ppx_inline_test ppx_sexp_conv))
  (modules
   (:standard \ RunTests)))

--- a/test-e2e/test/helpers.js
+++ b/test-e2e/test/helpers.js
@@ -451,5 +451,5 @@ module.exports = {
   isLinux,
   isMacos,
   COMMAND_FAILED: expect.stringMatching('command failed'),
-  COMMAND_NOT_FOUND: expect.stringMatching('unable to resolve command'),
+  COMMAND_NOT_FOUND: expect.stringMatching(isWindows ? 'command not found': 'unable to resolve command'),
 };

--- a/test/dune
+++ b/test/dune
@@ -4,4 +4,4 @@
  (libraries EsyBuild EsyLib ppx_inline_test.runtime-lib)
  (modules (:standard))
  (preprocess
-  (pps lwt_ppx ppx_let ppx_inline_test ppxlib.runner ppx_deriving.std)))
+  (pps lwt_ppx ppx_let ppx_inline_test ppx_deriving.std)))


### PR DESCRIPTION
Inline test runner executable needs to statically link `libstdc++`. This was not possible in the version of Dune in use. This PR updates the version of dune, makes the necessary dune lang changes everywhere, and pass flexlink flag, `-link -static-libstdc++` on Windows to statically link it.