### PR TITLE
Fix static-build segfault: drop -Wl,-E for static-PIE musl builds

### DIFF
--- a/dune-workspace
+++ b/dune-workspace
@@ -1,2 +1,11 @@
 (lang dune 2.0)
-(env (release-static (flags (:standard -ccopt -static))))
+; -Wl,--no-export-dynamic is required alongside -static on x86_64 musl.
+; ocamlopt links native executables with -Wl,-E (export-dynamic) by default,
+; and the combination of -static-pie + -Wl,-E makes ld leave an unresolved
+; dynamic TLS relocation (R_X86_64_TPOFF64) for OCaml 5's thread-local
+; Caml_state. musl's static-PIE startup self-relocator cannot apply TLS
+; relocations (it runs before the thread pointer is set up), so the binary
+; segfaults before main. Dropping -Wl,-E keeps a fully static PIE that
+; resolves the TLS access at link time. See
+; https://discuss.ocaml.org/t/segfaults-on-static-compilation-with-alpine-3-23-fix-no-pie/17800
+(env (release-static (flags (:standard -ccopt -static -ccopt -Wl,--no-export-dynamic))))


### PR DESCRIPTION
## Problem

The `static-build` CI job (`dockerfiles/alpine.Dockerfile`) fails with a **SIGSEGV** while running `fastreplacestring/config/discover.exe` during `dune build`:

```
#38 6.958 File "fastreplacestring/config/dune", lines 6-9 ...
#38 6.958 Command got signal SEGV.
#38 ERROR: process "/bin/sh -c /app/scripts/opam.sh build" did not complete successfully: exit code: 1
```

It is **x86_64-only** — the `static-build-arm64` job stayed green.

## Root cause

Nothing in esy changed. The Dockerfile uses `FROM alpine:latest`, which floated from **3.22** (gcc 14.2 / binutils 2.44) to **3.23** (gcc 15.2 / binutils 2.45.1). On 3.23, gcc makes `-static` default to **`-static-pie`**, so the build now produces position-independent static executables instead of the classic non-PIE `EXEC` it produced before.

OCaml 5 keeps its per-domain state pointer (`Caml_state`) in a **thread-local**. `ocamlopt` links native executables with `-Wl,-E` (export-dynamic) by default, and the combination of **`-static-pie` + `-Wl,-E`** makes `ld` leave an **unresolved dynamic TLS relocation** (`R_X86_64_TPOFF64`) in the binary. musl's static-PIE startup self-relocator runs *before* the thread pointer is set up and only applies `RELATIVE` relocations — it cannot apply a TLS relocation — so the very first `Caml_state` access faults **before `main`**. This affects every OCaml 5.x (it is not fixed upstream; the OCaml maintainers attribute it to `ld` + `-Wl,-E`).

Reference: <https://discuss.ocaml.org/t/segfaults-on-static-compilation-with-alpine-3-23-fix-no-pie/17800>

## Fix

Drop the export-dynamic flag for the static profile by adding `-Wl,--no-export-dynamic`. This lets `ld` resolve the TLS access at link time, **keeping a fully static PIE** (no switch to `-no-pie`).

## Verification

Reproduced and verified in an **Alpine 3.23 x86_64** musl toolchain (OCaml 5.2.0 + flambda + musl + static), building a native executable with the static profile flags:

| build flags | ELF type | TLS reloc | result |
|---|---|---|---|
| `-ccopt -static` (current) | `DYN` (PIE) | `R_X86_64_TPOFF64` present | **SIGSEGV (exit 139)** |
| `-ccopt -static -ccopt -Wl,--no-export-dynamic` | **`DYN` (PIE)** | **none** | **runs, exit 0** |

The binary remains a fully static PIE; only the unresolvable TLS relocation is gone.
