### PR TITLE
Fix flaky macOS CI: make Fs.symlink ~force idempotent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.6.12 @ latest
 
+- Fix intermittent `symlink ... build: File exists` failures on macOS by making `Fs.symlink ~force` idempotent when the link already points at the desired target by @ManasJayanth
 - Feature: Allow subfolders in github source URLs by @EduardoRFS in #1196
 - Fix EACCES during `esy i --cache-tarballs-path` by @ManasJayanth in #1182
 - Feature: Allow spaces in usernames on Windows by bumping esy-bash to 3.20 by @Et7f3 in #1340

--- a/esy-lib/Fs.re
+++ b/esy-lib/Fs.re
@@ -614,11 +614,21 @@ let symlink = (~force=false, ~src, dst) => {
   switch%lwt (symlink'(src, dst)) {
   | Ok () => return()
   | Error(Unix.EEXIST) when force =>
-    /* try rm path but ignore errors */
-    let%lwt _: Run.t(unit) = rmPath(dst);
-    switch%lwt (symlink'(src, dst)) {
-    | Ok () => return()
-    | Error(err) => mkError(err)
+    /* The destination already exists. If it is already a symlink pointing
+     * to `src` there is nothing to do — treat it as success. This keeps the
+     * operation idempotent and tolerant of concurrent writers. It also avoids
+     * the remove-then-recreate dance below, which is racy and, on macOS, can
+     * follow a symlink-to-directory during the recursive remove and leave the
+     * link in place, making the retry fail again with EEXIST. */
+    switch%lwt (readlinkOpt(dst)) {
+    | Ok(Some(existing)) when Path.equal(existing, src) => return()
+    | _ =>
+      /* try rm path but ignore errors */
+      let%lwt _: Run.t(unit) = rmPath(dst);
+      switch%lwt (symlink'(src, dst)) {
+      | Ok () => return()
+      | Error(err) => mkError(err)
+      };
     };
   | Error(err) => mkError(err)
   };


### PR DESCRIPTION
## Problem

The macOS e2e job on `master` failed (run [28007745142](https://github.com/esy/esy/actions/runs/28007745142)) with:

```
FAIL test-e2e/esy-install/opam.test.js
  Command failed: esy x depLinux.cmd
  error symlink .../store/b/root-39cf2421 -> .../_esy/default/build: File exists
```

The static-PIE jobs (`static-build`, `static-build-arm64`) and `ubuntu-latest` all passed — the red was purely this intermittent symlink failure on macOS, which then fail-fast-cancelled the windows/macos-13 jobs.

## Root cause

`BuildSandbox.makeSymlinksToStore` recreates the root package's `_esy/default/build → store/b/root-<hash>` symlink on **every** root rebuild. When several `esy x` commands run against the same sandbox (as `opam.test.js` does), a later build hits an already-existing, *identical* symlink → `EEXIST`.

The `Fs.symlink ~force` path then did:

```reason
let%lwt _ = rmPath(dst);   /* recursive Bos delete, ignores errors */
symlink'(src, dst);        /* retry */
```
